### PR TITLE
chore: modernize Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,9 +8,24 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
-        with:
-          target: minor
-          github-token: ${{ secrets.WAOS }}
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replace the outdated third-party action with the official GitHub-recommended approach:

- Replace `ahmadnassri/action-dependabot-auto-merge@v2` + `WAOS` PAT → `dependabot/fetch-metadata@v2` + `GITHUB_TOKEN`
- Add `if: github.actor == 'dependabot[bot]'` guard — workflow no longer runs on all PRs
- Explicit approve step (`gh pr review --approve`) before enabling auto-merge
- Auto-merge enabled only for **patch and minor** updates — majors stay manual
- Remove unused `issues: write` permission

## Why

- The `WAOS` PAT is a personal token with expiry risk; `GITHUB_TOKEN` is sufficient since auto-merge is enabled on the repo
- The `ahmadnassri` action is unmaintained and uses deprecated patterns
- The `dependabot[bot]` guard prevents the workflow from triggering on non-Dependabot PRs

## Test plan

- [ ] Open a Dependabot patch/minor PR and verify it gets auto-approved and merged once CI is green
- [ ] Open a Dependabot major PR and verify it does NOT get auto-merged