### PR TITLE
chore: homogenize CI workflow with Vue stack

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,3 +30,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pierreb-devkit/Node


### PR DESCRIPTION
## Summary

Aligns the Node CI workflow with the Vue stack structure.

- Rename job `build` → `test`
- `npm i` → `npm install`
- Upload coverage to Codecov only on `node 22.x` — avoids duplicate reports when the matrix runs multiple Node versions

## Bug fix (Vue alignment)

Vue uses `if: matrix.node-version == 'lts/*'` but the matrix declares `[22.x, 24.x]` — this condition never matches so coverage is never uploaded. This PR uses `== '22.x'` which correctly targets one run in the matrix.

## Test plan

- [ ] Verify CI runs on both Node 22.x and 24.x with MongoDB 7.0
- [ ] Verify Codecov report is uploaded exactly once (from the 22.x run)