### PR TITLE
fix: restore Codecov slug to fix Repository not found error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,3 +35,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pierreb-devkit/Node


### PR DESCRIPTION
## Fix

Restores the `slug: pierreb-devkit/Node` parameter removed in a previous PR on Copilot's suggestion.

Without it, `codecov-action@v5` cannot resolve the repository and throws:
\`\`\`
Upload failed: {"message":"Repository not found"}
\`\`\`

The slug is required for Codecov to correctly identify the target repository.