### PR TITLE
fix: restore Codecov slug to fix Repository not found error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,3 +35,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: pierreb-devkit/Node


### PR DESCRIPTION
## Fix

Restores `slug: pierreb-devkit/Node` in the Codecov step.

Without it, `codecov-action@v5` cannot resolve the repository and throws:
\`\`\`
Upload failed: {"message":"Repository not found"}
\`\`\`