### PR TITLE
docs: add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI](https://github.com/pierreb-devkit/Node/actions/workflows/CI.yml/badge.svg)](https://github.com/pierreb-devkit/Node/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/pierreb-devkit/Node/graph/badge.svg?token=5VB61OAHQX)](https://codecov.io/gh/pierreb-devkit/Node)
 [![Dependabot badge](https://img.shields.io/badge/Dependabot-enabled-2768cf.svg?style=flat-square)](https://dependabot.com)
 [![Known Vulnerabilities](https://snyk.io/test/github/pierreb-devkit/node/badge.svg?style=flat-square)](https://snyk.io/test/github/pierreb-devkit/node)
 


### PR DESCRIPTION
Adds the Codecov coverage badge next to the CI badge.