### PR TITLE
feat(deps): upgrade zod from v3 to v4

### DIFF
--- a/lib/helpers/zod.js
+++ b/lib/helpers/zod.js
@@ -3,16 +3,15 @@
  */
 import zxcvbn from 'zxcvbn';
 import config from '../../config/index.js';
-import { z } from 'zod';
 
 /**
  * @desc Zod superRefine for zxcvbn password strength
  */
 const passwordRefinement = (val, ctx) => {
   if (config.zxcvbn.forbiddenPasswords.includes(val)) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'password is too common' });
+    ctx.addIssue({ code: 'custom', message: 'password is too common', input: val });
   } else if (zxcvbn(val).score < config.zxcvbn.minimumScore) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `password must have a strength of at least ${config.zxcvbn.minimumScore}` });
+    ctx.addIssue({ code: 'custom', message: `password must have a strength of at least ${config.zxcvbn.minimumScore}`, input: val });
   }
 };
 

--- a/modules/tasks/models/tasks.schema.js
+++ b/modules/tasks/models/tasks.schema.js
@@ -7,10 +7,10 @@ import { z } from 'zod';
  *  Data Schema
  */
 const Task = z.object({
-  title: z.string({ invalid_type_error: 'title must be a string' }).trim().min(1),
+  title: z.string({ error: 'title must be a string' }).trim().min(1),
   description: z.string().default(''),
   user: z.string().trim().default(''),
-}).strip();
+});
 
 const TaskUpdate = Task.partial();
 

--- a/modules/users/models/user.schema.js
+++ b/modules/users/models/user.schema.js
@@ -21,7 +21,7 @@ const User = z.object({
   roles: z.array(z.enum(config.whitelists.users.roles)).min(1).default(['user']),
   /* Provider */
   provider: z.string().optional(),
-  providerData: z.record(z.unknown()).optional(),
+  providerData: z.record(z.string(), z.unknown()).optional(),
   /* Password */
   password: z.string()
     .max(config.zxcvbn.maxSize)
@@ -30,7 +30,7 @@ const User = z.object({
       if (val === '') return; // allow empty (OAuth users / no password set)
       zodHelpers.passwordRefinement(val, ctx);
       if (val.length < config.zxcvbn.minSize) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Password length must be at least ${config.zxcvbn.minSize} characters long` });
+        ctx.addIssue({ code: 'custom', message: `Password length must be at least ${config.zxcvbn.minSize} characters long`, input: val });
       }
     }),
   resetPasswordToken: z.string().nullable().optional(),
@@ -38,8 +38,8 @@ const User = z.object({
   // startup requirement
   terms: z.coerce.date().nullable().optional(),
   // others
-  complementary: z.record(z.unknown()).nullable().optional(),
-}).strip();
+  complementary: z.record(z.string(), z.unknown()).nullable().optional(),
+});
 
 const UserUpdate = User.partial();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "swagger-ui-express": "^5.0.1",
         "ts-jest": "^29.4.6",
         "winston": "^3.19.0",
-        "zod": "^3.25.76",
+        "zod": "^4.3.6",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -17835,9 +17835,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "swagger-ui-express": "^5.0.1",
     "ts-jest": "^29.4.6",
     "winston": "^3.19.0",
-    "zod": "^3.25.76",
+    "zod": "^4.3.6",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrades zod from `3.25.76` to `4.3.6` with full code migration.

Supersedes #3149 (which was closed because it only bumped the version without adapting the code).

## Changes

- `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` — v4 requires explicit key type
- `z.ZodIssueCode.custom` → `'custom'` — plain string literal per v4 API
- `z.string({ invalid_type_error })` → `z.string({ error })` — v4 error params rename
- `.strip()` removed from `z.object()` — now the default in v4
- `ctx.addIssue()` updated with required `input` field per v4 API

## Test plan

- [x] `npm test` — 222 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation schemas for user accounts and task management features, improving data consistency, validation accuracy, and providing clearer error feedback for users
  * Upgraded the core validation library dependency from version 3.25.76 to 4.3.6, incorporating modern standards, improvements, and enhanced functionality for greater overall reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->