### PR TITLE
chore(security): block direct git push to master/main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -244,6 +244,22 @@
           "reason": "Force push without lease is not allowed — use --force-with-lease"
         },
         {
+          "pattern": "git push origin master",
+          "reason": "Never push directly to master — use a feature branch and open a PR"
+        },
+        {
+          "pattern": "git push origin main",
+          "reason": "Never push directly to main — use a feature branch and open a PR"
+        },
+        {
+          "pattern": "git push * master",
+          "reason": "Never push directly to master — use a feature branch and open a PR"
+        },
+        {
+          "pattern": "git push * main",
+          "reason": "Never push directly to main — use a feature branch and open a PR"
+        },
+        {
           "pattern": "npm publish",
           "reason": "Package publishing requires explicit approval"
         },


### PR DESCRIPTION
## Summary

- Add 4 deny patterns to `.claude/settings.json` to block direct pushes to `master`/`main`
- Closes #3156
- Prevents Claude Code from bypassing the PR-only workflow if it ends up on a protected branch

## Test plan

- [ ] Attempt `git push origin master` from this repo — Claude Code should block it with the configured error message
- [ ] Attempt `git push origin main` — same result
- [ ] Confirm feature branch pushes (`git push -u origin HEAD`) still work normally