### PR TITLE
fix(policy): remove dead guest read rule on authenticated task routes

### DIFF
--- a/modules/tasks/policies/tasks.policy.js
+++ b/modules/tasks/policies/tasks.policy.js
@@ -12,7 +12,6 @@ const invokeRolesPolicies = () => {
     { roles: ['user'], actions: 'manage', subject: '/api/tasks/:taskId' },
     { roles: ['guest'], actions: ['read'], subject: '/api/tasks/stats' },
     { roles: ['guest'], actions: ['read'], subject: '/api/tasks' },
-    { roles: ['guest'], actions: ['read'], subject: '/api/tasks/:taskId' },
   ]);
 };
 


### PR DESCRIPTION
## Summary

- What changed: Removed the dead `guest` read rule for `/api/tasks/:taskId` from `tasks.policy.js`
- Why: The route `/api/tasks/:taskId` is protected by `passport.authenticate('jwt', { session: false })` — guests are rejected by the JWT middleware before `policy.isAllowed` is ever reached, making the guest rule unreachable dead code
- Related issues: Closes #3135

## Scope

- Module(s) impacted: `modules/tasks`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: removes a misleading policy rule that could give the false impression that guest access to individual tasks is permitted; actual access control is unaffected since JWT auth already blocks guests on this route
- Mergeability considerations: single-line deletion, no downstream conflicts expected
- Follow-up tasks: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted guest user access to individual task details, improving security while maintaining access to task lists and statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->