### PR TITLE
chore(pull-request skill): add guardrail against adjusting coverage thresholds

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -40,7 +40,7 @@ npm run commit
 
 Run `/verify` and fix all failures before opening the PR.
 
-> **Coverage thresholds are immutable.** If `test:coverage` fails due to threshold violations, add or improve tests — never lower the thresholds (e.g., `coverageThreshold` in `jest.config.js`).
+> **Coverage thresholds are immutable.** When you run `npm run test:coverage` locally, or when CI/Codecov runs coverage checks, if coverage fails due to threshold violations, add or improve tests — never lower the thresholds (e.g., `coverageThreshold` in `jest.config.js`).
 
 ## 4. Issue
 


### PR DESCRIPTION
## Summary

- What changed: Added explicit guardrail in the pull-request skill (sections 3 and 6d) stating that coverage thresholds are immutable.
- Why: During a downstream stack update, the AI lowered `coverageThreshold` in `jest.config.js` instead of writing missing tests. This rule prevents that.
- Related issues: Closes #3179

## Scope

- Module(s) impacted: `.claude/skills/pull-request/`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: Documentation-only change in skill file, fully merge-friendly.
- Follow-up tasks (optional): none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced pull request guidelines with clarified policies on test coverage thresholds. Updates emphasize that coverage thresholds are immutable and establish best practices for resolving coverage gaps through improved testing. Guidance updated in commit verification and coverage assessment sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->