### PR TITLE
chore(pull-request skill): forward stack-related review comments as upstream issues

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -212,14 +212,29 @@ gh api repos/$OWNER/$REPO/issues/$PR/comments --paginate | jq 'map({id, user: .u
 
 ### 6c. Fix all actionable comments from this pass
 
-**Stack-originated files:** If a review comment targets a file that exists in the upstream stack repo, do **not** fix it downstream. Check using the `devkit-node` remote (the remote name used by the `/update-stack` skill):
+**Stack-originated files:** If a review comment targets a file that exists in the upstream stack repo, do **not** fix it downstream. Check using the `devkit-node` remote (set up by `/update-stack`). Fetch first to ensure the ref is current:
 
 ```bash
+# Derive the upstream repo slug from the devkit-node remote
+STACK_REPO=$(gh api repos --jq '.full_name' 2>/dev/null || true)
+STACK_REPO=$(git remote get-url devkit-node 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||')
+
+# Fetch to ensure ref is up-to-date (skip silently if remote missing)
+git fetch devkit-node master 2>/dev/null || true
+
+# Check if file exists in the stack
 git cat-file -e devkit-node/master:path/to/file 2>/dev/null && echo "STACK" || echo "NOT_IN_STACK"
 ```
 
+> If `devkit-node` remote does not exist, the fetch and check will silently fail, and the file is treated as project-only. This is safe — stack detection only works after `/update-stack` has been run at least once.
+
 If the file is stack-originated:
-1. Create an issue on the stack repo describing the finding
+1. Create an issue on the stack repo using `--repo` to target upstream:
+   ```bash
+   gh issue create --repo "$STACK_REPO" \
+     --title "fix(scope): description" \
+     --body "Flagged by review bot in downstream PR <link>"
+   ```
 2. Reply to the review comment with a link to the upstream issue
 3. Resolve the thread — the fix should happen upstream
 


### PR DESCRIPTION
## Summary

- What changed: Added a guardrail in section 6c of the pull-request skill instructing the agent to forward review comments on stack-originated files as upstream issues instead of fixing them downstream.
- Why: During downstream stack update PRs, the AI was fixing issues in stack files locally instead of pushing them upstream where they belong.
- Related issues: Closes #3180

## Scope

- Module(s) impacted: `.claude/skills/pull-request/`
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: Documentation-only change in skill file, fully merge-friendly.
- Follow-up tasks (optional): none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request review guidelines to improve handling of actionable comments, including enhanced workflows for different file types.

**Note:** This is an internal process update with no direct end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->