### PR TITLE
chore(skill): align pull-request skill with Vue stack

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -217,7 +217,7 @@ gh api repos/$OWNER/$REPO/issues/$PR/comments --paginate | jq 'map({id, user: .u
 
 When running on a **downstream project** (not the stack repo itself), classify each actionable comment before fixing.
 
-> The `devkit-node` remote is set up by `/update-stack`. If it does not exist, skip this classification — all comments are treated as downstream.
+> The `devkit-node` remote is set up by `/update-stack`. If it does not exist, **stop and report** that stack/downstream classification cannot be performed — instruct the user to run `/update-stack` first. Do not silently treat all comments as downstream.
 
 1. **Check if the comment targets a stack-level file** — a file that exists in the upstream stack repo and has not been modified downstream:
    ```bash


### PR DESCRIPTION
## Summary

- What changed: Aligned the pull-request skill (SKILL.md) with the Vue stack version — restructured stack-level comment handling into a dedicated 6b-bis section, aligned wording and formatting
- Why: Both stacks should have the same PR skill behavior to avoid confusion when working across stacks
- Related issues: Closes pierreb-devkit/Vue#3604

## Scope

- Module(s) impacted: `.claude/skills/pull-request`
- Cross-module impact: `none`
- Risk level: `low` — skill documentation change only

## Validation

- [x] `npm run lint`
- [ ] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [ ] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: None
- Mergeability considerations: None — additive skill doc restructure
- Follow-up tasks (optional): None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised PR review workflow to split stack-level vs downstream-only comment handling into a two-path process with explicit upstream coordination.
  * Expanded and reworded informational guidance (e.g., "zero unresolved threads"), added examples, and clarified messaging about remotes and skip conditions.
  * Clarified batching, verification, per-pass commit/linking of fixes, thread resolution, and behavior when upstream access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->