### PR TITLE
feat(update-stack): report upstream issues when verify fails on stack code

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -60,11 +60,27 @@ If `/verify` failures originate from **stack module code** (`home`, `auth`, `use
 - **Stack code failure:** error occurs in unmodified stack module files (resolved with `--theirs`)
 - **Conflict resolution mistake:** error occurs in files you manually merged or in downstream-only modules
 
-**Issue format:**
-- Title: short description of the failure
-- Body: failing command output, affected file(s), and steps to reproduce
+**Create the issue:**
 
-This ensures upstream regressions are tracked and fixed at the source.
+```bash
+gh issue create \
+  --repo pierreb-devkit/Node \
+  --title "fix(scope): <short description>" \
+  --body "$(cat <<'BODY'
+## Problem
+<failing command output>
+
+## Affected file(s)
+<list>
+
+## Steps to reproduce
+<steps>
+BODY
+)" \
+  --label "Fix"
+```
+
+Proceed to Phase 2 and track the upstream fix separately — do not block downstream alignment on it.
 
 ---
 


### PR DESCRIPTION
## Summary

- What changed: Added step 3bis to the update-stack skill in `.claude/skills/update-stack/SKILL.md`
- Why: No mechanism existed to report upstream regressions back to the source repo when `/verify` failures originate from stack module code
- Related issues: Closes #3195

## Scope

- Module(s) impacted: `.claude/skills/update-stack/` (skill config only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — documentation-only change
- Mergeability considerations: no code changes, only skill markdown
- Follow-up tasks (optional): none