### PR TITLE
fix(config): replace _.merge with deepMerge to fix array handling

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -26,7 +26,7 @@ const deepMerge = (target, source) => {
     if (srcVal === undefined) continue;
     const tgtVal = result[key];
     if (Array.isArray(srcVal)) {
-      result[key] = srcVal;
+      result[key] = [...srcVal];
     } else if (srcVal && typeof srcVal === 'object' && !Array.isArray(srcVal) && tgtVal && typeof tgtVal === 'object' && !Array.isArray(tgtVal)) {
       result[key] = deepMerge(tgtVal, srcVal);
     } else {
@@ -135,4 +135,6 @@ const initGlobalConfig = async () => {
   return conf;
 };
 
-export default await initGlobalConfig();
+const config = await initGlobalConfig();
+export { deepMerge };
+export default config;

--- a/modules/core/tests/core.unit.tests.js
+++ b/modules/core/tests/core.unit.tests.js
@@ -6,7 +6,7 @@ import path from 'path';
 import { jest } from '@jest/globals';
 
 import assets from '../../../config/assets.js';
-import config from '../../../config/index.js';
+import config, { deepMerge } from '../../../config/index.js';
 import configHelper from '../../../lib/helpers/config.js';
 import logger from '../../../lib/services/logger.js';
 import mongooseService from '../../../lib/services/mongoose.js';
@@ -667,6 +667,46 @@ describe('Core unit tests:', () => {
     it('should return the password when checkPassword is called with a strong password', () => {
       const strong = 'C0rr3ct!H0rs3B@tt3ry';
       expect(AuthService.checkPassword(strong)).toBe(strong);
+    });
+  });
+
+  describe('deepMerge', () => {
+    it('should replace arrays instead of merging by index', () => {
+      const target = { items: ['a', 'b', 'c', 'd'] };
+      const source = { items: ['x', 'y'] };
+      const result = deepMerge(target, source);
+      expect(result.items).toEqual(['x', 'y']);
+    });
+
+    it('should deep merge nested objects', () => {
+      const target = { a: { b: 1, c: 2 } };
+      const source = { a: { c: 3, d: 4 } };
+      const result = deepMerge(target, source);
+      expect(result.a).toEqual({ b: 1, c: 3, d: 4 });
+    });
+
+    it('should skip undefined values', () => {
+      const target = { a: 1, b: 2 };
+      const source = { a: undefined, b: 3 };
+      const result = deepMerge(target, source);
+      expect(result.a).toBe(1);
+      expect(result.b).toBe(3);
+    });
+
+    it('should skip unsafe keys', () => {
+      const target = { safe: 1 };
+      const source = { safe: 2 };
+      Object.defineProperty(source, '__proto__', { value: { polluted: true }, enumerable: true });
+      const result = deepMerge(target, source);
+      expect(result.polluted).toBeUndefined();
+      expect(result.safe).toBe(2);
+    });
+
+    it('should not mutate source arrays', () => {
+      const sourceArr = ['a', 'b'];
+      const result = deepMerge({ items: ['x'] }, { items: sourceArr });
+      result.items.push('c');
+      expect(sourceArr).toEqual(['a', 'b']);
     });
   });
 });


### PR DESCRIPTION
## Summary

- What changed: Replaced `_.merge` from lodash with a custom `deepMerge` function in `config/index.js` that replaces arrays instead of merging them by index
- Why: `_.merge` merges arrays by index, causing downstream projects with shorter arrays to inherit extra items from defaults
- Related issues: Closes #3198

## Scope

- Module(s) impacted: none (config infrastructure)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: deepMerge guards against prototype pollution (`__proto__`, `constructor`, `prototype`)
- Mergeability considerations: same merge semantics for non-array values; only arrays change behavior (replace instead of index-merge)
- Follow-up tasks: same fix already applied on Vue stack (pierreb-devkit/Vue#3633)