### PR TITLE
docs(config): document merge architecture and array replacement semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Configuration is split between a **global** file and **per-module** files, then 
 
 ### File layout
 
+Only `config.*.js` files participate in the merge. Other config files in module directories (e.g. policy, seed) are loaded separately by their own init logic.
+
 ```text
 config/defaults/
   config.development.js          ← global defaults (app, db, host, port, log, seed, …)
@@ -135,8 +137,8 @@ modules/<name>/config/
 |-------|--------|---------|
 | 1 | Module development defaults | `modules/*/config/config.development.js` |
 | 2 | Global development defaults | `config/defaults/config.development.js` |
-| 3 | Module env overrides | `modules/*/config/config.production.js` |
-| 4 | Global env overrides | `config/defaults/config.production.js` |
+| 3 | Module env overrides | `modules/*/config/config.<env>.js` |
+| 4 | Global env overrides | `config/defaults/config.<env>.js` |
 | 5 | `DEVKIT_NODE_*` env vars | `DEVKIT_NODE_app_title='my app'` |
 
 Layers 3–4 are only applied when `NODE_ENV` is not `development`.


### PR DESCRIPTION
## Summary

- What changed: Rewrote the README configuration section to document the per-module config split, 5-layer merge order, and array replacement semantics
- Why: The README was outdated and didn't explain how config overrides work
- Related issues: Closes #3203

## Scope

- Module(s) impacted: none (docs only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: README section rewrite — downstream projects with customized READMEs may need manual merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced configuration documentation with detailed layouts, file structure diagrams, and merge order specifications.
  * Added comprehensive environment variable examples for better configuration understanding.
  * Improved clarity on layer priorities and conditional configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->