### PR TITLE
fix(skill): add merge conflict check in pull-request convergence loop

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -124,12 +124,13 @@ After `gh pr ready`, enter an autonomous polling loop. Do not wait for the user 
 consecutive_zero = 0
 
 REPEAT:
-  1. Wait for CI                        → sleep 30 then gh pr checks <number> --watch
+  1. Wait for CI                        → sleep 30 then gh pr checks $PR --watch
   2. If CI fails                        → fix, /verify, commit, push, consecutive_zero=0, GOTO 1
-  2b. Check mergeable status            → gh pr view $PR --json mergeable --jq .mergeable
-                                           if "CONFLICTING" → report to user and STOP
+  2b. Check mergeable status            → STATUS=$(gh pr view $PR --json mergeable --jq .mergeable)
+                                           if STATUS == "UNKNOWN" → sleep 10, retry up to 3 times
+                                           if STATUS == "CONFLICTING" → report to user and STOP
   3. Grace period                       → sleep 180 + adaptive check (see 6b)
-  4. Re-check pending review checks     → gh pr checks <number> — if any still pending, GOTO 3
+  4. Re-check pending review checks     → gh pr checks $PR — if any still pending, GOTO 3
   5. Read all feedback                  → unresolved threads only (see 6b)
   6. If actionable comments             → fix all, /verify, commit, push, reply, resolve, consecutive_zero=0, GOTO 1
   7. If non-actionable unresolved       → reply all explaining why, resolve all, consecutive_zero=0, GOTO 5


### PR DESCRIPTION
## Summary
- Add mergeable check (step 2b) after CI passes in convergence loop
- Stop early and report to user if PR has merge conflicts
- Update section 6f to reference the new mid-loop check

Closes #3236

## Test plan
- [ ] PR with no conflicts → loop proceeds normally
- [ ] PR with conflicts → loop stops and reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request merge procedures documentation with enhanced conflict detection and status validation throughout the merge workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->