### PR TITLE
docs(billing): add module README

### DIFF
--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -53,7 +53,7 @@ await BillingUsageService.increment(organizationId, 'documents.create', 1);
 Listen for plan changes in downstream modules:
 
 ```js
-import { billingEvents } from '../billing/lib/events.js';
+import billingEvents from '../billing/lib/events.js';
 
 billingEvents.on('plan.changed', ({ organizationId, previousPlan, newPlan, isDowngrade }) => {
   if (isDowngrade) {


### PR DESCRIPTION
## Summary
- Add billing module README with quota system documentation
- Add commented-out quota config example in development config
- Covers: configuration, requireQuota middleware, BillingUsageService, usage endpoint, plan change events

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (264 tests)