### PR TITLE
feat(verify): add coverage enforcement to verify skill

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -25,7 +25,7 @@ description: Run quality loop (audit + lint + tests) to verify code quality, cor
 
 3. **Tests + coverage** — check if MongoDB is reachable:
    - **Infra up** → `npm run test:coverage` (all tests + coverage enforcement)
-   - **Infra down** → `npm run test:coverage -- --testPathPattern='unit'` (unit only + coverage) + warn: "Integration/E2E skipped — run `docker compose -f docker-compose.test.yml up -d` for full coverage"
+   - **Infra down** → `npm run test:coverage -- --testPathPatterns='unit'` (unit only + coverage) + warn: "Integration/E2E skipped — run `docker compose -f docker-compose.test.yml up -d` for full coverage"
    - If coverage drops below thresholds (jest.config.js) → fail. Add tests, never lower thresholds.
 
 4. **Summary:** ✅ All passed → ready to commit | ❌ Failed → show failures, fix, re-run


### PR DESCRIPTION
## Summary

- `/verify` skill now runs tests with **coverage enforcement** (`npm run test:coverage`) instead of plain `npm run test:all`
- If coverage drops below the thresholds defined in `jest.config.js` (statements 80%, branches 65%, functions 80%, lines 80%), the verify step fails
- Maintains the infra-up/infra-down detection: unit-only coverage when MongoDB is unreachable

## Test plan

- [ ] Run `/verify` with infra up — confirms `npm run test:coverage` executes and enforces thresholds
- [ ] Run `/verify` with infra down — confirms unit-only coverage runs with warning
- [ ] Intentionally drop coverage below threshold — confirms verify fails