### PR TITLE
feat(ci): support self-hosted runners via RUNNER variable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
 
     services:
       mongo:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- Replace hardcoded `runs-on: ubuntu-latest` with `${{ vars.RUNNER || 'ubuntu-latest' }}` in `CI.yml` and `dependabot.yml`
- Downstream orgs can set `vars.RUNNER = self-hosted` at org level to use their own runners
- Default behavior unchanged when variable is not set

## Test plan
- [ ] CI passes on this PR (validates the expression syntax works with default fallback)
- [ ] Verify downstream repos inherit the change via `/update-stack`

Closes #3327