### PR TITLE
perf(ci): optimize GitHub Actions — timeout, skip merge push, Node LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,14 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [master, main]
   pull_request:
     branches: [master, main]
 
 jobs:
   test:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
 
     services:
       mongo:
@@ -21,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 15` to CI test job to prevent stuck jobs from burning all org minutes
- Add `timeout-minutes: 5` to dependabot auto-merge job
- Remove `push` trigger from CI — runs on `pull_request` only, eliminating double runs on merge
- Standardize `node-version` from hardcoded `22` to `lts/*`

Note: Docker layer cache (item #2 from the issue) is not applicable to this repo — there is no build/release workflow here. That optimization applies to downstream project repos.

Closes #3326

## Test plan
- [ ] CI triggers on this PR (pull_request event)
- [ ] CI does NOT trigger on merge to master (push event removed)
- [ ] Job timeout visible in Actions UI
- [ ] Node LTS resolves correctly in setup-node step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs only for pull requests targeting main branches (no direct push runs).
  * Node.js selection changed from a fixed version to the latest LTS stream.
  * Execution time limits added to CI and Dependabot jobs to fail long-running runs.
  * Existing build, lint, and test stages are preserved under the updated workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->