### PR TITLE
feat(ci): add container mode for ARC kubernetes compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,11 @@ jobs:
     services:
       mongo:
         image: mongo:7
+        options: >-
+          --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
 
     env:
       DEVKIT_NODE_db_uri: mongodb://mongo:27017/NodeTest


### PR DESCRIPTION
## Summary
- Add `container: node:lts` to CI test job for ARC kubernetes mode compatibility
- Set `DEVKIT_NODE_db_uri` env var to use `mongo` hostname (service container name) instead of `localhost`
- Remove `actions/setup-node` (redundant when running inside `node:lts` container)
- Remove `ports` mapping from mongo service (not needed in container-to-container networking)

Closes #3331

## Test plan
- [ ] CI passes on this PR (container mode with GitHub-hosted runner)
- [ ] Verify mongo connectivity works via `mongo` hostname

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run tests inside a container and improve database service reliability via health checks.
  * Simplified node setup in CI while retaining install, lint, and test steps to keep validation consistent.
  * Introduced an environment-level database connection reference to stabilize test connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->