### PR TITLE
feat(ci): use APP_ENV and MONGO_URI variables for downstream configs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,14 +21,14 @@ jobs:
 
     env:
       NODE_ENV: ${{ vars.APP_ENV || 'test' }}
-      DEVKIT_NODE_db_uri: ${{ vars.MONGO_URI || 'mongodb://mongo:27017/NodeTest' }}
+      DEVKIT_NODE_db_uri: ${{ secrets.MONGO_URI || vars.MONGO_URI || 'mongodb://mongo:27017/NodeTest' }}
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Wait for MongoDB
         run: |
-          timeout 30 bash -c 'until node -e "const s=require(\"net\").createConnection({host:\"mongo\",port:27017});s.on(\"connect\",()=>{s.end();process.exit(0)});s.on(\"error\",()=>process.exit(1))" 2>/dev/null; do sleep 1; done'
+          timeout 120 bash -c 'until node -e "const uri=process.env.DEVKIT_NODE_db_uri;let host=\"mongo\";let port=27017;try{if(uri){const u=new URL(uri);if(u.hostname)host=u.hostname;if(u.port)port=Number(u.port)||port;}}catch(e){}const s=require(\"net\").createConnection({host,port});s.setTimeout(5000);s.on(\"connect\",()=>{s.end();process.exit(0)});s.on(\"timeout\",()=>{s.destroy();process.exit(1)});s.on(\"error\",()=>process.exit(1))"; do echo "waiting for $DEVKIT_NODE_db_uri..."; sleep 1; done'
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- Add `APP_ENV` repo variable support: `NODE_ENV: ${{ vars.APP_ENV || 'test' }}`
- Add `MONGO_URI` repo variable support: `DEVKIT_NODE_db_uri: ${{ vars.MONGO_URI || 'mongodb://mongo:27017/NodeTest' }}`
- Add "Wait for MongoDB" step using Node TCP check for ARC kubernetes runner compatibility

## Test plan
- [ ] CI passes on this PR (defaults apply, no repo variables set)
- [ ] Downstream project with `APP_ENV` repo variable loads correct config
- [ ] MongoDB wait step succeeds before npm ci runs

Closes #3333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI pipeline robustness with health checks to ensure dependent services are ready before tests run.
  * Enhanced CI configuration flexibility through parameterized environment variables for easier deployment across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->