### PR TITLE
feat(ci): skip setup-node and container for self-hosted runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,12 +7,13 @@ on:
 jobs:
   test:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    container: node:lts
     timeout-minutes: 30
 
     services:
       mongo:
         image: mongo:7
+        ports:
+          - 27017:27017
         options: >-
           --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
           --health-interval=10s
@@ -21,10 +22,17 @@ jobs:
 
     env:
       NODE_ENV: ${{ vars.APP_ENV || 'test' }}
-      DEVKIT_NODE_db_uri: ${{ secrets.MONGO_URI || vars.MONGO_URI || 'mongodb://mongo:27017/NodeTest' }}
+      DEVKIT_NODE_db_uri: ${{ secrets.MONGO_URI || vars.MONGO_URI || 'mongodb://localhost:27017/NodeTest' }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: ${{ !vars.RUNNER }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
 
       - name: Wait for MongoDB
         run: |


### PR DESCRIPTION
## Summary
- Remove `container: node:lts` so the job runs directly on the runner host
- Add conditional `setup-node@v4` step (only on GitHub-hosted, skipped when `vars.RUNNER` is set)
- Add explicit `ports: 27017:27017` mapping for the mongo service (required without a job container)
- Switch fallback mongo URI from `mongo` hostname to `localhost` (host networking)

Closes #3338

## Test plan
- [ ] CI passes on GitHub-hosted runner (ubuntu-latest) with setup-node + mongo service
- [ ] CI passes on self-hosted runner with pre-installed node + external mongo (via `vars.RUNNER` + `vars.MONGO_URI`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to improve build reliability and testing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->