### PR TITLE
fix(ci): simplify CI.yml — remove ARC-specific conditionals

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,15 +28,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: ${{ !vars.RUNNER }}
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: npm
-
-      - name: Wait for MongoDB
-        run: |
-          timeout 120 bash -c 'until node -e "const uri=process.env.DEVKIT_NODE_db_uri;let host=\"mongo\";let port=27017;try{if(uri){const u=new URL(uri);if(u.hostname)host=u.hostname;if(u.port)port=Number(u.port)||port;}}catch(e){}const s=require(\"net\").createConnection({host,port});s.setTimeout(5000);s.on(\"connect\",()=>{s.end();process.exit(0)});s.on(\"timeout\",()=>{s.destroy();process.exit(1)});s.on(\"error\",()=>process.exit(1))"; do echo "waiting for $DEVKIT_NODE_db_uri..."; sleep 1; done'
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- Remove `if: ${{ !vars.RUNNER }}` condition from setup-node step (always run it)
- Remove the entire "Wait for MongoDB" step with its complex Node TCP probe — the services health check already guarantees MongoDB is ready

## Test plan
- [ ] CI passes on this PR (self-validating: the simplified workflow runs successfully)

Closes #3342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow by streamlining build pipeline steps and removing redundant verification processes for more efficient build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->