### PR TITLE
chore(ci): align Node CI with Vue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,9 @@ jobs:
       - run: npm run test:coverage
 
       - uses: codecov/codecov-action@v5
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        if: env.CODECOV_TOKEN != ''
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to skip CI on doc-only changes (`*.md`, `documentation/`, `.claude/`)
- Add `concurrency` group to cancel stale in-progress PR runs on new pushes
- Add Codecov upload step after `npm run test:coverage`

Closes #3344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflows to skip pipeline execution for pull requests that only modify documentation and markdown files
  * Implemented workflow concurrency management to automatically cancel duplicate or in-progress runs, improving resource efficiency
  * Integrated automated code coverage reporting to provide enhanced visibility into test coverage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->