### PR TITLE
fix(ci): add codecov.yml configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: auto
     patch:
       default:
         target: 80%


### PR DESCRIPTION
## Summary
- Add `codecov.yml` at repo root (matching Vue's config)
- `target: auto` on project coverage (no regression allowed)
- `target: 80%` on patch coverage (new code must be well-tested)

Closes #3346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration with coverage status thresholds. Project metric set to automatic; patch metric configured to 80%. These baseline settings establish standards for code coverage tracking and assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->