### PR TITLE
docs(feature): add enum/schema consistency check to self-review

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -79,6 +79,10 @@ If an action affects another user:
 **Tests:**
 - [ ] Tests: add unit (`*.unit.tests.js`) + integration (`*.integration.tests.js`) tests. Add E2E (`*.e2e.tests.js`) only if the change affects a critical user flow (auth, org onboarding, invite/join).
 
+**Schema consistency:**
+- [ ] New enum values added to ALL schema definitions (Mongoose model `enum`, Zod `z.enum`, tests)
+- [ ] Grep existing enum values to find all locations before committing
+
 **Modularity:**
 - [ ] Isolated in ONE module (or justified)
 - [ ] No cross-module Repository/Model imports (use target module's Service)
@@ -87,6 +91,9 @@ If an action affects another user:
 **Notifications:**
 - [ ] Actions affecting other users trigger email (if configured)
 - [ ] Templates created for each email type
+
+**Error documentation:**
+- [ ] If a non-obvious bug was fixed, document it in `ERRORS.md` (root of repo) with: symptom, root cause, fix
 
 ### 8b. Elegance check
 


### PR DESCRIPTION
## Summary
- Adds a **Schema consistency** section to the `/feature` skill self-review checklist
- Requires verifying new enum values exist in ALL schema definitions (Mongoose model `enum`, Zod `z.enum`, tests)
- Requires grepping existing enum values to find all locations before committing
- Adds an **Error documentation** checklist item to prompt documenting non-obvious bugs in `ERRORS.md`

## Why
Prevents silent validation failures when schemas are out of sync — e.g. adding an enum value to a messages config but forgetting the Mongoose model or Zod schema. Also ensures non-obvious bug fixes are documented for future reference.

Closes #3353

## Test plan
- [x] Lint passes
- [x] Documentation-only change, no runtime impact