### PR TITLE
ci: run CI on push to master for Codecov baseline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,12 @@
 name: CI
 
 on:
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - '**/*.md'
+      - 'documentation/**'
+      - '.claude/**'
   pull_request:
     branches: [master, main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- Add `push` trigger on `master`/`main` to the CI workflow
- Ensures Codecov uploads a baseline on every merge, so `codecov/project` can compare PRs properly

## Context
All PRs currently fail `codecov/project` because CI only ran on `pull_request` — no baseline existed on master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow configuration to optimize build performance by skipping unnecessary runs when only documentation or configuration files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->