### PR TITLE
chore(scripts): rename dev:billing → dev:env and start:billing → start:env

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "scripts": {
     "start": "node server.js",
-    "start:billing": "node --env-file-if-exists=.env server.js",
+    "start:env": "node --env-file-if-exists=.env server.js",
     "dev": "node --watch server.js",
-    "dev:billing": "node --env-file-if-exists=.env --watch server.js",
+    "dev:env": "node --env-file-if-exists=.env --watch server.js",
     "debug": "nodemon --inspect server.js",
     "prod": "cross-env NODE_ENV=production node server.js --name=node",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --testPathPatterns='unit'",


### PR DESCRIPTION
## Summary

- What changed: Renamed `dev:billing` → `dev:env` and `start:billing` → `start:env` in `package.json`
- Why: The `:billing` suffix was misleading — these scripts load a `.env` file, which is not billing-specific. The `:env` suffix accurately reflects the behavior.
- Related issues: Closes #3367

## Scope

- Module(s) impacted: `package.json` (scripts only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none
- Mergeability considerations: Downstream projects using `dev:billing` or `start:billing` will need to update their npm scripts — no backwards compat alias provided (devkit stack, direct rename).
- Follow-up tasks (optional): Downstream projects should be updated via `/update-stack`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed npm scripts for improved clarity: `start:billing` and `dev:billing` are now `start:env` and `dev:env`, respectively. These scripts continue to support environment file configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->