### PR TITLE
docs(api): hide models sidebar in Scalar reference

### DIFF
--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -92,6 +92,7 @@ const initSwagger = (app) => {
       '/api/docs',
       apiReference({
         spec: { content: spec },
+        hideModels: true,
       }),
     );
   }


### PR DESCRIPTION
## Summary

- Pass `hideModels: true` to the Scalar `apiReference` middleware mounted at `/api/docs` in `lib/services/express.js`.
- The public docs no longer expose the Models sidebar tree (Mongoose-derived shapes, error envelopes, intermediate DTOs). Endpoint schemas are still documented inline on each route — the Models section just leaked implementation detail without helping API consumers.
- Stack-side default: every downstream project benefits without extra config.

## Verification

- `hideModels` option confirmed against the installed version of `@scalar/express-api-reference` (`0.9.7`). The config type is `HtmlRenderingConfiguration` re-exported from `@scalar/core`, and `node_modules/@scalar/types/dist/api-reference/api-reference-configuration.d.ts` declares `hideModels: z.ZodCatch<z.ZodDefault<z.ZodOptional<z.ZodBoolean>>>` — option name and typing both valid.
- Out of scope (kept for a later PR per one-fix-per-PR rule): theme changes, `hiddenClients` trimming, `customCss`, layout tuning.

## Test plan

- [x] `npm run lint` — green
- [x] `npm test` — 499/499 unit tests passing
- [x] Manual sanity check of the diff (one-line addition)
- [ ] CI green on PR
- [ ] CodeRabbit review clean

Closes #3458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API reference documentation now hides models in the rendered interface, providing a streamlined view at `/api/docs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->