### PR TITLE
docs(api): wire app.title/description and domain into OpenAPI spec

### DIFF
--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -66,6 +66,15 @@ const initSwagger = (app) => {
       return;
     }
 
+    // Inject runtime-resolved metadata from config so each downstream project
+    // advertises its own title, description, and public domain in the spec.
+    spec.info = {
+      ...(spec.info || {}),
+      title: config.app.title,
+      description: config.app.description,
+    };
+    spec.servers = [{ url: config.domain || 'http://localhost:3000' }];
+
     // Merge per-module markdown guides into info.description so Scalar
     // renders them in its sidebar alongside the OpenAPI reference.
     const guides = guidesHelper.loadGuides(config.files.guides || []);

--- a/modules/core/doc/index.yml
+++ b/modules/core/doc/index.yml
@@ -1,8 +1,6 @@
 openapi: '3.0.0'
 info:
   version: '1.0.0'
-servers:
-  - url: 'http://localhost:3000'
 components:
   securitySchemes:
     bearerAuth:

--- a/modules/core/tests/core.integration.tests.js
+++ b/modules/core/tests/core.integration.tests.js
@@ -300,13 +300,16 @@ describe('Core integration tests:', () => {
       expect(res.body.openapi).toBe('3.0.0');
       expect(res.body.info).toBeDefined();
       expect(typeof res.body.info.version).toBe('string');
-      // The stack ships zero public API guides — downstream projects own the
-      // content rendered in their /api/docs via their own modules' doc/guides/*.md.
-      // `info.description` is therefore optional (string when any module provides
-      // a guide, undefined/empty otherwise).
-      if (res.body.info.description !== undefined) {
-        expect(typeof res.body.info.description).toBe('string');
-      }
+      // title and description are injected from config at runtime so every
+      // downstream project advertises its own identity instead of empty/hardcoded values.
+      expect(typeof res.body.info.title).toBe('string');
+      expect(res.body.info.title.length).toBeGreaterThan(0);
+      expect(typeof res.body.info.description).toBe('string');
+      // servers[0].url is sourced from config.domain (fallback http://localhost:3000).
+      expect(Array.isArray(res.body.servers)).toBe(true);
+      expect(res.body.servers).toHaveLength(1);
+      expect(typeof res.body.servers[0].url).toBe('string');
+      expect(res.body.servers[0].url.length).toBeGreaterThan(0);
     });
 
     it('should serve the Scalar API reference page on /api/docs', async () => {

--- a/modules/core/tests/core.integration.tests.js
+++ b/modules/core/tests/core.integration.tests.js
@@ -305,6 +305,7 @@ describe('Core integration tests:', () => {
       expect(typeof res.body.info.title).toBe('string');
       expect(res.body.info.title.length).toBeGreaterThan(0);
       expect(typeof res.body.info.description).toBe('string');
+      expect(res.body.info.description.trim().length).toBeGreaterThan(0);
       // servers[0].url is sourced from config.domain (fallback http://localhost:3000).
       expect(Array.isArray(res.body.servers)).toBe(true);
       expect(res.body.servers).toHaveLength(1);

--- a/modules/core/tests/core.unit.tests.js
+++ b/modules/core/tests/core.unit.tests.js
@@ -642,6 +642,78 @@ describe('Core unit tests:', () => {
         }
       });
 
+      it('should inject info.title, info.description and servers from config', () => {
+        config.swagger = { enable: true };
+        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')] };
+        const originalDomain = config.domain;
+        config.domain = 'https://api.example.test';
+        try {
+          const mockGet = jest.fn();
+          const mockUse = jest.fn();
+          const mockApp = { get: mockGet, use: mockUse };
+          expressService.initSwagger(mockApp);
+          const handler = mockGet.mock.calls.find((c) => c[0] === '/api/spec.json')[1];
+          const mockRes = { json: jest.fn() };
+          handler({}, mockRes);
+          const served = mockRes.json.mock.calls[0][0];
+          expect(served.info.title).toBe(config.app.title);
+          expect(served.info.description).toBe(config.app.description);
+          expect(served.servers).toEqual([{ url: 'https://api.example.test' }]);
+        } finally {
+          config.domain = originalDomain;
+        }
+      });
+
+      it('should fall back to localhost in servers when config.domain is empty', () => {
+        config.swagger = { enable: true };
+        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')] };
+        const originalDomain = config.domain;
+        config.domain = '';
+        try {
+          const mockGet = jest.fn();
+          const mockUse = jest.fn();
+          const mockApp = { get: mockGet, use: mockUse };
+          expressService.initSwagger(mockApp);
+          const handler = mockGet.mock.calls.find((c) => c[0] === '/api/spec.json')[1];
+          const mockRes = { json: jest.fn() };
+          handler({}, mockRes);
+          const served = mockRes.json.mock.calls[0][0];
+          expect(served.servers).toEqual([{ url: 'http://localhost:3000' }]);
+        } finally {
+          config.domain = originalDomain;
+        }
+      });
+
+      it('should preserve config description then append guides on top', async () => {
+        const { default: fsMod } = await import('fs');
+        const tmpDir = path.join('/tmp', `guides-inject-${Date.now()}`);
+        fsMod.mkdirSync(tmpDir, { recursive: true });
+        const tmpGuide = path.join(tmpDir, 'welcome.md');
+        fsMod.writeFileSync(tmpGuide, 'Welcome guide content for description merge.\n');
+        try {
+          config.swagger = { enable: true };
+          config.files = {
+            ...config.files,
+            swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')],
+            guides: [tmpGuide],
+          };
+          const mockGet = jest.fn();
+          const mockUse = jest.fn();
+          const mockApp = { get: mockGet, use: mockUse };
+          expressService.initSwagger(mockApp);
+          const handler = mockGet.mock.calls.find((c) => c[0] === '/api/spec.json')[1];
+          const mockRes = { json: jest.fn() };
+          handler({}, mockRes);
+          const served = mockRes.json.mock.calls[0][0];
+          // Config description must be first, guide content appended after
+          expect(served.info.description.startsWith(config.app.description)).toBe(true);
+          expect(served.info.description).toContain('Welcome guide content for description merge.');
+        } finally {
+          fsMod.unlinkSync(tmpGuide);
+          fsMod.rmdirSync(tmpDir);
+        }
+      });
+
       it('should warn and skip registration when all YAML files produce an empty spec', async () => {
         // Write a temp YAML file that parses to a scalar — after filter(Boolean), contents is empty → spec is {}
         const { default: fsMod } = await import('fs');

--- a/modules/core/tests/core.unit.tests.js
+++ b/modules/core/tests/core.unit.tests.js
@@ -644,7 +644,7 @@ describe('Core unit tests:', () => {
 
       it('should inject info.title, info.description and servers from config', () => {
         config.swagger = { enable: true };
-        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')] };
+        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')], guides: [] };
         const originalDomain = config.domain;
         config.domain = 'https://api.example.test';
         try {
@@ -666,7 +666,7 @@ describe('Core unit tests:', () => {
 
       it('should fall back to localhost in servers when config.domain is empty', () => {
         config.swagger = { enable: true };
-        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')] };
+        config.files = { ...config.files, swagger: [path.join(process.cwd(), 'modules/core/doc/index.yml')], guides: [] };
         const originalDomain = config.domain;
         config.domain = '';
         try {


### PR DESCRIPTION
## Summary

- Inject `info.title`, `info.description` and `servers[0].url` into the merged OpenAPI spec from `config.app.title`, `config.app.description` and `config.domain` in `initSwagger`, right before the markdown guides helper appends its sidebar content. Each downstream project (trawl, pierreb, comes, montaine...) now advertises its own identity and public domain at `/api/spec.json`, so Scalar renders the reference with the right title and its Try-It samples hit the real API base URL.
- Delete the redundant `servers:` block from `modules/core/doc/index.yml` so the code remains the single source of truth (the YAML was hardcoded to `http://localhost:3000` and competed with the config).
- Order is important: set `info.description` from config first, then let `guidesHelper.mergeGuidesIntoSpec` concatenate markdown guides after (`[existing, ...sections].filter(Boolean).join('\n\n')`).

Closes #3461

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:coverage` all 64 suites / 769 tests green, coverage thresholds respected
- [x] New unit tests in `core.unit.tests.js` cover: `info.title` / `info.description` injection, custom `config.domain`, empty-domain fallback to `http://localhost:3000`, guides still appended after config description
- [x] Integration test `core.integration.tests.js` now asserts non-empty `info.title`, `info.description` and `servers[0].url`
- [x] `modules/home` `app.locals.title` rendering unaffected (unchanged code path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * API documentation now dynamically configured from application settings (title, description, and server URL).
  * Server URL automatically defaults to localhost when not specified in configuration.

* **Tests**
  * Enhanced test coverage for API specification generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->