### PR TITLE
feat(guides): strip numeric ordering prefix from rendered titles

### DIFF
--- a/lib/helpers/guides.js
+++ b/lib/helpers/guides.js
@@ -17,12 +17,20 @@ import logger from '../services/logger.js';
 /**
  * Derive a human-readable title from a guide file path.
  * E.g. `modules/auth/doc/guides/getting-started.md` → `Getting Started`
+ *
+ * A leading numeric ordering prefix (`NN-` or `NN_`, any digit count) is
+ * stripped before title-casing so projects can control sidebar order via
+ * filename prefixes (`00-welcome.md`, `01-api-access.md`, ...) without the
+ * numbers leaking into the rendered titles. Filenames that are purely
+ * numeric (`42.md`) fall back to the digits so we never emit an empty title.
  * @param {string} filePath - Absolute or relative path to the guide file.
  * @returns {string} Title-cased guide name.
  */
 const titleFromPath = (filePath) => {
   const base = path.basename(String(filePath), path.extname(String(filePath)));
-  return base
+  const stripped = base.replace(/^\d+[-_]/, '');
+  const source = stripped || base;
+  return source
     .split(/[-_\s]+/)
     .filter(Boolean)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -64,8 +72,15 @@ const loadGuides = (filePaths) => {
     })
     .filter(Boolean)
     // Stable alphabetical order so the sidebar is deterministic across
-    // filesystems (glob order varies on macOS vs Linux containers).
-    .sort((a, b) => a.title.localeCompare(b.title));
+    // filesystems (glob order varies on macOS vs Linux containers). Sort on
+    // the raw basename rather than the rendered title so numeric ordering
+    // prefixes (`00-welcome.md`, `01-api-access.md`) still control order
+    // even though the digits are stripped from the visible title.
+    .sort((a, b) => {
+      const keyA = path.basename(String(a.path), path.extname(String(a.path)));
+      const keyB = path.basename(String(b.path), path.extname(String(b.path)));
+      return keyA.localeCompare(keyB);
+    });
 };
 
 /**

--- a/modules/core/tests/core.unit.tests.js
+++ b/modules/core/tests/core.unit.tests.js
@@ -833,6 +833,45 @@ describe('Core unit tests:', () => {
       expect(guidesHelper.titleFromPath('multi_word_file.md')).toBe('Multi Word File');
     });
 
+    it('should strip a leading numeric ordering prefix before title-casing', () => {
+      expect(guidesHelper.titleFromPath('00-welcome.md')).toBe('Welcome');
+      expect(guidesHelper.titleFromPath('01-api-access.md')).toBe('Api Access');
+      expect(guidesHelper.titleFromPath('/abs/path/10-getting-started.md')).toBe('Getting Started');
+      expect(guidesHelper.titleFromPath('007_secret_agent.md')).toBe('Secret Agent');
+    });
+
+    it('should keep titles without a numeric prefix unchanged', () => {
+      expect(guidesHelper.titleFromPath('welcome.md')).toBe('Welcome');
+      expect(guidesHelper.titleFromPath('getting-started.md')).toBe('Getting Started');
+    });
+
+    it('should fall back to the raw basename for digits-only filenames', () => {
+      expect(guidesHelper.titleFromPath('42.md')).toBe('42');
+      expect(guidesHelper.titleFromPath('/abs/path/007.md')).toBe('007');
+    });
+
+    it('should load guides and sort by filename so numeric prefixes control order', async () => {
+      const { default: fsMod } = await import('fs');
+      const tmpDir = path.join('/tmp', `guides-order-${Date.now()}`);
+      fsMod.mkdirSync(tmpDir, { recursive: true });
+      const files = [
+        { name: '02-scraping.md', body: '# Scraping\n\nScraping body.\n' },
+        { name: '00-welcome.md', body: '# Welcome\n\nWelcome body.\n' },
+        { name: '01-api-access.md', body: '# Api Access\n\nAccess body.\n' },
+      ].map(({ name, body }) => {
+        const full = path.join(tmpDir, name);
+        fsMod.writeFileSync(full, body);
+        return full;
+      });
+      try {
+        const guides = guidesHelper.loadGuides(files);
+        expect(guides.map((g) => g.title)).toEqual(['Welcome', 'Api Access', 'Scraping']);
+      } finally {
+        files.forEach((f) => fsMod.unlinkSync(f));
+        fsMod.rmdirSync(tmpDir);
+      }
+    });
+
     it('should strip the leading H1 from markdown content', () => {
       const input = '# Title\n\nBody paragraph';
       expect(guidesHelper.stripLeadingH1(input)).toBe('Body paragraph');


### PR DESCRIPTION
## Summary

- `titleFromPath` now strips a leading `NN-` or `NN_` prefix before title-casing, so projects can use numeric ordering prefixes (`00-welcome.md`, `01-api-access.md`) without the digits leaking into rendered Scalar titles.
- Digits-only filenames (`42.md`) fall back to the raw basename so we never emit an empty title.
- `loadGuides` now sorts on the raw filename basename instead of the rendered title, so numeric prefixes still drive order even after the visible title is stripped.

Closes #3463

## Test plan

- [x] `npm run lint`
- [x] `npm run test:unit -- --testPathPatterns='core.unit'` (506 passed)
- [x] `guides.js` coverage: 100% statements / 100% functions / 100% lines / 90% branches
- [x] New unit tests cover prefixed filenames, non-prefixed filenames, digits-only fallback, and numeric-prefix sort order