### PR TITLE
fix(users): relax firstName to optional to accept digit-only email local-parts

### DIFF
--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -134,6 +134,31 @@ describe('Auth integration tests:', () => {
       }
     });
 
+    test('should register a new user when firstName is omitted (digit-only email local-part)', async () => {
+      const digitOnlyPayload = {
+        email: 'register_digits_123@test.com',
+        password: credentials[1].password,
+        provider: 'local',
+      };
+      try {
+        const existing = await UserService.getBrut({ email: digitOnlyPayload.email });
+        if (existing) await UserService.remove(existing);
+      } catch (_) { /* cleanup */ }
+
+      let created;
+      try {
+        const result = await agent.post('/api/auth/signup').send(digitOnlyPayload).expect(200);
+        created = result.body.user;
+        expect(result.body.user.email).toBe(digitOnlyPayload.email);
+        expect(result.body.user.firstName).toBe('');
+      } catch (err) {
+        console.log(err);
+        expect(err).toBeFalsy();
+      } finally {
+        try { if (created) await UserService.remove(created); } catch (_) { /* cleanup */ }
+      }
+    });
+
     test('should register a new user successfully', async () => {
       // Init user edited
       _userEdited.email = 'register_new_user_@test.com';
@@ -505,7 +530,7 @@ describe('Auth integration tests:', () => {
 
     test('should throw validation AppError when checkOAuthUserProfile receives an invalid profile', async () => {
       const invalidProfil = {
-        firstName: '', // invalid — fails min(1)
+        firstName: 'Invalid1', // invalid — digits fail the names refinement
         lastName: 'Test',
         email: 'invalid-oauth@test.com',
         avatar: '',
@@ -567,7 +592,7 @@ describe('Auth integration tests:', () => {
           strategy: false,
           key: 'id',
           value: 'cb-app-auth-id-invalid-999',
-          firstName: '',
+          firstName: 'Invalid1',
           lastName: 'Callback',
           email: 'oauthcb-invalid@test.com',
         })

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -136,7 +136,7 @@ describe('Auth integration tests:', () => {
 
     test('should register a new user when firstName is omitted (digit-only email local-part)', async () => {
       const digitOnlyPayload = {
-        email: 'register_digits_123@test.com',
+        email: '123@test.com',
         password: credentials[1].password,
         provider: 'local',
       };

--- a/modules/users/models/users.schema.js
+++ b/modules/users/models/users.schema.js
@@ -12,8 +12,8 @@ const names = /^[a-zA-Zàáâäãåąčćęèéêëėįìíîïłńòóôöõø�
  * User Data Schema
  */
 const User = z.object({
-  firstName: z.string().min(1).max(50).trim()
-    .refine((val) => names.test(val), { message: 'Invalid characters in name' }),
+  firstName: z.string().max(50).trim().optional().default('')
+    .refine((val) => val === '' || names.test(val), { message: 'Invalid characters in name' }),
   lastName: z.string().max(50).trim().optional().default('')
     .refine((val) => val === '' || names.test(val), { message: 'Invalid characters in name' }),
   bio: z.string().max(200).trim().optional().default(''),

--- a/modules/users/tests/user.unit.tests.js
+++ b/modules/users/tests/user.unit.tests.js
@@ -27,7 +27,7 @@ describe('User unit tests:', () => {
       done();
     });
 
-    test('should accept an empty firstName (optional, signup with digit-only email local-part)', (done) => {
+    test('should accept an empty optional firstName', (done) => {
       user.firstName = '';
 
       const result = schema.User.safeParse(user);

--- a/modules/users/tests/user.unit.tests.js
+++ b/modules/users/tests/user.unit.tests.js
@@ -27,8 +27,28 @@ describe('User unit tests:', () => {
       done();
     });
 
-    test('should be able to show an error when trying a schema without first name', (done) => {
+    test('should accept an empty firstName (optional, signup with digit-only email local-part)', (done) => {
       user.firstName = '';
+
+      const result = schema.User.safeParse(user);
+      expect(typeof result).toBe('object');
+      expect(result.error).toBeFalsy();
+      expect(result.data.firstName).toBe('');
+      done();
+    });
+
+    test('should accept an undefined firstName and default it to an empty string', (done) => {
+      delete user.firstName;
+
+      const result = schema.User.safeParse(user);
+      expect(typeof result).toBe('object');
+      expect(result.error).toBeFalsy();
+      expect(result.data.firstName).toBe('');
+      done();
+    });
+
+    test('should reject a firstName containing digits via the names refinement', (done) => {
+      user.firstName = 'Invalid1';
 
       const result = schema.User.safeParse(user);
       expect(typeof result).toBe('object');


### PR DESCRIPTION
## Summary

- What changed: relax `firstName` in `modules/users/models/users.schema.js` — drop `.min(1)`, add `.optional().default('')`, and let `refine` accept empty strings (mirrors the existing `lastName` pattern).
- Why: signup returned 422 `Expected string, received undefined` on `firstName` whenever the email local-part contained any digit (e.g. `123@example.com`, `user1@example.com`). Vue's `deduceNamesFromEmail` filters tokens with `/^[a-zA-Z]+$/`, drops every digit-bearing token, then `signup()` only forwards truthy fields — so `firstName` arrives `undefined` and Zod rejects it. Downstream consumers (`auth.controller.js` displayName, organizations service, analytics identify) already tolerate empty `firstName`.
- Related issues: Closes #3477

## Scope

- Module(s) impacted: `users` (schema), `users` (unit tests), `auth` (integration tests — added digit-only signup coverage)
- Cross-module impact: `none` — downstream usages already fall back on empty firstName (`|| 'User'`, `.filter(Boolean).join(' ')`).
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test` (776/776 pass, coverage 84.44 / 72.2 / 86.32 / 85.91 — above thresholds)
- [x] Manual checks done (if applicable) — new unit test covers `firstName === ''` acceptance; new integration test covers signup with digit-bearing local-part.

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects (schema relaxation only; existing required-name callers unaffected)
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: none — relaxing an already-validated string field; max length and character-class refine remain in place for non-empty inputs.
- Mergeability considerations: clean schema-level change, mirrors the existing `lastName` precedent in the same object. No migration needed (empty-string default is idempotent for new docs; existing docs already carry valid firstNames).
- Follow-up tasks (optional): Vue side can be tightened later to prompt the user for firstName when deduction fails, but the spec explicitly says "no Vue form change" — covered post-signup in profile edit.