### PR TITLE
fix(tests): guard jest globalSetup against non-test NODE_ENV (#3476)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -172,7 +172,11 @@ export default {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  testMatch: ['<rootDir>/modules/*/tests/**/*.js', '<rootDir>/lib/**/tests/**/*.js'],
+  testMatch: [
+    '<rootDir>/modules/*/tests/**/*.js',
+    '<rootDir>/lib/**/tests/**/*.js',
+    '<rootDir>/scripts/tests/**/*.js',
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: ['/node_modules/', '/tests/fixtures/'],

--- a/scripts/jest.globalSetup.js
+++ b/scripts/jest.globalSetup.js
@@ -2,12 +2,36 @@
  * Jest global setup - drops the test database before the test suite runs.
  * Replaces the gulp dropDB task that previously ran before jest.
  * Silently skips if MongoDB is unreachable (e.g. fresh CI environment).
+ *
+ * Safety guards (#3476):
+ *   1. Refuse to drop anything when `NODE_ENV !== 'test'`. Protects downstream
+ *      projects that export `NODE_ENV=<project>` in their shell and invoke
+ *      jest directly (e.g. `npx jest`, IDE runners) bypassing the
+ *      `cross-env NODE_ENV=test` wrapper used by the npm `test*` scripts.
+ *   2. Belt-and-suspenders: also refuse when the resolved DB name does not
+ *      contain `test` (case-insensitive). Catches leaked overrides of
+ *      `config.db.uri` that point at a non-test database.
+ *
+ * Both checks log a clear refusal reason and exit without connecting.
  */
 import mongoose from 'mongoose';
 
 export default async () => {
+  if (process.env.NODE_ENV !== 'test') {
+    console.warn(
+      `[jest.globalSetup] Refusing to drop DB: NODE_ENV is "${process.env.NODE_ENV}", expected "test". Skipping drop.`,
+    );
+    return;
+  }
   try {
     const config = (await import('../config/index.js')).default;
+    const dbName = new URL(config.db.uri).pathname.replace(/^\//, '');
+    if (!/test/i.test(dbName)) {
+      console.warn(
+        `[jest.globalSetup] Refusing to drop "${dbName}": name does not match /test/i. Aborting.`,
+      );
+      return;
+    }
     await mongoose.connect(config.db.uri);
     await mongoose.connection.dropDatabase();
     await mongoose.disconnect();

--- a/scripts/jest.globalSetup.js
+++ b/scripts/jest.globalSetup.js
@@ -16,6 +16,14 @@
  */
 import mongoose from 'mongoose';
 
+/**
+ * Jest global setup entry point — drops the test database before the suite runs.
+ * Enforces the NODE_ENV + DB-name guards described at the top of this file.
+ * @returns {Promise<void>} Resolves once the guard check completes and, when
+ * guards pass and Mongo is reachable, once the database has been dropped and
+ * the connection closed. Never rejects — a Mongo failure is swallowed so tests
+ * can still run against existing state (e.g. fresh CI without mongo).
+ */
 export default async () => {
   if (process.env.NODE_ENV !== 'test') {
     console.warn(
@@ -33,8 +41,11 @@ export default async () => {
       return;
     }
     await mongoose.connect(config.db.uri);
-    await mongoose.connection.dropDatabase();
-    await mongoose.disconnect();
+    try {
+      await mongoose.connection.dropDatabase();
+    } finally {
+      await mongoose.disconnect();
+    }
   } catch {
     // MongoDB unreachable or drop failed — tests will run against existing state
   }

--- a/scripts/tests/jest.globalSetup.unit.tests.js
+++ b/scripts/tests/jest.globalSetup.unit.tests.js
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for jest globalSetup safety guards (#3476).
+ *
+ * The globalSetup runs BEFORE any test suite, so its own behaviour can't be
+ * observed from inside a test. These tests exercise the module as a plain
+ * async function — the same entry point jest uses — while mocking mongoose
+ * and config to avoid touching a real database.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+const connect = jest.fn(async () => {});
+const dropDatabase = jest.fn(async () => {});
+const disconnect = jest.fn(async () => {});
+
+jest.unstable_mockModule('mongoose', () => ({
+  default: {
+    connect,
+    disconnect,
+    connection: { dropDatabase },
+  },
+}));
+
+describe('scripts/jest.globalSetup safety guards', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy;
+
+  beforeEach(() => {
+    connect.mockClear();
+    dropDatabase.mockClear();
+    disconnect.mockClear();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.resetModules();
+  });
+
+  test('refuses to drop when NODE_ENV is not "test" (project env leak)', async () => {
+    process.env.NODE_ENV = 'ism';
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await globalSetup();
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NODE_ENV is "ism"'));
+  });
+
+  test('refuses to drop when NODE_ENV is undefined', async () => {
+    delete process.env.NODE_ENV;
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await globalSetup();
+
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NODE_ENV is "undefined"'));
+  });
+
+  test('refuses to drop when resolved DB name does not contain "test"', async () => {
+    process.env.NODE_ENV = 'test';
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/ProductionDb' } },
+    }));
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await globalSetup();
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Refusing to drop "ProductionDb"'));
+  });
+
+  test('drops database when NODE_ENV=test and DB name contains "test" (case-insensitive)', async () => {
+    process.env.NODE_ENV = 'test';
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/NodeTest' } },
+    }));
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await globalSetup();
+
+    expect(connect).toHaveBeenCalledWith('mongodb://localhost:27017/NodeTest');
+    expect(dropDatabase).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test('swallows errors when MongoDB is unreachable', async () => {
+    process.env.NODE_ENV = 'test';
+    connect.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/NodeTest' } },
+    }));
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await expect(globalSetup()).resolves.toBeUndefined();
+    expect(dropDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/tests/jest.globalSetup.unit.tests.js
+++ b/scripts/tests/jest.globalSetup.unit.tests.js
@@ -33,7 +33,11 @@ describe('scripts/jest.globalSetup safety guards', () => {
 
   afterEach(() => {
     warnSpy.mockRestore();
-    process.env.NODE_ENV = originalNodeEnv;
+    // Restore the original NODE_ENV — `process.env` coerces values to strings,
+    // so assigning `undefined` would leave the literal string "undefined". Use
+    // `delete` when the variable was originally absent.
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
     jest.resetModules();
   });
 
@@ -97,5 +101,19 @@ describe('scripts/jest.globalSetup safety guards', () => {
 
     await expect(globalSetup()).resolves.toBeUndefined();
     expect(dropDatabase).not.toHaveBeenCalled();
+  });
+
+  test('disconnects even when dropDatabase() fails (no dangling connection)', async () => {
+    process.env.NODE_ENV = 'test';
+    dropDatabase.mockRejectedValueOnce(new Error('drop failed'));
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/NodeTest' } },
+    }));
+    const { default: globalSetup } = await import('../jest.globalSetup.js');
+
+    await expect(globalSetup()).resolves.toBeUndefined();
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(dropDatabase).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Hard-guard `scripts/jest.globalSetup.js` so `dropDatabase()` is never called when `NODE_ENV !== 'test'` or when the resolved DB name does not match `/test/i`.
- Add 5 unit tests covering the two guards + the happy path + Mongo unreachable.
- Extend `jest.config.js` `testMatch` to include `scripts/tests/**/*.js`.

## Why

Downstream projects (ism_node, trawl_node, comes_node, montaine_node) export `NODE_ENV=<project>` in the developer shell so their config resolves to the project DB. Running jest directly (`npx jest`, IDE runner, editor extension) bypasses the `cross-env NODE_ENV=test` wrapper and the previous globalSetup happily dropped that project DB.

Real incident (2026-04-20, ism_node): `NODE_ENV=ism npx jest modules/appointments --silent` wiped 16 collections in 22 ms. No replica set / oplog / dump available, unrecoverable.

## Behaviour

| NODE_ENV | DB name | Outcome |
|----------|---------|---------|
| `test`   | `NodeTest`    | drop (unchanged) |
| `test`   | `Production`  | refuse + warn (belt-and-suspenders) |
| `ism`    | any           | refuse + warn |
| `undefined` | any        | refuse + warn |

## Test plan

- [x] `NODE_ENV=test npm run test:unit` — 44 suites / 513 tests passing
- [x] `NODE_ENV=ism node -e "..."` — logs refusal, no drop
- [x] `npm run lint` — clean
- [x] New unit test file `scripts/tests/jest.globalSetup.unit.tests.js` — 5 tests passing

Closes #3476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Jest configuration to include test files from additional directory paths.
  * Added comprehensive test coverage for database cleanup safety validation.

* **Bug Fixes**
  * Implemented safety checks to prevent accidental database cleanup when running outside test environments or with non-test database names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->