### PR TITLE
fix(auth): handle GET OAuth callback with undefined req.body on Express 5

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -342,7 +342,7 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
 const oauthCallback = async (req, res, next) => {
   const strategy = req.params.strategy;
   // app Auth with Strategy managed on client side
-  if (req.body.strategy === false && req.body.key) {
+  if (req.body?.strategy === false && req.body?.key) {
     const allowedKeys = ['id', 'sub', 'email'];
     if (!allowedKeys.includes(req.body.key)) {
       return responses.error(res, 422, 'Unprocessable Entity', 'Invalid provider key')();

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -626,6 +626,25 @@ describe('Auth integration tests:', () => {
       authenticateSpy.mockRestore();
     });
 
+    test('should handle GET callback when req.body is undefined (Express 5)', async () => {
+      const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
+        (strategy, callback) => () => callback(null, { id: 'mock-get-cb-user' }),
+      );
+      const cookies = {};
+      const redirectCalls = [];
+      const mockReq = { params: { strategy: 'google' } };
+      const mockRes = {
+        cookie(name, val, opts) { cookies[name] = { val, opts }; return this; },
+        redirect(code, url) { redirectCalls.push({ code, url }); },
+      };
+
+      await AuthController.oauthCallback(mockReq, mockRes, () => {});
+
+      expect(cookies.TOKEN).toBeDefined();
+      expect(redirectCalls[0]).toMatchObject({ code: 302 });
+      authenticateSpy.mockRestore();
+    });
+
     test('should find an existing OAuth user via checkOAuthUserProfile', async () => {
       // Create an OAuth user directly first
       const createdUser = await UserService.create({


### PR DESCRIPTION
## Summary

- Optional-chain `req.body` access in `oauthCallback` — Express 5 leaves `req.body` undefined on GET callbacks, crashing the classic web OAuth flow before reaching `passport.authenticate()`.
- Add integration test simulating an Express 5 GET callback (no `body` field on request).

Closes #3492

## Context

Discovered while enabling Google OAuth on trawl (`api.trawl.me`). First real signin attempt returned:

```
{"message":"Cannot read properties of undefined (reading 'strategy')"}
```

Root cause: Express 5 no longer initializes `req.body` to `{}` when no body-parser middleware applies to the request. The existing unit test at `auth.integration.tests.js:613` passed `body: {}` explicitly, hiding the bug.

Apple OAuth is unaffected (uses POST `form_post` → body populated by `express.urlencoded`).

## Test plan

- [x] `npm run test:integration` — 260/260 green
- [ ] Post-merge: propagate to downstream projects via `/update-all-projects`, re-test Google signin end-to-end on trawl.me

## Related follow-ups (separate PRs)

- #3493 — OAuth account linking for existing verified-email local users
- #3494 — OAuth-created users should have `emailVerified: true`
- #3495 — OAuth error logging + safe error serialization in redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth callback handler to prevent crashes when processing certain request types, improving authentication reliability.

* **Tests**
  * Added integration tests for OAuth callback handling to ensure robustness across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->