### PR TITLE
fix(auth): log OAuth callback errors and drop useless error={} redirect

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -441,11 +441,19 @@ const oauthCallback = async (req, res, next) => {
   passport.authenticate(strategy, (err, user) => {
     const url = getBaseUrl();
     if (err) {
-      const _err = JSON.stringify(err);
+      logger.error(
+        { err: { message: err?.message, code: err?.code, stack: err?.stack }, strategy },
+        'OAuth callback failed',
+      );
+      const _err = encodeURIComponent(err?.message || err?.code || 'oauth_error');
       const path = 'token?message=Unprocessable%20Entity';
       res.redirect(302, `${url}/${path}&error=${_err}`);
     } else if (!user) {
-      const _err = JSON.stringify(err);
+      logger.error(
+        { err: { message: err?.message, code: err?.code, stack: err?.stack }, strategy },
+        'OAuth callback failed',
+      );
+      const _err = encodeURIComponent(err?.message || err?.code || 'oauth_no_user');
       const path = 'token?message=Could%20not%20define%20user%20in%20oAuth';
       res.redirect(302, `${url}/${path}&error=${_err}`);
     } else {

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -10,6 +10,7 @@ import passport from 'passport';
 import { bootstrap } from '../../../lib/app.js';
 import mongooseService from '../../../lib/services/mongoose.js';
 import config from '../../../config/index.js';
+import logger from '../../../lib/services/logger.js';
 
 /**
  * Unit tests
@@ -642,6 +643,78 @@ describe('Auth integration tests:', () => {
 
       expect(cookies.TOKEN).toBeDefined();
       expect(redirectCalls[0]).toMatchObject({ code: 302 });
+      authenticateSpy.mockRestore();
+    });
+
+    test('should log and redirect with message when classic web oAuth errors out', async () => {
+      const oauthErr = new Error('token exchange failed');
+      oauthErr.code = 'OAUTH_TOKEN_EXCHANGE';
+      const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
+        (strategy, callback) => () => callback(oauthErr, null),
+      );
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+      const redirectCalls = [];
+      const mockReq = { params: { strategy: 'google' }, body: {} };
+      const mockRes = {
+        cookie() { return this; },
+        redirect(code, url) { redirectCalls.push({ code, url }); },
+      };
+
+      await AuthController.oauthCallback(mockReq, mockRes, () => {});
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({
+            message: 'token exchange failed',
+            code: 'OAUTH_TOKEN_EXCHANGE',
+            stack: expect.any(String),
+          }),
+          strategy: 'google',
+        }),
+        'OAuth callback failed',
+      );
+      expect(redirectCalls[0].code).toBe(302);
+      // Redirect must carry the actual error message, not an empty object
+      expect(redirectCalls[0].url).toContain('error=');
+      expect(redirectCalls[0].url).not.toContain('error={}');
+      expect(redirectCalls[0].url).toContain(encodeURIComponent('token exchange failed'));
+
+      loggerSpy.mockRestore();
+      authenticateSpy.mockRestore();
+    });
+
+    test('should log and redirect with sensible message when no user is returned by passport', async () => {
+      const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
+        (strategy, callback) => () => callback(null, null),
+      );
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+      const redirectCalls = [];
+      const mockReq = { params: { strategy: 'google' }, body: {} };
+      const mockRes = {
+        cookie() { return this; },
+        redirect(code, url) { redirectCalls.push({ code, url }); },
+      };
+
+      await AuthController.oauthCallback(mockReq, mockRes, () => {});
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({
+            message: undefined,
+            code: undefined,
+            stack: undefined,
+          }),
+          strategy: 'google',
+        }),
+        'OAuth callback failed',
+      );
+      expect(redirectCalls[0].code).toBe(302);
+      expect(redirectCalls[0].url).toContain('error=');
+      expect(redirectCalls[0].url).not.toContain('error={}');
+      expect(redirectCalls[0].url).toContain('oauth_no_user');
+      expect(redirectCalls[0].url).toContain('Could%20not%20define%20user%20in%20oAuth');
+
+      loggerSpy.mockRestore();
       authenticateSpy.mockRestore();
     });
 


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify(err)` in `oauthCallback` (both `err` and `!user` branches) with `encodeURIComponent(err?.message || err?.code || 'oauth_error'|'oauth_no_user')` so the redirect query carries something meaningful instead of `error={}`.
- Emit a structured `logger.error({ err: { message, code, stack }, strategy }, 'OAuth callback failed')` on both failing branches so Sentry / PostHog / any log sink actually see OAuth failures (today only morgan logs a 302).
- Keep the redirect path, status, and success branch unchanged — Vue still reads `error` as a query param.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:integration -- --testPathPatterns='auth.integration'` (269 passed)
- New tests assert:
  - error branch: `logger.error` called with `{ err: { message, code, stack }, strategy }`, redirect is 302, `error=` contains the URL-encoded error message, never `{}`
  - no-user branch: `logger.error` called, redirect is 302, `error=oauth_no_user` in URL

Closes #3495