### PR TITLE
fix(auth): gate OAuth user creation behind config.sign.up (#3503)

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -373,7 +373,9 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
   // 4. No match → create new user
   try {
     if (!config.sign.up) {
-      throw new AppError('oAuth signup disabled', {
+      // Mirror the local signup endpoint's error shape so clients see the same
+      // `message`/`description` regardless of signup method (see `signup` above).
+      throw new AppError('Signup error', {
         code: 'VALIDATION_ERROR',
         details: { message: 'Registration is currently deactivated' },
       });

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -372,6 +372,12 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
   }
   // 4. No match → create new user
   try {
+    if (!config.sign.up) {
+      throw new AppError('oAuth signup disabled', {
+        code: 'VALIDATION_ERROR',
+        details: { message: 'Registration is currently deactivated' },
+      });
+    }
     const user = {
       firstName: profil.firstName,
       lastName: profil.lastName,

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -820,8 +820,14 @@ describe('Auth integration tests:', () => {
     });
 
     describe('signup gate (config.sign.up = false)', () => {
+      let originalSignUpConfig;
+
+      beforeEach(() => {
+        originalSignUpConfig = config.sign.up;
+      });
+
       afterEach(() => {
-        config.sign.up = true;
+        config.sign.up = originalSignUpConfig;
       });
 
       test('should reject new OAuth user creation when signup is disabled (branch 4)', async () => {

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -819,6 +819,121 @@ describe('Auth integration tests:', () => {
       ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
     });
 
+    describe('signup gate (config.sign.up = false)', () => {
+      afterEach(() => {
+        config.sign.up = true;
+      });
+
+      test('should reject new OAuth user creation when signup is disabled (branch 4)', async () => {
+        config.sign.up = false;
+        const email = 'oauth-signup-gate-new@test.com';
+        const profil = {
+          firstName: 'Gated',
+          lastName: 'Signup',
+          email,
+          avatar: '',
+          providerData: { sub: 'google-gated-sub-3503' },
+          emailVerifiedByProvider: false,
+        };
+        await expect(
+          AuthController.checkOAuthUserProfile(profil, 'sub', 'google'),
+        ).rejects.toMatchObject({
+          code: 'VALIDATION_ERROR',
+          details: { message: 'Registration is currently deactivated' },
+        });
+        // Ensure no user was persisted
+        const users = await UserService.search({ email });
+        expect(users.length).toBe(0);
+      });
+
+      test('should allow existing OAuth-first user to sign in when signup disabled (branch 1)', async () => {
+        const email = 'oauth-signup-gate-b1@test.com';
+        const existing = await UserService.create({
+          firstName: 'Branch',
+          lastName: 'One',
+          email,
+          provider: 'google',
+          providerData: { sub: 'google-gated-b1-sub' },
+          roles: ['user'],
+        });
+        config.sign.up = false;
+        const profil = {
+          firstName: 'Branch',
+          lastName: 'One',
+          email,
+          avatar: '',
+          providerData: { sub: 'google-gated-b1-sub' },
+        };
+        const found = await AuthController.checkOAuthUserProfile(profil, 'sub', 'google');
+        expect(found).toBeDefined();
+        expect(found.id).toBe(existing.id);
+
+        try { await UserService.remove(existing); } catch (_) { /* cleanup */ }
+      });
+
+      test('should allow linked OAuth user to sign in when signup disabled (branch 2)', async () => {
+        const email = 'oauth-signup-gate-b2@test.com';
+        const localUser = await UserService.create({
+          firstName: 'Branch',
+          lastName: 'Two',
+          email,
+          password: 'W@os.jsI$Aw3$0m3',
+          provider: 'local',
+          roles: ['user'],
+        });
+        // Inject additionalProvidersData to simulate a pre-linked account
+        const brutLocal = await UserService.getBrut({ email });
+        await UserService.update(brutLocal, {
+          additionalProvidersData: {
+            google: { sub: 'google-gated-b2-sub', email_verified: true },
+          },
+        }, 'recover');
+
+        config.sign.up = false;
+        const profil = {
+          firstName: 'Branch',
+          lastName: 'Two',
+          email,
+          avatar: '',
+          providerData: { sub: 'google-gated-b2-sub' },
+        };
+        const found = await AuthController.checkOAuthUserProfile(profil, 'sub', 'google');
+        expect(found).toBeDefined();
+        expect(found.id).toBe(localUser.id);
+
+        try { await UserService.remove(localUser); } catch (_) { /* cleanup */ }
+      });
+
+      test('should link local user via verified email when signup disabled (branch 3)', async () => {
+        const email = 'oauth-signup-gate-b3@test.com';
+        const localUser = await UserService.create({
+          firstName: 'Branch',
+          lastName: 'Three',
+          email,
+          password: 'W@os.jsI$Aw3$0m3',
+          provider: 'local',
+          roles: ['user'],
+        });
+
+        config.sign.up = false;
+        const profil = {
+          firstName: 'Branch',
+          lastName: 'Three',
+          email,
+          avatar: '',
+          providerData: { sub: 'google-gated-b3-sub', email_verified: true },
+          emailVerifiedByProvider: true,
+        };
+        const linked = await AuthController.checkOAuthUserProfile(profil, 'sub', 'google');
+        expect(linked).toBeDefined();
+        expect(linked.id).toBe(localUser.id);
+        const brutLinked = await UserService.getBrut({ id: linked.id });
+        expect(brutLinked.additionalProvidersData?.google?.sub).toBe('google-gated-b3-sub');
+
+        try { await UserService.remove(linked); } catch (_) { /* cleanup */ }
+      });
+    });
+
     test('token endpoint should strip accessToken/refreshToken from additionalProvidersData', async () => {
       // Create a local user then sign in to get an auth cookie
       const localEmail = 'token-sanitize@test.com';


### PR DESCRIPTION
## Summary

- Extend the existing `config.sign.up` signup freeze to OAuth flows. Today, when local signup is disabled, the classic `/api/auth/signup` endpoint returns a 404 "Registration is currently deactivated" — but any stranger could still create a Devkit account by signing in via Google / Apple OAuth, because `checkOAuthUserProfile` branch 4 (no match → create) had no gate.
- The gate is applied at the top of branch 4 only. Branches 1-3 (primary lookup, linked identity, link-on-verified-email) remain open, so existing users keep being able to sign in even during a signup freeze. The freeze applies strictly to fresh account creation via OAuth.
- Thrown as `VALIDATION_ERROR` with the same user-facing message as the local signup endpoint (`Registration is currently deactivated`), which `oauthCallback` maps to 422 for the client.

## Test plan

- [x] `npm run test:integration -- --testPathPatterns='auth.integration'` — 271/271 green
- [x] `npm run lint` — clean
- [x] New test: `config.sign.up = false` + no match → VALIDATION_ERROR, asserts no user persisted via `UserService.search`
- [x] New test: `config.sign.up = false` + existing OAuth-first user (branch 1) → returns existing user, no freeze
- [x] New test: `config.sign.up = false` + linked local user via `additionalProvidersData` (branch 2) → returns linked user, no freeze
- [x] New test: `config.sign.up = false` + local user with verified email (branch 3) → returns linked user, no freeze
- [x] `afterEach` resets `config.sign.up = true` to avoid leaking state to sibling tests

Closes #3503