### PR TITLE
fix(auth): require verified local account for OAuth email link (#3504)

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -371,8 +371,10 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
     try {
       const linked = await UserService.linkProviderByEmail(profil.email, provider, profil.providerData);
       if (linked) return linked;
-      // No verified local match. Check whether an unverified local user exists
-      // for this email — if so, reject explicitly (do not silently annex).
+      // Link returned null → either no local user with this email, or the local
+      // user exists but is not emailVerified. Disambiguate so we can reject the
+      // squatter case explicitly instead of falling through to branch 4 (which
+      // would later fail on the unique-email index with a less actionable error).
       const existing = await UserService.findByEmail(profil.email);
       if (existing && !existing.emailVerified) {
         throw new AppError('oAuth, cannot link to unverified local account', {
@@ -382,6 +384,11 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
           },
         });
       }
+      // If `existing` is emailVerified here, a rare race between the atomic
+      // findOneAndUpdate and this findByEmail let verification complete in
+      // between. Falling through is safe: branch 4 will fail on the unique
+      // email index, the OAuth client will see the error, and a retry will
+      // hit the now-linkable state via branch 3.
     } catch (err) {
       if (err instanceof AppError) throw err;
       throw new AppError('oAuth, link to existing user failed', { code: 'SERVICE_ERROR', details: err });

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -358,15 +358,32 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
   } catch (err) {
     throw new AppError('oAuth, find linked user failed', { code: 'SERVICE_ERROR', details: err });
   }
-  // 3. Link on verified email: if a local user exists with the same email and the OAuth
-  //    provider vouches for it, attach providerData under additionalProvidersData.{provider}
-  //    without overwriting user.provider (keeps password reset + local login intact).
-  //    Atomic findOneAndUpdate avoids TOCTOU races between concurrent OAuth callbacks.
+  // 3. Link on verified email: if a local user exists with the same email AND is
+  //    already emailVerified locally AND the OAuth provider vouches for the email,
+  //    attach providerData under additionalProvidersData.{provider} without
+  //    overwriting user.provider (keeps password reset + local login intact).
+  //    Atomic findOneAndUpdate (filter includes emailVerified: true) avoids TOCTOU
+  //    races and prevents an unverified-squatter local account from being annexed
+  //    by a later OAuth signin (issue #3504). If a matching email exists but is
+  //    not locally verified, we reject with VALIDATION_ERROR rather than fall
+  //    through to branch 4 (which would later fail on the unique-email index).
   if (profil.email && profil.emailVerifiedByProvider) {
     try {
       const linked = await UserService.linkProviderByEmail(profil.email, provider, profil.providerData);
       if (linked) return linked;
+      // No verified local match. Check whether an unverified local user exists
+      // for this email — if so, reject explicitly (do not silently annex).
+      const existing = await UserService.findByEmail(profil.email);
+      if (existing && !existing.emailVerified) {
+        throw new AppError('oAuth, cannot link to unverified local account', {
+          code: 'VALIDATION_ERROR',
+          details: {
+            message: 'A pending account with this email is not verified. Verify the original signup first or contact support.',
+          },
+        });
+      }
     } catch (err) {
+      if (err instanceof AppError) throw err;
       throw new AppError('oAuth, link to existing user failed', { code: 'SERVICE_ERROR', details: err });
     }
   }

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1043,6 +1043,10 @@ describe('Auth integration tests:', () => {
           provider: 'local',
           roles: ['user'],
         });
+        // Mark the local account as email-verified — branch 3 link-gate now
+        // requires both OAuth provider AND local emailVerified (issue #3504).
+        const brutSeed = await UserService.getBrut({ email });
+        await UserService.update(brutSeed, { emailVerified: true }, 'recover');
 
         config.sign.up = false;
         const profil = {

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -746,8 +746,9 @@ describe('Auth integration tests:', () => {
       } catch (_) { /* cleanup – ignore errors */ }
     });
 
-    test('should link OAuth signin to existing local user when provider verifies email', async () => {
-      // Seed a local user with a password (provider=local), email not yet linked via OAuth
+    test('should link OAuth signin to existing local user when both local emailVerified and provider verify', async () => {
+      // Seed a local user with a password (provider=local) that has ALREADY verified its email
+      // — the branch-3 link-on-verified-email gate requires both sides to vouch (issue #3504).
       const localEmail = 'oauthlink-local@test.com';
       const localUser = await UserService.create({
         firstName: 'Local',
@@ -757,6 +758,9 @@ describe('Auth integration tests:', () => {
         provider: 'local',
         roles: ['user'],
       });
+      // Mark the local account as email-verified (done normally by the verification flow).
+      const brutLocal = await UserService.getBrut({ email: localEmail });
+      await UserService.update(brutLocal, { emailVerified: true }, 'recover');
 
       // OAuth signin arrives with matching email + provider-verified flag
       const profil = {
@@ -782,6 +786,52 @@ describe('Auth integration tests:', () => {
       expect(second.id).toBe(localUser.id);
 
       try { await UserService.remove(linked); } catch (_) { /* cleanup */ }
+    });
+
+    test('should reject link when local account is NOT emailVerified even if OAuth provider verified (#3504)', async () => {
+      // Squatter scenario (issue #3504): someone signed up locally with victim's email
+      // but never verified it. A later OAuth signin by the real owner must NOT silently
+      // annex the unverified local account.
+      const squatterEmail = 'oauthlink-squatter@test.com';
+      const localUser = await UserService.create({
+        firstName: 'Squatter',
+        lastName: 'Pending',
+        email: squatterEmail,
+        password: credentials[0].password,
+        provider: 'local',
+        roles: ['user'],
+      });
+      // Sanity: freshly created local user is not emailVerified by default.
+      const brutBefore = await UserService.getBrut({ email: squatterEmail });
+      expect(brutBefore.emailVerified).toBe(false);
+      expect(brutBefore.additionalProvidersData?.google).toBeUndefined();
+      expect(brutBefore.providerData == null).toBe(true);
+
+      const profil = {
+        firstName: 'Real',
+        lastName: 'Owner',
+        email: squatterEmail,
+        avatar: '',
+        providerData: { sub: 'google-owner-sub-3504', email_verified: true },
+        emailVerifiedByProvider: true,
+      };
+
+      await expect(
+        AuthController.checkOAuthUserProfile(profil, 'sub', 'google'),
+      ).rejects.toMatchObject({
+        code: 'VALIDATION_ERROR',
+        message: 'oAuth, cannot link to unverified local account',
+      });
+
+      // The unverified local account must be untouched — no silent annexation.
+      const users = await UserService.search({ email: squatterEmail });
+      expect(users.length).toBe(1);
+      const brutAfter = await UserService.getBrut({ email: squatterEmail });
+      expect(brutAfter.emailVerified).toBe(false);
+      expect(brutAfter.additionalProvidersData?.google).toBeUndefined();
+      expect(brutAfter.providerData == null).toBe(true);
+
+      try { await UserService.remove(localUser); } catch (_) { /* cleanup */ }
     });
 
     test('should NOT link when OAuth provider did not verify the email', async () => {

--- a/modules/users/repositories/users.repository.js
+++ b/modules/users/repositories/users.repository.js
@@ -194,15 +194,20 @@ const updateMany = (filter, data) => User.updateMany(filter, data, { runValidato
 /**
  * @desc Atomically attach an OAuth provider to an existing user matched by email.
  * Uses findOneAndUpdate to avoid TOCTOU races between concurrent OAuth callbacks.
+ * Filter requires `emailVerified: true` so an unverified-squatter local signup
+ * cannot be silently annexed by a later OAuth signin (issue #3504).
  * @param {string} email - The email to match
  * @param {string} provider - The OAuth provider key (e.g. 'google', 'apple')
  * @param {Object} providerData - The provider's identity data to store
- * @returns {Promise<Object|null>} Updated user document or null if no match
+ * @returns {Promise<Object|null>} Updated user document, or null when no match
+ *   OR when a match exists but is not email-verified — the caller is expected
+ *   to follow up with findByEmail to distinguish the two cases if it needs to
+ *   return a specific error.
  */
 const linkProviderByEmail = (email, provider, providerData) =>
   User.findOneAndUpdate(
-    { email },
-    { $set: { [`additionalProvidersData.${provider}`]: providerData, emailVerified: true } },
+    { email, emailVerified: true },
+    { $set: { [`additionalProvidersData.${provider}`]: providerData } },
     { returnDocument: 'after', runValidators: true },
   ).exec();
 


### PR DESCRIPTION
## Summary

An unverified local signup squatting a victim's email could be silently annexed by a later OAuth signin (Google/Apple), because the link-by-email branch of `checkOAuthUserProfile` only checked `profil.emailVerifiedByProvider`. The pre-existing local account's own `emailVerified` flag was ignored, so the OAuth signin inherited the unverified account, its password, and any state attached.

Tightens the gate so the atomic link fires **only when both sides vouch for the email**: OAuth provider verified AND local account `emailVerified: true`. If the local account exists but is unverified, reject with a clear `VALIDATION_ERROR` instead of falling through to account creation (which would later throw on the unique-email index with a less actionable error).

## Changes

- **`UserRepository.linkProviderByEmail`** — filter now includes `emailVerified: true` (atomic gate). Dropped the redundant `$set: { emailVerified: true }` since the filter already guarantees it.
- **`AuthController.checkOAuthUserProfile` (branch 3)** — after a null link, follow up with `findByEmail` to detect the unverified-squatter case and throw `AppError('oAuth, cannot link to unverified local account', { code: 'VALIDATION_ERROR', ... })` with an actionable message.
- **Integration tests** — the existing "link succeeds" case now explicitly marks the local account verified before the OAuth signin; new squatter-rejection test asserts the local doc is unchanged (no `additionalProvidersData`, `emailVerified` still false, `providerData` still null).

## Scope

- Branches 1 (primary identity) and 2 (already-linked local) are untouched — they are key-based lookups and independent of `emailVerified`.
- The existing `emailVerifiedByProvider` guard is preserved; the new check is additive.

## Test plan

- [x] `npm run test:integration -- modules/auth/tests/auth.integration.tests.js` → 60/60 pass (incl. new squatter test)
- [x] `npm run test:unit` → 544/544 pass
- [x] `npm run lint` → clean

Closes #3504