### PR TITLE
fix(auth): canonical responses.error envelope on OAuth redirect

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -23,11 +23,15 @@ Redirect URL is `${getBaseUrl()}/token?message=<title>&error=<json>` where `<jso
 {
   "type": "error",
   "message": "<err.message || fallbackTitle>",
+  "code": 422,
+  "status": 422,
   "errorCode": "<err.code || 'OAUTH_ERROR'>",
   "description": "<err.details.message || ''>",
   "details": { "message": "<err.details.message || title>" }
 }
 ```
+
+`code` and `status` are fixed at `422` (Unprocessable Entity) — OAuth callback failures surface via 302 redirect (not a JSON 4xx) so there is no live HTTP status; `422` matches the canonical shape of Zod / AppError validation failures elsewhere in the API.
 
 ### Why `details.message` is still shipped
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,52 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## Auth OAuth redirect: canonical `responses.error` envelope on failure (2026-04-24)
+
+The `GET /api/auth/oauth/:strategy/callback` redirect now carries a JSON-encoded error payload mirroring the canonical `lib/helpers/responses.js` shape, so the Vue client can surface OAuth failures with the same parser it uses for every other API error.
+
+### What changed
+
+- New private helper `oauthErrorRedirect(res, err, fallbackTitle)` in `modules/auth/controllers/auth.controller.js` — builds the redirect URL and stamps a canonical error envelope into the `error` query param (`URLSearchParams` ensures proper encoding).
+- Both failure branches of `oauthCallback` (passport error, `!user`) now delegate to the helper instead of hand-rolling query strings with hardcoded titles.
+- The `message` query now reflects the real `AppError.message` (e.g. `Signup error`) instead of the hardcoded `Unprocessable Entity` / `Could not define user in oAuth`.
+- `logger.error(...)` calls are preserved — observability unchanged.
+
+### Contract
+
+Redirect URL is `${getBaseUrl()}/token?message=<title>&error=<json>` where `<json>` is a stringified envelope:
+
+```json
+{
+  "type": "error",
+  "message": "<err.message || fallbackTitle>",
+  "errorCode": "<err.code || 'OAUTH_ERROR'>",
+  "description": "<err.details.message || ''>",
+  "details": { "message": "<err.details.message || title>" }
+}
+```
+
+### Why `details.message` is still shipped
+
+Current downstream `token.view.vue` parsers read `error.details.message` rather than the canonical `error.description` / `error.message`. Shipping the canonical envelope AND the legacy `details.message` field lets Node deploy ahead of Vue without regressing the user-visible error toast during rollout.
+
+Once every downstream Vue deploy has adopted the canonical parser (tracked in Vue issue #4021), the `details` field will be removed from the payload. A follow-up Node PR will ship that cleanup.
+
+### Non-breaking
+
+- Successful OAuth redirect (`${baseUrl}/token` + `TOKEN` cookie) is unchanged.
+- The `message` query still exists — only its value changed (from hardcoded constants to the actual error title).
+- The `error` query used to be a URL-encoded plain string; it is now URL-encoded JSON. Downstream clients that tried `JSON.parse` on the old payload were already throwing — the fix aligns them with the canonical parser path.
+
+### Action for downstream
+
+1. `/update-stack` pulls the change.
+2. No env var changes.
+3. No Mongo migration.
+4. Vue consumers that currently read `error.details.message` keep working; new consumers should read `error.message` / `error.description` / `error.errorCode` per the canonical envelope.
+
+---
+
 ## Organizations: global admin bypass extended to updateRole + `isGlobalAdmin` helper (2026-04-24)
 
 Completes the platform-admin bypass started in #3509, and centralizes the repeated `Array.isArray(req.user?.roles) && req.user.roles.includes('admin')` check into a shared helper.

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -439,9 +439,14 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
 const oauthErrorRedirect = (res, err, fallbackTitle) => {
   const title = err?.message || fallbackTitle;
   const descriptionFromDetails = typeof err?.details?.message === 'string' ? err.details.message : '';
+  // OAuth callback failures are surfaced as a 302 redirect (not a JSON 422), so
+  // there is no live HTTP status — we embed 422 to match the canonical shape of
+  // a Zod / AppError validation failure elsewhere in the API.
   const payload = {
     type: 'error',
     message: title,
+    code: 422,
+    status: 422,
     errorCode: err?.code || 'OAUTH_ERROR',
     description: descriptionFromDetails,
     // Legacy shape — the current Vue `token.view.vue` parser reads `details.message`.

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -449,11 +449,14 @@ const oauthErrorRedirect = (res, err, fallbackTitle) => {
     // `responses.error` parser (tracked in Vue issue #4021).
     details: { message: descriptionFromDetails || title },
   };
-  const qs = new URLSearchParams({
-    message: title,
-    error: JSON.stringify(payload),
-  });
-  res.redirect(302, `${getBaseUrl()}/token?${qs.toString()}`);
+  // Build the redirect URL via the `URL` constructor so the origin + path stay
+  // server-controlled (`getBaseUrl()` resolves from `config.cors.origin`). User
+  // input only flows into the query string, fully encoded by `URLSearchParams`,
+  // so this is not an open-redirect sink.
+  const target = new URL('/token', getBaseUrl());
+  target.searchParams.set('message', title);
+  target.searchParams.set('error', JSON.stringify(payload));
+  res.redirect(302, target.toString());
 };
 
 /**

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -426,6 +426,37 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
 };
 
 /**
+ * @desc Build a redirect URL carrying the canonical `responses.error` error envelope
+ * and push the browser to `/token?...`. The payload mirrors the shape returned by
+ * `lib/helpers/responses.js` so the Vue client can parse OAuth failures the same
+ * way as any other API error.
+ *
+ * @param {Object} res - Express response object
+ * @param {Object|null} err - AppError (or plain Error) raised by passport / strategy; may be null
+ * @param {string} fallbackTitle - Human-readable title used when `err?.message` is missing
+ * @returns {void} triggers a 302 redirect to `${baseUrl}/token?...`
+ */
+const oauthErrorRedirect = (res, err, fallbackTitle) => {
+  const title = err?.message || fallbackTitle;
+  const descriptionFromDetails = typeof err?.details?.message === 'string' ? err.details.message : '';
+  const payload = {
+    type: 'error',
+    message: title,
+    errorCode: err?.code || 'OAUTH_ERROR',
+    description: descriptionFromDetails,
+    // Legacy shape — the current Vue `token.view.vue` parser reads `details.message`.
+    // Remove this field once all downstream Vue deploys have adopted the canonical
+    // `responses.error` parser (tracked in Vue issue #4021).
+    details: { message: descriptionFromDetails || title },
+  };
+  const qs = new URLSearchParams({
+    message: title,
+    error: JSON.stringify(payload),
+  });
+  res.redirect(302, `${getBaseUrl()}/token?${qs.toString()}`);
+};
+
+/**
  * @desc Endpoint for oautCallCallBack
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
@@ -471,30 +502,25 @@ const oauthCallback = async (req, res, next) => {
   }
   // classic web oAuth
   passport.authenticate(strategy, (err, user) => {
-    const url = getBaseUrl();
     if (err) {
       logger.error(
         { err: { message: err?.message, code: err?.code, stack: err?.stack }, strategy },
         'OAuth callback failed',
       );
-      const _err = encodeURIComponent(err?.message || err?.code || 'oauth_error');
-      const path = 'token?message=Unprocessable%20Entity';
-      res.redirect(302, `${url}/${path}&error=${_err}`);
-    } else if (!user) {
+      return oauthErrorRedirect(res, err, 'oAuth error');
+    }
+    if (!user) {
       logger.error(
         { err: { message: err?.message, code: err?.code, stack: err?.stack }, strategy },
         'OAuth callback failed',
       );
-      const _err = encodeURIComponent(err?.message || err?.code || 'oauth_no_user');
-      const path = 'token?message=Could%20not%20define%20user%20in%20oAuth';
-      res.redirect(302, `${url}/${path}&error=${_err}`);
-    } else {
-      const token = jwt.sign({ userId: user.id }, config.jwt.secret, {
-        expiresIn: config.jwt.expiresIn,
-      });
-      res.cookie('TOKEN', token, tokenCookieOptions);
-      res.redirect(302, `${getBaseUrl()}/token`);
+      return oauthErrorRedirect(res, null, 'Could not define user in oAuth');
     }
+    const token = jwt.sign({ userId: user.id }, config.jwt.secret, {
+      expiresIn: config.jwt.expiresIn,
+    });
+    res.cookie('TOKEN', token, tokenCookieOptions);
+    return res.redirect(302, `${getBaseUrl()}/token`);
   })(req, res, next);
 };
 

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -684,6 +684,8 @@ describe('Auth integration tests:', () => {
       expect(parsed.searchParams.get('message')).toBe('token exchange failed');
       const payload = JSON.parse(parsed.searchParams.get('error'));
       expect(payload).toEqual({
+        code: 422,
+        status: 422,
         type: 'error',
         message: 'token exchange failed',
         errorCode: 'OAUTH_TOKEN_EXCHANGE',
@@ -720,6 +722,8 @@ describe('Auth integration tests:', () => {
       expect(parsed.searchParams.get('message')).toBe('Signup error');
       const payload = JSON.parse(parsed.searchParams.get('error'));
       expect(payload).toEqual({
+        code: 422,
+        status: 422,
         type: 'error',
         message: 'Signup error',
         errorCode: 'VALIDATION_ERROR',
@@ -788,6 +792,8 @@ describe('Auth integration tests:', () => {
       expect(parsed.searchParams.get('message')).toBe('Could not define user in oAuth');
       const payload = JSON.parse(parsed.searchParams.get('error'));
       expect(payload).toEqual({
+        code: 422,
+        status: 422,
         type: 'error',
         message: 'Could not define user in oAuth',
         errorCode: 'OAUTH_ERROR',

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -648,7 +648,7 @@ describe('Auth integration tests:', () => {
       authenticateSpy.mockRestore();
     });
 
-    test('should log and redirect with message when classic web oAuth errors out', async () => {
+    test('should log and redirect with canonical error envelope when classic web oAuth errors out', async () => {
       const oauthErr = new Error('token exchange failed');
       oauthErr.code = 'OAUTH_TOKEN_EXCHANGE';
       const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
@@ -676,16 +676,86 @@ describe('Auth integration tests:', () => {
         'OAuth callback failed',
       );
       expect(redirectCalls[0].code).toBe(302);
-      // Redirect must carry the actual error message, not an empty object
-      expect(redirectCalls[0].url).toContain('error=');
       expect(redirectCalls[0].url).not.toContain('error={}');
-      expect(redirectCalls[0].url).toContain(encodeURIComponent('token exchange failed'));
+
+      // Parse the redirect URL and assert the canonical `responses.error` envelope
+      const parsed = new URL(redirectCalls[0].url);
+      expect(parsed.pathname).toBe('/token');
+      expect(parsed.searchParams.get('message')).toBe('token exchange failed');
+      const payload = JSON.parse(parsed.searchParams.get('error'));
+      expect(payload).toEqual({
+        type: 'error',
+        message: 'token exchange failed',
+        errorCode: 'OAUTH_TOKEN_EXCHANGE',
+        description: '',
+        details: { message: 'token exchange failed' },
+      });
 
       loggerSpy.mockRestore();
       authenticateSpy.mockRestore();
     });
 
-    test('should log and redirect with sensible message when no user is returned by passport', async () => {
+    test('should redirect with canonical envelope preserving AppError details.message', async () => {
+      const AppError = (await import(path.resolve('./lib/helpers/AppError.js'))).default;
+      const oauthErr = new AppError('Signup error', {
+        code: 'VALIDATION_ERROR',
+        details: { message: 'Registration is currently deactivated' },
+      });
+      const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
+        (strategy, callback) => () => callback(oauthErr, null),
+      );
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+      const redirectCalls = [];
+      const mockReq = { params: { strategy: 'google' }, body: {} };
+      const mockRes = {
+        cookie() { return this; },
+        redirect(code, url) { redirectCalls.push({ code, url }); },
+      };
+
+      await AuthController.oauthCallback(mockReq, mockRes, () => {});
+
+      expect(redirectCalls[0].code).toBe(302);
+      const parsed = new URL(redirectCalls[0].url);
+      expect(parsed.pathname).toBe('/token');
+      expect(parsed.searchParams.get('message')).toBe('Signup error');
+      const payload = JSON.parse(parsed.searchParams.get('error'));
+      expect(payload).toEqual({
+        type: 'error',
+        message: 'Signup error',
+        errorCode: 'VALIDATION_ERROR',
+        description: 'Registration is currently deactivated',
+        details: { message: 'Registration is currently deactivated' },
+      });
+
+      loggerSpy.mockRestore();
+      authenticateSpy.mockRestore();
+    });
+
+    test('should fall back to OAUTH_ERROR code for plain Error without code', async () => {
+      const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
+        (strategy, callback) => () => callback(new Error('boom'), null),
+      );
+      const loggerSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+      const redirectCalls = [];
+      const mockReq = { params: { strategy: 'google' }, body: {} };
+      const mockRes = {
+        cookie() { return this; },
+        redirect(code, url) { redirectCalls.push({ code, url }); },
+      };
+
+      await AuthController.oauthCallback(mockReq, mockRes, () => {});
+
+      const parsed = new URL(redirectCalls[0].url);
+      const payload = JSON.parse(parsed.searchParams.get('error'));
+      expect(payload.errorCode).toBe('OAUTH_ERROR');
+      expect(payload.message).toBe('boom');
+      expect(payload.type).toBe('error');
+
+      loggerSpy.mockRestore();
+      authenticateSpy.mockRestore();
+    });
+
+    test('should log and redirect with canonical envelope when no user is returned by passport', async () => {
       const authenticateSpy = jest.spyOn(passport, 'authenticate').mockImplementationOnce(
         (strategy, callback) => () => callback(null, null),
       );
@@ -711,10 +781,19 @@ describe('Auth integration tests:', () => {
         'OAuth callback failed',
       );
       expect(redirectCalls[0].code).toBe(302);
-      expect(redirectCalls[0].url).toContain('error=');
       expect(redirectCalls[0].url).not.toContain('error={}');
-      expect(redirectCalls[0].url).toContain('oauth_no_user');
-      expect(redirectCalls[0].url).toContain('Could%20not%20define%20user%20in%20oAuth');
+
+      const parsed = new URL(redirectCalls[0].url);
+      expect(parsed.pathname).toBe('/token');
+      expect(parsed.searchParams.get('message')).toBe('Could not define user in oAuth');
+      const payload = JSON.parse(parsed.searchParams.get('error'));
+      expect(payload).toEqual({
+        type: 'error',
+        message: 'Could not define user in oAuth',
+        errorCode: 'OAUTH_ERROR',
+        description: '',
+        details: { message: 'Could not define user in oAuth' },
+      });
 
       loggerSpy.mockRestore();
       authenticateSpy.mockRestore();


### PR DESCRIPTION
## Summary

Fixes the OAuth callback redirect so failures now carry a canonical `responses.error`-shaped JSON payload in the `error` query param (instead of a plain string that crashed the Vue parser), and the `message` query reflects the real `AppError.message` instead of hardcoded titles.

- New private helper `oauthErrorRedirect(res, err, fallbackTitle)` in `modules/auth/controllers/auth.controller.js` builds the redirect with a canonical envelope (`type`, `message`, `errorCode`, `description`) via `URLSearchParams`.
- Both failure branches of `oauthCallback` (passport `err`, `!user`) delegate to the helper. `logger.error(...)` calls preserved.
- Ships a legacy `details.message` field alongside the canonical envelope so Node can deploy ahead of downstream Vue clients that still read the old shape (tracked in Vue issue #4021). Field will be removed once all deploys adopt the canonical parser.
- MIGRATIONS.md entry documents the new contract + the legacy field rollout plan.

Closes #3513

## Test plan

- [x] `npm run test:integration -- --testPathPatterns='auth.integration'` — 71/71 pass
- [x] `npm run test:integration` — 279/279 pass
- [x] `npm run test:unit` — 563/563 pass
- [x] `npm run lint` — clean
- [x] New integration tests cover: AppError with `details.message` → canonical envelope + legacy field, plain `Error` without `code` → falls back to `OAUTH_ERROR`, `!user` branch → well-formed JSON with fallback title