### PR TITLE
chore(test): per-pid Mongo DB default + globalTeardown to unblock parallel runs (#3515)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,40 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## Test DB isolation: per-pid Mongo database default + globalTeardown (2026-04-24)
+
+Default test database is now `mongodb://127.0.0.1:27017/NodeTest_${process.pid}` instead of the shared `NodeTest`. Concurrent jest invocations (e.g. multiple agent worktrees running `npm run test:coverage` in parallel) get isolated databases, eliminating the 401 / 404 / 422 / `MongoPoolClosedError` flake patterns documented in trawl_node#980.
+
+### What changed
+
+- `config/defaults/test.config.js` — `db.uri` is now computed at module load with `process.pid` suffix.
+- `scripts/jest.globalTeardown.js` — new file; drops the resolved per-pid DB after the suite finishes so local Mongo doesn't accumulate orphan `NodeTest_<pid>` databases. Reuses the same NODE_ENV + `/test/i` guards as `globalSetup`.
+- `jest.config.js` — registers the new `globalTeardown`.
+- New regression tests: `scripts/tests/jest.globalTeardown.unit.tests.js` and `scripts/tests/testConfig.perPid.unit.tests.js`.
+
+### Why `NodeTest_` (not just `Test_<pid>`)
+
+The `NodeTest_` prefix preserves the `/test/i` DB-name guard in `scripts/jest.globalSetup.js` (#3476) — the guard refuses to drop any DB whose name does not contain `test`. Keeping the literal substring keeps the belt-and-suspenders intact.
+
+### CI is unaffected
+
+CI workflows (`.github/workflows/CI.yml` and downstream copies) set `DEVKIT_NODE_db_uri` explicitly, which lands in Layer 4 of `config/index.js` and overrides this default. Per-pid never applies on CI runs.
+
+### Action for downstream
+
+1. `/update-stack` pulls the change.
+2. No env var changes required — your CI workflow's `DEVKIT_NODE_db_uri` keeps working.
+3. If a downstream README / docs / make target references the literal `NodeTest` DB name (e.g. a manual `mongo NodeTest --eval ...` command), update it to point at the new default or invoke `mongosh` against the resolved URI from `config.db.uri`.
+4. No Mongo data migration — test DBs are dropped on every run by design.
+
+### Non-breaking
+
+- CI is unchanged (env var override wins, see above).
+- All test scripts (`npm run test`, `test:integration`, `test:coverage`, etc.) keep working with no flag changes.
+- `docker-compose.test.yml` still ships an explicit `DEVKIT_NODE_db_uri` override (`mongodb://mongo:27017/NodeTest`) so containerised runs stay deterministic.
+
+---
+
 ## Auth OAuth redirect: canonical `responses.error` envelope on failure (2026-04-24)
 
 The `GET /api/auth/oauth/:strategy/callback` redirect now carries a JSON-encoded error payload mirroring the canonical `lib/helpers/responses.js` shape, so the Vue client can surface OAuth failures with the same parser it uses for every other API error.

--- a/config/defaults/test.config.js
+++ b/config/defaults/test.config.js
@@ -1,3 +1,18 @@
+/**
+ * Test environment defaults.
+ *
+ * The default `db.uri` is suffixed with `process.pid` so concurrent jest
+ * invocations (e.g. multiple agent worktrees running `npm run test:coverage`
+ * in parallel) hit isolated databases. Without this isolation, each process'
+ * `globalSetup` `dropDatabase()` wipes the others' fixtures mid-run, producing
+ * the 401/404/422/MongoPoolClosedError flake patterns documented in
+ * https://github.com/pierreb-devkit/Node/issues/3515.
+ *
+ * The literal `NodeTest_` prefix preserves the `/test/i` DB-name guard in
+ * `scripts/jest.globalSetup.js` (#3476). CI workflows set
+ * `DEVKIT_NODE_db_uri` explicitly (`Layer 4` env override in `config/index.js`)
+ * so they keep their own per-run unique DB and never pick up this default.
+ */
 const config = {
   app: {
     title: 'Devkit Node - Test Environment',
@@ -6,7 +21,7 @@ const config = {
     port: 3000,
   },
   db: {
-    uri: 'mongodb://127.0.0.1:27017/NodeTest',
+    uri: `mongodb://127.0.0.1:27017/NodeTest_${process.pid}`,
     debug: false,
   },
   audit: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -84,7 +84,7 @@ export default {
   globalSetup: './scripts/jest.globalSetup.js',
 
   // A path to a module which exports an async function that is triggered once after all test suites
-  // globalTeardown: null,
+  globalTeardown: './scripts/jest.globalTeardown.js',
 
   // A set of global variables that need to be available in all test environments
   globals: {

--- a/scripts/jest.globalTeardown.js
+++ b/scripts/jest.globalTeardown.js
@@ -1,0 +1,51 @@
+/**
+ * Jest global teardown — drops the test database after the test suite finishes.
+ * Companion to `scripts/jest.globalSetup.js` (#3476) and the per-pid DB default
+ * introduced in #3515. Without teardown, every parallel jest run leaves an
+ * orphan `NodeTest_<pid>` database on the local mongod and they accumulate
+ * indefinitely.
+ *
+ * Safety guards mirror globalSetup:
+ *   1. Refuse to drop anything when `NODE_ENV !== 'test'`.
+ *   2. Refuse when the resolved DB name does not contain `test`
+ *      (case-insensitive).
+ *
+ * Failures are swallowed — an offline mongod after the suite ran (e.g. the
+ * developer killed it manually) must not fail the jest exit code.
+ */
+import mongoose from 'mongoose';
+
+/**
+ * Jest global teardown entry point — drops the test DB resolved from config.
+ * @returns {Promise<void>} Resolves once the guard check completes and, when
+ * guards pass and Mongo is reachable, once the database has been dropped and
+ * the connection closed. Never rejects.
+ */
+export default async () => {
+  if (process.env.NODE_ENV !== 'test') {
+    console.warn(
+      `[jest.globalTeardown] Refusing to drop DB: NODE_ENV is "${process.env.NODE_ENV}", expected "test". Skipping drop.`,
+    );
+    return;
+  }
+  try {
+    const config = (await import('../config/index.js')).default;
+    const dbName = new URL(config.db.uri).pathname.replace(/^\//, '');
+    if (!/test/i.test(dbName)) {
+      console.warn(
+        `[jest.globalTeardown] Refusing to drop "${dbName}": name does not match /test/i. Aborting.`,
+      );
+      return;
+    }
+    await mongoose.connect(config.db.uri);
+    try {
+      await mongoose.connection.dropDatabase();
+    } finally {
+      await mongoose.disconnect();
+    }
+  } catch (err) {
+    // MongoDB unreachable or drop failed — log so silent failures don't hide
+    // accumulating orphan DBs in CI logs, but never fail the suite exit code.
+    console.warn(`[jest.globalTeardown] Skipped drop: ${err && err.message ? err.message : err}`);
+  }
+};

--- a/scripts/tests/jest.globalTeardown.unit.tests.js
+++ b/scripts/tests/jest.globalTeardown.unit.tests.js
@@ -90,6 +90,10 @@ describe('scripts/jest.globalTeardown safety guards', () => {
 
     await expect(globalTeardown()).resolves.toBeUndefined();
     expect(dropDatabase).not.toHaveBeenCalled();
+    // Connect rejected → no live connection → disconnect must NOT be called
+    // (calling it would throw on Mongoose's disconnected state and pollute
+    // the warn log with a misleading second error).
+    expect(disconnect).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipped drop'));
   });
 

--- a/scripts/tests/jest.globalTeardown.unit.tests.js
+++ b/scripts/tests/jest.globalTeardown.unit.tests.js
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for jest globalTeardown safety guards (#3515).
+ *
+ * Mirrors the globalSetup contract: refuse to drop when NODE_ENV is not
+ * "test" or when the resolved DB name does not match /test/i, swallow
+ * connection errors, and always disconnect even when dropDatabase fails.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+const connect = jest.fn(async () => {});
+const dropDatabase = jest.fn(async () => {});
+const disconnect = jest.fn(async () => {});
+
+jest.unstable_mockModule('mongoose', () => ({
+  default: {
+    connect,
+    disconnect,
+    connection: { dropDatabase },
+  },
+}));
+
+describe('scripts/jest.globalTeardown safety guards', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy;
+
+  beforeEach(() => {
+    connect.mockClear();
+    dropDatabase.mockClear();
+    disconnect.mockClear();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    jest.resetModules();
+  });
+
+  test('refuses to drop when NODE_ENV is not "test"', async () => {
+    process.env.NODE_ENV = 'ism';
+    const { default: globalTeardown } = await import('../jest.globalTeardown.js');
+
+    await globalTeardown();
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NODE_ENV is "ism"'));
+  });
+
+  test('refuses to drop when resolved DB name does not contain "test"', async () => {
+    process.env.NODE_ENV = 'test';
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/ProductionDb' } },
+    }));
+    const { default: globalTeardown } = await import('../jest.globalTeardown.js');
+
+    await globalTeardown();
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Refusing to drop "ProductionDb"'));
+  });
+
+  test('drops the per-pid DB resolved from config (no hardcoded NodeTest)', async () => {
+    process.env.NODE_ENV = 'test';
+    const perPidUri = `mongodb://localhost:27017/NodeTest_${process.pid}`;
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: perPidUri } },
+    }));
+    const { default: globalTeardown } = await import('../jest.globalTeardown.js');
+
+    await globalTeardown();
+
+    // Critical: teardown must use the resolved URI, not a hardcoded string —
+    // otherwise per-pid orphan DBs would accumulate forever.
+    expect(connect).toHaveBeenCalledWith(perPidUri);
+    expect(dropDatabase).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test('swallows errors when MongoDB is unreachable (no failed exit code)', async () => {
+    process.env.NODE_ENV = 'test';
+    connect.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/NodeTest_999' } },
+    }));
+    const { default: globalTeardown } = await import('../jest.globalTeardown.js');
+
+    await expect(globalTeardown()).resolves.toBeUndefined();
+    expect(dropDatabase).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipped drop'));
+  });
+
+  test('disconnects even when dropDatabase() fails (no dangling connection)', async () => {
+    process.env.NODE_ENV = 'test';
+    dropDatabase.mockRejectedValueOnce(new Error('drop failed'));
+    jest.unstable_mockModule('../../config/index.js', () => ({
+      default: { db: { uri: 'mongodb://localhost:27017/NodeTest_42' } },
+    }));
+    const { default: globalTeardown } = await import('../jest.globalTeardown.js');
+
+    await expect(globalTeardown()).resolves.toBeUndefined();
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(dropDatabase).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/tests/testConfig.perPid.unit.tests.js
+++ b/scripts/tests/testConfig.perPid.unit.tests.js
@@ -1,0 +1,30 @@
+/**
+ * Regression test for `config/defaults/test.config.js` per-pid DB URI (#3515).
+ *
+ * Without isolation, parallel jest processes (multi-worktree agent batches)
+ * stomp on each other's fixtures via the shared `NodeTest` DB and
+ * `globalSetup.dropDatabase()`. The default URI must include
+ * `process.pid` so each invocation gets its own database.
+ *
+ * The literal `NodeTest_` prefix preserves the `/test/i` DB-name guard in
+ * `scripts/jest.globalSetup.js`. Both invariants are asserted here.
+ */
+import { describe, test, expect } from '@jest/globals';
+
+import testConfig from '../../config/defaults/test.config.js';
+
+describe('config/defaults/test.config.js per-pid DB URI', () => {
+  test('default db.uri includes process.pid (parallel-process isolation)', () => {
+    expect(testConfig.db.uri).toContain(String(process.pid));
+  });
+
+  test('default db.uri starts with NodeTest_ to preserve /test/i drop-guard', () => {
+    const dbName = new URL(testConfig.db.uri).pathname.replace(/^\//, '');
+    expect(dbName).toMatch(/^NodeTest_/);
+    expect(/test/i.test(dbName)).toBe(true);
+  });
+
+  test('default db.uri targets the local mongod (not a shared CI host)', () => {
+    expect(testConfig.db.uri).toMatch(/^mongodb:\/\/127\.0\.0\.1:27017\//);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3515.

Default test DB URI is now `mongodb://127.0.0.1:27017/NodeTest_${process.pid}` so concurrent jest invocations (multi-worktree agent batches running `npm run test:coverage` in parallel) hit isolated databases instead of stomping on a single shared `NodeTest` via `globalSetup.dropDatabase()`.

Eliminates the 4 flake patterns traced in trawl_node#980:
- 401 on authenticated API-key endpoints (`apikeys` collection wiped mid-run)
- 404 on fixture lookups (org/user docs wiped)
- 422 on validators (session cookie outlives downstream state)
- `MongoPoolClosedError` (peer process disconnects mid-query)

## Changes

- `config/defaults/test.config.js`: `db.uri` suffixed with `process.pid`. Literal `NodeTest_` prefix preserves the `/test/i` drop-guard from #3476.
- `scripts/jest.globalTeardown.js` *(new)*: drops the resolved per-pid DB after the suite finishes, mirroring `globalSetup`'s `NODE_ENV` + `/test/i` guards. Local Mongo no longer accumulates orphan `NodeTest_<pid>` databases. Connection errors are warned + swallowed so an offline mongod after-the-fact never fails the jest exit code.
- `jest.config.js`: registers the new `globalTeardown`.
- New regression tests:
  - `scripts/tests/jest.globalTeardown.unit.tests.js` — full guard parity with `globalSetup` + asserts the resolved URI is used (no hardcoded `NodeTest`).
  - `scripts/tests/testConfig.perPid.unit.tests.js` — asserts the default URI contains `process.pid`, starts with `NodeTest_`, and targets the local mongod.
- `MIGRATIONS.md`: downstream upgrade note.

## CI safety

CI workflows (`.github/workflows/CI.yml` and downstream copies) set `DEVKIT_NODE_db_uri` explicitly, which lands in Layer 4 of `config/index.js` and overrides this default. **Per-pid never applies on CI runs.** Verified by inspection of the env layering in `config/index.js`.

`docker-compose.test.yml` also keeps its explicit `DEVKIT_NODE_db_uri: mongodb://mongo:27017/NodeTest` override → unchanged.

## Backward compat

- Any tooling that hardcoded the literal `NodeTest` DB name in a manual mongo CLI command should switch to reading `config.db.uri`. Documented in MIGRATIONS.md so `/update-stack` propagation surfaces it.
- No env var changes required for downstream projects.
- No Mongo data migration — test DBs are dropped on every run by design.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run test:coverage` — 72 suites / 859 tests / coverage thresholds met
- [x] New unit tests cover globalTeardown guards + per-pid URI invariants
- [ ] CI green on PR
- [ ] Companion PR #3516 (parallel-process integration smoke) — depends on this PR

## Propagation

After merge, `/update-all-projects` propagates to: trawl_node, comes_node, montaine_node, pierreb_node, ism_node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added breaking-change migration note describing shift to isolated per-process test databases to prevent concurrent test runs from interfering with each other.

* **Tests**
  * Enabled automatic test database cleanup via global teardown hook.
  * Added unit test coverage for database isolation configuration and teardown safety guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->