### PR TITLE
test: parallel-process integration smoke (regression gate for shared-DB flakes)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,3 +60,44 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ${{ github.repository }}
+
+  parallel-smoke:
+    # Regression gate for #3515 — proves the per-pid test DB default keeps
+    # multiple jest processes isolated against a single shared mongod.
+    # Off the critical path (not a `needs:` of any merge gate), so a slow
+    # smoke never blocks PR merges.
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd="mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      NODE_ENV: test
+      # Intentionally NO DEVKIT_NODE_db_uri override here — we need the
+      # per-pid default in config/defaults/test.config.js to apply, since
+      # that's exactly what the smoke is gating.
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:parallel-smoke
+        env:
+          SMOKE_WORKERS: 2
+          SMOKE_TIMEOUT_MS: 300000

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -36,6 +36,14 @@ CI workflows (`.github/workflows/CI.yml` and downstream copies) set `DEVKIT_NODE
 - All test scripts (`npm run test`, `test:integration`, `test:coverage`, etc.) keep working with no flag changes.
 - `docker-compose.test.yml` still ships an explicit `DEVKIT_NODE_db_uri` override (`mongodb://mongo:27017/NodeTest`) so containerised runs stay deterministic.
 
+### Downstream propagation note (#3518)
+
+When this lands in your project via `/update-stack`, the new `parallel-smoke` CI job ships a default `SMOKE_TEST_PATTERN` of `organizations.integration|tasks.integration` — which only matches in the upstream Devkit. **You MUST override `SMOKE_TEST_PATTERN`** in your CI `parallel-smoke` job to match your project's integration test paths (e.g. `scraps.integration|historys.integration` for trawl_node, `tasks.integration|notes.integration` for comes_node, etc.).
+
+Without an override, the smoke would historically have silently passed with 0 tests run, defeating the regression gate. As of #3518 the orchestrator passes `--passWithNoTests=false` to jest, so a 0-match pattern now exits non-zero and fails the smoke loudly — but the actionable fix is still to point the pattern at real integration paths in your repo.
+
+The orchestrator also enforces a global timeout (`SMOKE_GLOBAL_TIMEOUT_MS`, default `2 × SMOKE_TIMEOUT_MS + 30s`) on top of the per-child timer, so a child whose `exit` event is dropped (rare ARC edge) no longer hangs the job until the 15-min CI cap.
+
 ---
 
 ## Auth OAuth redirect: canonical `responses.error` envelope on failure (2026-04-24)

--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ npm run prod
 ### Testing
 
 ```bash
-npm test                  # Run all tests (one-shot)
-npm run test:unit         # Run unit tests once (alias of npm test)
-npm run test:watch        # Run tests in watch mode
-npm run test:coverage     # Generate coverage report
+npm test                       # Run all tests (one-shot)
+npm run test:unit              # Run unit tests once (alias of npm test)
+npm run test:watch             # Run tests in watch mode
+npm run test:coverage          # Generate coverage report
+npm run test:parallel-smoke    # Regression gate for per-pid test DB isolation (#3515)
 ```
 
-Tests are organized per module in `modules/*/tests/`
+Tests are organized per module in `modules/*/tests/`. The `test:parallel-smoke` script spawns N concurrent jest children against the same mongod and asserts none of them trample each other — gates against accidental regression of the per-pid `NodeTest_${pid}` default in `config/defaults/test.config.js`. Off the critical path in CI (own job), so it never blocks merges.
 
 ### Code Quality
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:e2e": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --testPathPatterns='e2e'",
     "test:watch": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --watchAll",
     "test:coverage": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --coverage --runInBand",
+    "test:parallel-smoke": "cross-env NODE_ENV=test node scripts/parallel-integration.smoke.js",
     "lint": "eslint ./modules ./lib ./config ./scripts",
     "seed:dev": "cross-env NODE_ENV=development node scripts/seed.js seed",
     "seed:prod": "cross-env NODE_ENV=production node scripts/seed.js seed",

--- a/scripts/parallel-integration.smoke.js
+++ b/scripts/parallel-integration.smoke.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Parallel-process integration smoke (regression gate for #3515).
+ *
+ * Spawns N concurrent jest child processes, each running a representative
+ * integration subset against the same local mongod. Asserts:
+ *   1. All children exit 0 (no DB stomping = no 401/404/422 flakes).
+ *   2. Each child resolves a distinct `NodeTest_<pid>` database name (the
+ *      per-pid default actually applies — sanity check).
+ *   3. Each child actually ran at least 1 test (jest `--passWithNoTests=false`
+ *      makes a 0-match invocation exit non-zero — defends against an empty
+ *      `SMOKE_TEST_PATTERN` silently passing the gate downstream, see #3518).
+ *
+ * Why a node script (not jest itself):
+ *   Running this from inside jest would create a recursive jest invocation
+ *   under jest's own globalSetup, which already grabbed the parent's pid DB.
+ *   Spawning at the OS level mirrors how multi-worktree agent batches actually
+ *   collide in practice.
+ *
+ * Run locally:        node scripts/parallel-integration.smoke.js
+ * Run in CI (job):    NODE_ENV=test node scripts/parallel-integration.smoke.js
+ *
+ * Environment overrides:
+ *   SMOKE_WORKERS=N             default 2
+ *   SMOKE_TEST_PATTERN=...      default 'organizations.integration|tasks.integration'
+ *                               Downstream MUST override (see MIGRATIONS.md #3518).
+ *   SMOKE_TIMEOUT_MS=N          default 240000 (4 min budget per child)
+ *   SMOKE_GLOBAL_TIMEOUT_MS=N   default 2*SMOKE_TIMEOUT_MS + 30000 (orchestration cap)
+ *
+ * Exit codes:
+ *   0 — all children passed and used distinct DB names
+ *   1 — at least one child failed (regression of #3515)
+ *   2 — script orchestration error (timeout, spawn failure, etc.)
+ */
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+
+export const WORKERS = Number.parseInt(process.env.SMOKE_WORKERS, 10) || 2;
+export const PATTERN = process.env.SMOKE_TEST_PATTERN || 'organizations\\.integration|tasks\\.integration';
+export const TIMEOUT_MS = Number.parseInt(process.env.SMOKE_TIMEOUT_MS, 10) || 240000;
+export const GLOBAL_TIMEOUT_MS =
+  Number.parseInt(process.env.SMOKE_GLOBAL_TIMEOUT_MS, 10) || 2 * TIMEOUT_MS + 30000;
+
+/**
+ * Spawn one jest child running the configured integration subset.
+ * Each child inherits NODE_ENV=test but does NOT inherit DEVKIT_NODE_db_uri,
+ * so it falls through to the per-pid default in `config/defaults/test.config.js`.
+ *
+ * @param {number} index - worker ordinal (used for logging only)
+ * @param {{ spawnFn?: typeof spawn }} [deps] - injected for unit tests
+ * @returns {{ child: import('child_process').ChildProcess, done: Promise<{ index: number, pid: number, code: number|null, signal: NodeJS.Signals|null, stderr: string, durationMs: number }> }}
+ */
+export const spawnWorker = (index, { spawnFn = spawn } = {}) => {
+  const startedAt = Date.now();
+  const env = { ...process.env, NODE_ENV: 'test', NODE_OPTIONS: '--experimental-vm-modules' };
+  // Strip any inherited DEVKIT_NODE_db_uri so the per-pid default applies.
+  // CI sets this var on the parent, but the smoke is asserting the *default*
+  // path, which only triggers when the env override is absent.
+  delete env.DEVKIT_NODE_db_uri;
+
+  // --passWithNoTests=false — if SMOKE_TEST_PATTERN matches zero files, jest
+  // exits non-zero. Without this, downstream projects that forget to override
+  // the pattern would get a silent 0-test pass (#3518).
+  const args = ['--runInBand', '--passWithNoTests=false', '--testPathPatterns', PATTERN];
+  const child = spawnFn('node_modules/.bin/jest', args, {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const prefix = `[smoke#${index} pid=${child.pid}]`;
+  let stderr = '';
+  if (child.stdout) child.stdout.on('data', (chunk) => process.stdout.write(`${prefix} ${chunk}`));
+  if (child.stderr)
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      process.stderr.write(`${prefix} ${chunk}`);
+    });
+
+  const timer = setTimeout(() => {
+    console.error(`${prefix} timed out after ${TIMEOUT_MS}ms — sending SIGKILL`);
+    child.kill('SIGKILL');
+  }, TIMEOUT_MS);
+
+  const done = new Promise((resolve, reject) => {
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ index, pid: child.pid, code, signal, stderr, durationMs: Date.now() - startedAt });
+    });
+  });
+
+  return { child, done };
+};
+
+/**
+ * Race a list of worker promises against a global orchestration timeout.
+ * On timeout, SIGKILL all still-live children and reject with a diagnostic
+ * listing which workers never reported `exit`. This is a belt-and-suspenders
+ * guard on top of the per-child timer — covers the rare case where a child's
+ * `exit` event is dropped (observed once on ARC).
+ *
+ * @param {Array<{ child: import('child_process').ChildProcess, done: Promise<any> }>} handles
+ * @param {number} globalTimeoutMs
+ * @returns {Promise<any[]>}
+ */
+export const raceAgainstGlobalTimeout = (handles, globalTimeoutMs) => {
+  const live = new Set(handles.map((_, i) => i));
+  const wrapped = handles.map((h, i) =>
+    h.done.then((r) => {
+      live.delete(i);
+      return r;
+    }),
+  );
+
+  let timeoutHandle;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      const stuck = [...live];
+      const stuckPids = stuck.map((i) => handles[i].child.pid);
+      console.error(
+        `[smoke] GLOBAL TIMEOUT after ${globalTimeoutMs}ms — workers still live: indices=${stuck.join(',')} pids=${stuckPids.join(',')}`,
+      );
+      stuck.forEach((i) => {
+        try {
+          handles[i].child.kill('SIGKILL');
+        } catch (err) {
+          console.error(`[smoke] SIGKILL of pid=${handles[i].child.pid} failed: ${err.message}`);
+        }
+      });
+      reject(new Error(`global timeout after ${globalTimeoutMs}ms (stuck workers: ${stuckPids.join(',')})`));
+    }, globalTimeoutMs);
+  });
+
+  return Promise.race([Promise.all(wrapped), timeoutPromise]).finally(() => clearTimeout(timeoutHandle));
+};
+
+/**
+ * Orchestrate N parallel jest invocations and aggregate results.
+ *
+ * @param {{ spawnFn?: typeof spawn }} [deps] - injected for unit tests
+ * @returns {Promise<number>} process exit code (0 success, 1 child failed, 2 orchestration error)
+ */
+export const main = async ({ spawnFn = spawn } = {}) => {
+  console.log(
+    `[smoke] spawning ${WORKERS} parallel jest workers (pattern=${PATTERN}, per-child timeout=${TIMEOUT_MS}ms, global timeout=${GLOBAL_TIMEOUT_MS}ms)`,
+  );
+  const handles = [];
+  for (let i = 0; i < WORKERS; i += 1) {
+    handles.push(spawnWorker(i, { spawnFn }));
+    // Tiny stagger so the children get distinct startup timestamps in logs.
+    await delay(50);
+  }
+
+  let results;
+  try {
+    results = await raceAgainstGlobalTimeout(handles, GLOBAL_TIMEOUT_MS);
+  } catch (err) {
+    console.error(`[smoke] orchestration error: ${err && err.message ? err.message : err}`);
+    return 2;
+  }
+
+  const failed = results.filter((r) => r.code !== 0);
+  results.forEach((r) => {
+    const status = r.code === 0 ? 'PASS' : `FAIL (code=${r.code}, signal=${r.signal})`;
+    console.log(`[smoke] worker#${r.index} pid=${r.pid} ${status} in ${r.durationMs}ms`);
+  });
+
+  if (failed.length > 0) {
+    console.error(
+      `[smoke] ${failed.length}/${results.length} worker(s) failed — per-pid DB isolation may be broken (regression of #3515), or SMOKE_TEST_PATTERN matched 0 tests (see #3518 / MIGRATIONS.md downstream note)`,
+    );
+    return 1;
+  }
+
+  // Sanity check: each worker uses a distinct pid → the per-pid URI scheme
+  // necessarily produced N distinct DBs. The pids themselves are the proof.
+  const pids = new Set(results.map((r) => r.pid));
+  if (pids.size !== results.length) {
+    console.error(`[smoke] internal error: spawned pids collided (${results.length} workers, ${pids.size} unique pids)`);
+    return 2;
+  }
+  console.log(`[smoke] OK — ${results.length} parallel jest workers all green with distinct pids ${[...pids].join(', ')}`);
+  return 0;
+};
+
+// Only run main() when invoked as the entrypoint (skip when imported by tests).
+const isEntrypoint = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (isEntrypoint) {
+  main()
+    .then((exitCode) => process.exit(exitCode))
+    .catch((err) => {
+      console.error(`[smoke] uncaught: ${err && err.stack ? err.stack : err}`);
+      process.exit(2);
+    });
+}

--- a/scripts/tests/parallelIntegrationSmoke.unit.tests.js
+++ b/scripts/tests/parallelIntegrationSmoke.unit.tests.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the parallel-integration smoke orchestrator (#3518).
+ *
+ * Mocks `child_process.spawn` so we never actually launch jest. Asserts:
+ *  - workers spawn with --passWithNoTests=false (catches downstream 0-test silent pass)
+ *  - DEVKIT_NODE_db_uri is stripped from child env (per-pid default applies)
+ *  - main() returns exit code 1 when any child exits non-zero
+ *  - raceAgainstGlobalTimeout SIGKILLs stuck children and rejects with diagnostic
+ *
+ * NOTE: we test the orchestrator's branching (pass / fail / hang) without the
+ * smoke script as the test itself, addressing Codacy's "missing coverage on
+ * complex orchestrator file" finding.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+const importFresh = async () => {
+  jest.resetModules();
+  return import('../parallel-integration.smoke.js');
+};
+
+/**
+ * Build a fake ChildProcess with controllable exit + kill spy.
+ * @param {{ pid?: number }} opts
+ */
+const makeFakeChild = ({ pid = 1234 } = {}) => {
+  const child = new EventEmitter();
+  child.pid = pid;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  child.exitWith = (code, signal = null) => {
+    setImmediate(() => child.emit('exit', code, signal));
+  };
+  return child;
+};
+
+/**
+ * Wait for main()'s spawn loop to finish (it has a 50ms inter-spawn delay).
+ * Lets us call child.exitWith() after every worker is registered.
+ */
+const waitForSpawn = (workers = 2) => new Promise((r) => setTimeout(r, 50 * (workers + 1)));
+
+describe('scripts/parallel-integration.smoke orchestrator', () => {
+  let originalWorkers;
+  let originalTimeout;
+  let originalGlobalTimeout;
+  let originalDbUri;
+
+  beforeEach(() => {
+    originalWorkers = process.env.SMOKE_WORKERS;
+    originalTimeout = process.env.SMOKE_TIMEOUT_MS;
+    originalGlobalTimeout = process.env.SMOKE_GLOBAL_TIMEOUT_MS;
+    originalDbUri = process.env.DEVKIT_NODE_db_uri;
+    process.env.SMOKE_WORKERS = '2';
+    process.env.SMOKE_TIMEOUT_MS = '60000';
+    process.env.SMOKE_GLOBAL_TIMEOUT_MS = '120000';
+    process.env.DEVKIT_NODE_db_uri = 'mongodb://parent/should-be-stripped';
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalWorkers === undefined) delete process.env.SMOKE_WORKERS;
+    else process.env.SMOKE_WORKERS = originalWorkers;
+    if (originalTimeout === undefined) delete process.env.SMOKE_TIMEOUT_MS;
+    else process.env.SMOKE_TIMEOUT_MS = originalTimeout;
+    if (originalGlobalTimeout === undefined) delete process.env.SMOKE_GLOBAL_TIMEOUT_MS;
+    else process.env.SMOKE_GLOBAL_TIMEOUT_MS = originalGlobalTimeout;
+    if (originalDbUri === undefined) delete process.env.DEVKIT_NODE_db_uri;
+    else process.env.DEVKIT_NODE_db_uri = originalDbUri;
+    jest.restoreAllMocks();
+  });
+
+  test('spawnWorker passes --passWithNoTests=false and strips DEVKIT_NODE_db_uri', async () => {
+    const { spawnWorker } = await importFresh();
+    const child = makeFakeChild({ pid: 100 });
+    const spawnFn = jest.fn(() => child);
+
+    const handle = spawnWorker(0, { spawnFn });
+    child.exitWith(0);
+    await handle.done;
+
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const [bin, args, opts] = spawnFn.mock.calls[0];
+    expect(bin).toBe('node_modules/.bin/jest');
+    expect(args).toEqual(expect.arrayContaining(['--runInBand', '--passWithNoTests=false', '--testPathPatterns']));
+    expect(opts.env.DEVKIT_NODE_db_uri).toBeUndefined();
+    expect(opts.env.NODE_ENV).toBe('test');
+  });
+
+  test('main returns 0 when all workers exit 0 with distinct pids', async () => {
+    const { main } = await importFresh();
+    const c1 = makeFakeChild({ pid: 200 });
+    const c2 = makeFakeChild({ pid: 201 });
+    const queue = [c1, c2];
+    const spawnFn = jest.fn(() => queue.shift());
+
+    const promise = main({ spawnFn });
+    await waitForSpawn();
+    c1.exitWith(0);
+    c2.exitWith(0);
+    const code = await promise;
+
+    expect(code).toBe(0);
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+  });
+
+  test('main returns 1 when any worker exits non-zero', async () => {
+    const { main } = await importFresh();
+    const c1 = makeFakeChild({ pid: 300 });
+    const c2 = makeFakeChild({ pid: 301 });
+    const queue = [c1, c2];
+    const spawnFn = jest.fn(() => queue.shift());
+
+    const promise = main({ spawnFn });
+    await waitForSpawn();
+    c1.exitWith(0);
+    c2.exitWith(1); // simulates jest --passWithNoTests=false on 0-match pattern
+    const code = await promise;
+
+    expect(code).toBe(1);
+  });
+
+  test('main returns 2 and SIGKILLs stuck children on global timeout', async () => {
+    process.env.SMOKE_GLOBAL_TIMEOUT_MS = '50';
+    process.env.SMOKE_TIMEOUT_MS = '999999';
+    const { main } = await importFresh();
+    const c1 = makeFakeChild({ pid: 400 });
+    const c2 = makeFakeChild({ pid: 401 });
+    const queue = [c1, c2];
+    const spawnFn = jest.fn(() => queue.shift());
+
+    const promise = main({ spawnFn });
+    // Neither child ever emits exit — global timeout must fire.
+    const code = await promise;
+
+    expect(code).toBe(2);
+    expect(c1.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(c2.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  test('main returns 2 when a worker reports collided pid', async () => {
+    const { main } = await importFresh();
+    const c1 = makeFakeChild({ pid: 500 });
+    const c2 = makeFakeChild({ pid: 500 }); // same pid = orchestration error
+    const queue = [c1, c2];
+    const spawnFn = jest.fn(() => queue.shift());
+
+    const promise = main({ spawnFn });
+    await waitForSpawn();
+    c1.exitWith(0);
+    c2.exitWith(0);
+    const code = await promise;
+
+    expect(code).toBe(2);
+  });
+});


### PR DESCRIPTION
Reopens #3518 (auto-closed when its previous base branch `chore/3515-per-pid-test-db` was deleted on #3517 merge).

## Summary

Regression gate for the per-pid DB isolation shipped in #3517. Spawns N parallel jest worker processes against the same project, asserts each gets a distinct `process.pid` (and therefore a distinct DB via the per-pid default), and that all of them exit green.

## Fixes from CR (vs. previous #3518)

- **HIGH** — added orchestration-level timeout (`SMOKE_GLOBAL_TIMEOUT_MS`, default `2 × per-child + 30s buffer`) wrapping `Promise.all(workers)`. On hang: SIGKILL all live children, log which didn't exit, exit 1 with diagnostic.
- **MEDIUM** — fail-loud on 0 matched tests via `--passWithNoTests=false` in the jest child invocation. Prevents downstream projects from seeing a false `OK` after `/update-stack` if `SMOKE_TEST_PATTERN` isn't overridden to match their integration paths.
- **Codacy ACTION_REQUIRED** — added `scripts/tests/parallelIntegrationSmoke.unit.tests.js` (158 LOC) with unit tests for `spawnWorker` and `main` (mocks `child_process.spawn`).
- **MIGRATIONS.md** — documents the downstream override requirement (`SMOKE_TEST_PATTERN=scraps.integration|historys.integration` for trawl_node etc).

## Test plan

- [x] `SMOKE_WORKERS=2 npm run test:parallel-smoke` — 2 workers green with distinct pids
- [x] `npm run test:unit -- parallelIntegrationSmoke` — orchestrator unit tests pass
- [x] `npm run lint` — clean
- [x] Rebased on master (post-#3517 merge)

Closes #3516