### PR TITLE
chore: gitignore graphify-out/ + Graphify doc note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ app/tests/coverage/
 coverage/
 .coveralls.yml
 
+# Graphify code knowledge graph (transient, regen via `graphify update .`)
+graphify-out/
+
 # waos Node app and assets
 # ======================
 # Environment files (secrets)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ Node / Express / Mongoose / JWT stack from Devkit. Standalone backend or fullsta
 - E2E only for critical product flows (auth, org onboarding, invite/join)
 - Docker: `docker compose -f docker-compose.test.yml up --build --abort-on-container-exit`
 
+## Dev tooling
+
+- **Code knowledge graph (optional)** : install Graphify via `uv tool install graphifyy==0.5.0` (Python tool, system-wide). Run `graphify update .` to generate `graph.json` + report under `graphify-out/`. Pin v0.5.0 — Graphify ships fast (5 releases / 48h around 22-23 April 2026), expect breaking changes on minor bumps.
+
 ## Guardrails
 
 - Never commit secrets (`.env*`, keys, tokens)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ Node / Express / Mongoose / JWT stack from Devkit. Standalone backend or fullsta
 
 ## Dev tooling
 
-- **Code knowledge graph (optional)** : install Graphify via `uv tool install graphifyy==0.5.0` (Python tool, system-wide). Run `graphify update .` to generate `graph.json` + report under `graphify-out/`. Pin v0.5.0 — Graphify ships fast (5 releases / 48h around 22-23 April 2026), expect breaking changes on minor bumps.
+- **Code knowledge graph (optional):**
+  - Install Graphify via `uv tool install graphifyy==0.5.0` (Python tool, system-wide).
+  - Run `graphify update .` to generate `graph.json` and a report under `graphify-out/`.
+  - Pin v0.5.0 — Graphify ships fast (5 releases / 48h around 22-23 April 2026), so expect breaking changes on minor bumps.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

Closes #3523.

- Add `graphify-out/` to `.gitignore` (transient code-knowledge-graph artefact, regenerated via `graphify update .`).
- Add a short "Dev tooling" section to `CLAUDE.md` with the install + usage hint and v0.5.0 pin recommendation.

## Test plan

- [x] `npm run lint` clean
- [x] No source files touched (gitignore + doc only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude auto-generated output files from version control.

* **Documentation**
  * Added developer tooling documentation for code knowledge graph generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->