### PR TITLE
feat(billing): meter service, extras balance, weekly reset (PR-N2)

### DIFF
--- a/modules/billing/models/billing.extraBalance.model.mongoose.js
+++ b/modules/billing/models/billing.extraBalance.model.mongoose.js
@@ -1,0 +1,145 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+/**
+ * ExtraBalance Data Model Mongoose
+ *
+ * Tracks prepaid "extra" meter units per organization.
+ * Each org has at most one ExtraBalance document (unique on organization).
+ *
+ * The ledger array is an append-only audit trail of all balance mutations.
+ * cachedBalance is kept in sync on every atomic write to avoid scanning
+ * the entire ledger on hot-path reads.
+ *
+ * NOTE — Mixed type caveats (applies to embedded objects in subdocuments):
+ *   Mongoose validators are NOT executed for in-place mutations on Mixed fields
+ *   (doc.field.x = y; doc.save() silently skips validators).
+ *   Always use atomic MongoDB operators ($inc, $push, $set via findOneAndUpdate)
+ *   or Model.create() which runs validators on the full document.
+ */
+const LedgerEntrySchema = new Schema(
+  {
+    kind: {
+      type: String,
+      enum: ['topup', 'debit', 'refund', 'expiration', 'adjustment'],
+      required: true,
+    },
+    /**
+     * Signed amount in meter units.
+     * Positive for topup/refund/adjustment (add to balance).
+     * Negative for debit/expiration (subtract from balance).
+     */
+    amount: {
+      type: Number,
+      required: true,
+    },
+    /**
+     * Stripe checkout session ID — used for topup idempotency.
+     * Sparse: only set for kind='topup'.
+     */
+    stripeSessionId: {
+      type: String,
+      sparse: true,
+    },
+    /**
+     * ObjectId reference to the History document that triggered a debit.
+     * Sparse: only set for kind='debit'.
+     */
+    historyId: {
+      type: Schema.ObjectId,
+      sparse: true,
+    },
+    /**
+     * Generic external reference string.
+     * Used for: debit idempotency key, expiration ref ('expire-<entryId>'),
+     * or adjustment memo.
+     */
+    refId: {
+      type: String,
+      sparse: true,
+    },
+    at: {
+      type: Date,
+      default: Date.now,
+    },
+    /**
+     * Expiry date for topup entries.
+     * Sparse: only set on kind='topup' when the pack has a finite lifespan.
+     */
+    expiresAt: {
+      type: Date,
+      sparse: true,
+    },
+  },
+  { _id: true },
+);
+
+const ExtraBalanceMongoose = new Schema(
+  {
+    organization: {
+      type: Schema.ObjectId,
+      ref: 'Organization',
+      required: true,
+      unique: true,
+    },
+    ledger: {
+      type: [LedgerEntrySchema],
+      default: () => [],
+    },
+    /**
+     * Running total of available meter units.
+     * Updated atomically on every write (via $inc) to avoid full ledger scans.
+     * May temporarily diverge from sum(ledger.amount) during partial expiration
+     * sweeps; addExpirationEntries + cachedBalance update is always atomic.
+     */
+    cachedBalance: {
+      type: Number,
+      default: 0,
+    },
+    cachedBalanceAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+/**
+ * Index for idempotent topup lookups — check if a stripeSessionId was already
+ * applied before pushing a new ledger entry.
+ */
+ExtraBalanceMongoose.index({ 'ledger.stripeSessionId': 1 }, { sparse: true });
+
+/**
+ * Index for debit replay protection — check if a historyId was already debited.
+ */
+ExtraBalanceMongoose.index({ 'ledger.historyId': 1 }, { sparse: true });
+
+/**
+ * Index for expiration sweeps — find topup entries with expiresAt in the past.
+ */
+ExtraBalanceMongoose.index({ 'ledger.expiresAt': 1 }, { sparse: true });
+
+/**
+ * Returns the hex string representation of the document ObjectId.
+ * @returns {string} Hex string of the ObjectId.
+ */
+function addID() {
+  return this._id.toHexString();
+}
+
+/**
+ * Model configuration
+ */
+ExtraBalanceMongoose.virtual('id').get(addID);
+ExtraBalanceMongoose.set('toJSON', {
+  virtuals: true,
+});
+
+mongoose.model('BillingExtraBalance', ExtraBalanceMongoose);

--- a/modules/billing/models/billing.extraBalance.model.mongoose.js
+++ b/modules/billing/models/billing.extraBalance.model.mongoose.js
@@ -39,19 +39,17 @@ const LedgerEntrySchema = new Schema(
     },
     /**
      * Stripe checkout session ID — used for topup idempotency.
-     * Sparse: only set for kind='topup'.
+     * Only set for kind='topup'.
      */
     stripeSessionId: {
       type: String,
-      sparse: true,
     },
     /**
      * ObjectId reference to the History document that triggered a debit.
-     * Sparse: only set for kind='debit'.
+     * Only set for kind='debit'.
      */
     historyId: {
       type: Schema.ObjectId,
-      sparse: true,
     },
     /**
      * Generic external reference string.
@@ -60,7 +58,6 @@ const LedgerEntrySchema = new Schema(
      */
     refId: {
       type: String,
-      sparse: true,
     },
     at: {
       type: Date,
@@ -68,11 +65,10 @@ const LedgerEntrySchema = new Schema(
     },
     /**
      * Expiry date for topup entries.
-     * Sparse: only set on kind='topup' when the pack has a finite lifespan.
+     * Only set on kind='topup' when the pack has a finite lifespan.
      */
     expiresAt: {
       type: Date,
-      sparse: true,
     },
   },
   { _id: true },

--- a/modules/billing/models/billing.extraBalance.model.mongoose.js
+++ b/modules/billing/models/billing.extraBalance.model.mongoose.js
@@ -38,6 +38,10 @@ const LedgerEntrySchema = new Schema(
     amount: {
       type: Number,
       required: true,
+      validate: {
+        validator: (v) => v !== 0,
+        message: 'Ledger entry amount cannot be zero',
+      },
     },
     /**
      * Stripe checkout session ID — used for topup idempotency.

--- a/modules/billing/models/billing.extraBalance.model.mongoose.js
+++ b/modules/billing/models/billing.extraBalance.model.mongoose.js
@@ -30,8 +30,10 @@ const LedgerEntrySchema = new Schema(
     },
     /**
      * Signed amount in meter units.
-     * Positive for topup/refund/adjustment (add to balance).
-     * Negative for debit/expiration (subtract from balance).
+     * Positive for topup/adjustment (add to balance).
+     * Negative for debit/expiration/refund (subtract from balance).
+     * Note: 'refund' entries are clawbacks and carry a negative amount,
+     * reflecting the economic debt when credits already consumed must be reclaimed.
      */
     amount: {
       type: Number,

--- a/modules/billing/models/billing.extraBalance.schema.js
+++ b/modules/billing/models/billing.extraBalance.schema.js
@@ -23,8 +23,9 @@ const LedgerEntry = z.object({
   /**
    * Signed amount in meter units.
    * Positive for topup/refund/adjustment; negative for debit/expiration.
+   * Zero is rejected as an operational guard (zero-amount entries are always a bug).
    */
-  amount: z.number(),
+  amount: z.number().refine((n) => n !== 0, { message: 'Ledger entry amount must not be zero' }),
   stripeSessionId: z.string().trim().optional().nullable(),
   historyId: z
     .string()

--- a/modules/billing/models/billing.extraBalance.schema.js
+++ b/modules/billing/models/billing.extraBalance.schema.js
@@ -16,28 +16,52 @@ const LedgerKind = z.enum(['topup', 'debit', 'refund', 'expiration', 'adjustment
 
 /**
  * Single ledger entry schema.
+ * Enforces:
+ *   - amount !== 0 (zero is always a bug)
+ *   - sign by kind: topup/adjustment must be > 0; debit/expiration/refund must be < 0
  */
-const LedgerEntry = z.object({
-  _id: z.string().trim().regex(objectIdRegex, '_id must be a valid ObjectId').optional(),
-  kind: LedgerKind,
-  /**
-   * Signed amount in meter units.
-   * Positive for topup/adjustment; negative for debit/expiration/refund.
-   * 'refund' entries are clawbacks (negative) reflecting reclaimed units.
-   * Zero is rejected as an operational guard (zero-amount entries are always a bug).
-   */
-  amount: z.number().refine((n) => n !== 0, { message: 'Ledger entry amount must not be zero' }),
-  stripeSessionId: z.string().trim().optional().nullable(),
-  historyId: z
-    .string()
-    .trim()
-    .regex(objectIdRegex, 'historyId must be a valid ObjectId')
-    .optional()
-    .nullable(),
-  refId: z.string().trim().optional().nullable(),
-  at: z.coerce.date().optional(),
-  expiresAt: z.coerce.date().optional().nullable(),
-});
+const LedgerEntry = z
+  .object({
+    _id: z.string().trim().regex(objectIdRegex, '_id must be a valid ObjectId').optional(),
+    kind: LedgerKind,
+    /**
+     * Signed amount in meter units.
+     * Positive for topup/adjustment; negative for debit/expiration/refund.
+     * 'refund' entries are clawbacks (negative) reflecting reclaimed units.
+     * Zero is rejected as an operational guard (zero-amount entries are always a bug).
+     */
+    amount: z.number().refine((n) => n !== 0, { message: 'Ledger entry amount must not be zero' }),
+    stripeSessionId: z.string().trim().optional().nullable(),
+    historyId: z
+      .string()
+      .trim()
+      .regex(objectIdRegex, 'historyId must be a valid ObjectId')
+      .optional()
+      .nullable(),
+    refId: z.string().trim().optional().nullable(),
+    at: z.coerce.date().optional(),
+    expiresAt: z.coerce.date().optional().nullable(),
+  })
+  .superRefine((entry, ctx) => {
+    const { kind, amount } = entry;
+    if (kind === 'topup' || kind === 'adjustment') {
+      if (amount <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Ledger entry of kind '${kind}' must have a positive amount`,
+          path: ['amount'],
+        });
+      }
+    } else if (kind === 'debit' || kind === 'expiration' || kind === 'refund') {
+      if (amount >= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Ledger entry of kind '${kind}' must have a negative amount`,
+          path: ['amount'],
+        });
+      }
+    }
+  });
 
 /**
  * Full ExtraBalance document schema.

--- a/modules/billing/models/billing.extraBalance.schema.js
+++ b/modules/billing/models/billing.extraBalance.schema.js
@@ -22,7 +22,8 @@ const LedgerEntry = z.object({
   kind: LedgerKind,
   /**
    * Signed amount in meter units.
-   * Positive for topup/refund/adjustment; negative for debit/expiration.
+   * Positive for topup/adjustment; negative for debit/expiration/refund.
+   * 'refund' entries are clawbacks (negative) reflecting reclaimed units.
    * Zero is rejected as an operational guard (zero-amount entries are always a bug).
    */
   amount: z.number().refine((n) => n !== 0, { message: 'Ledger entry amount must not be zero' }),

--- a/modules/billing/models/billing.extraBalance.schema.js
+++ b/modules/billing/models/billing.extraBalance.schema.js
@@ -1,0 +1,75 @@
+/**
+ * Module dependencies
+ */
+import { z } from 'zod';
+
+/**
+ * BillingExtraBalance Zod schema — mirrors billing.extraBalance.model.mongoose.js
+ */
+
+const objectIdRegex = /^[a-f\d]{24}$/i;
+
+/**
+ * Ledger entry kinds enum — mirrors the Mongoose enum.
+ */
+const LedgerKind = z.enum(['topup', 'debit', 'refund', 'expiration', 'adjustment']);
+
+/**
+ * Single ledger entry schema.
+ */
+const LedgerEntry = z.object({
+  _id: z.string().trim().regex(objectIdRegex, '_id must be a valid ObjectId').optional(),
+  kind: LedgerKind,
+  /**
+   * Signed amount in meter units.
+   * Positive for topup/refund/adjustment; negative for debit/expiration.
+   */
+  amount: z.number(),
+  stripeSessionId: z.string().trim().optional().nullable(),
+  historyId: z
+    .string()
+    .trim()
+    .regex(objectIdRegex, 'historyId must be a valid ObjectId')
+    .optional()
+    .nullable(),
+  refId: z.string().trim().optional().nullable(),
+  at: z.coerce.date().optional(),
+  expiresAt: z.coerce.date().optional().nullable(),
+});
+
+/**
+ * Full ExtraBalance document schema.
+ */
+const BillingExtraBalance = z.object({
+  organization: z.string().trim().regex(objectIdRegex, 'organization must be a valid ObjectId'),
+  ledger: z.array(LedgerEntry).default(() => []),
+  cachedBalance: z.number().default(0),
+  cachedBalanceAt: z.coerce.date().optional(),
+});
+
+/**
+ * Schema for creditPack input.
+ */
+const ExtraBalanceCreditPack = z.object({
+  orgId: z.string().trim().regex(objectIdRegex, 'orgId must be a valid ObjectId'),
+  amount: z.number().int().min(1, 'amount must be >= 1'),
+  stripeSessionId: z.string().trim().min(1, 'stripeSessionId is required'),
+  expiresAt: z.coerce.date().optional().nullable(),
+});
+
+/**
+ * Schema for debit input.
+ */
+const ExtraBalanceDebit = z.object({
+  orgId: z.string().trim().regex(objectIdRegex, 'orgId must be a valid ObjectId'),
+  amount: z.number().int().min(1, 'amount must be >= 1'),
+  refId: z.string().trim().min(1, 'refId is required'),
+});
+
+export default {
+  LedgerKind,
+  LedgerEntry,
+  BillingExtraBalance,
+  ExtraBalanceCreditPack,
+  ExtraBalanceDebit,
+};

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -55,6 +55,8 @@ const getOrCreate = (orgId) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
   if (!isValidOrgId(orgId)) return { doc: null, applied: false };
+  if (!Number.isFinite(amount) || amount <= 0) throw new Error('invalid argument: amount must be a positive finite number');
+  if (typeof stripeSessionId !== 'string' || stripeSessionId.trim() === '') throw new Error('invalid argument: stripeSessionId must be a non-empty string');
   const entry = {
     kind: 'topup',
     amount,
@@ -97,6 +99,8 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const debit = async (orgId, amount, refId) => {
   if (!isValidOrgId(orgId)) return { doc: null, applied: false };
+  if (!Number.isFinite(amount) || amount <= 0) throw new Error('invalid argument: amount must be a positive finite number');
+  if (typeof refId !== 'string' || refId.trim() === '') throw new Error('invalid argument: refId must be a non-empty string');
   const entry = {
     kind: 'debit',
     amount: -amount,
@@ -198,6 +202,8 @@ const addExpirationEntries = async (orgId, now) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const refundPartial = async (orgId, stripeSessionId, refundUnits, refId) => {
   if (!isValidOrgId(orgId)) return { doc: null, applied: false };
+  if (!Number.isFinite(refundUnits) || refundUnits <= 0) throw new Error('invalid argument: refundUnits must be a positive finite number');
+  if (typeof refId !== 'string' || refId.trim() === '') throw new Error('invalid argument: refId must be a non-empty string');
   const entry = {
     kind: 'refund',
     amount: -refundUnits,

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -9,6 +9,7 @@ import mongoose from 'mongoose';
  * @param {string} orgId - The organization id to validate.
  * @returns {boolean}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const isValidOrgId = (orgId) => mongoose.Types.ObjectId.isValid(orgId);
 
 /**

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -169,6 +169,46 @@ const addExpirationEntries = async (orgId, now) => {
 };
 
 /**
+ * @function refundPartial
+ * @description Atomically push a negative 'refund' ledger entry and decrement cachedBalance.
+ *              Idempotent: if a ledger entry with the same refId already exists the update
+ *              is a no-op and applied=false is returned.
+ *              The balance may go negative when units were already consumed — this correctly
+ *              reflects the economic debt (replenished on next creditPack).
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {string} stripeSessionId - Stripe session ID of the original purchase.
+ * @param {number} refundUnits - Meter units to claw back (must be > 0).
+ * @param {string} refId - Unique idempotency key for this refund (e.g. `refund-<sessionId>-<cents>`).
+ * @returns {Promise<{doc: Object|null, applied: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const refundPartial = async (orgId, stripeSessionId, refundUnits, refId) => {
+  const entry = {
+    kind: 'refund',
+    amount: -refundUnits,
+    stripeSessionId,
+    refId,
+    at: new Date(),
+  };
+
+  const doc = await BillingExtraBalance().findOneAndUpdate(
+    {
+      organization: orgId,
+      'ledger.refId': { $ne: refId },
+    },
+    {
+      $push: { ledger: entry },
+      $inc: { cachedBalance: -refundUnits },
+      $set: { cachedBalanceAt: new Date() },
+    },
+    { returnDocument: 'after' },
+  );
+
+  if (doc) return { doc, applied: true };
+  return { doc: null, applied: false };
+};
+
+/**
  * @function getBalance
  * @description Return the current cachedBalance for an organization.
  *              Cheap read — no ledger scan.
@@ -186,5 +226,6 @@ export default {
   creditPack,
   debit,
   addExpirationEntries,
+  refundPartial,
   getBalance,
 };

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -4,6 +4,14 @@
 import mongoose from 'mongoose';
 
 /**
+ * Validate that orgId is a syntactically valid MongoDB ObjectId.
+ * Returns false for malformed strings to avoid Mongoose CastError → 500.
+ * @param {string} orgId - The organization id to validate.
+ * @returns {boolean}
+ */
+const isValidOrgId = (orgId) => mongoose.Types.ObjectId.isValid(orgId);
+
+/**
  * @function BillingExtraBalance
  * @description Lazily resolves the BillingExtraBalance Mongoose model.
  *              Deferred to keep unit tests importable before model registration.
@@ -21,12 +29,14 @@ const BillingExtraBalance = () => mongoose.model('BillingExtraBalance');
  * @returns {Promise<Object>} The ExtraBalance document.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
-const getOrCreate = (orgId) =>
-  BillingExtraBalance().findOneAndUpdate(
+const getOrCreate = (orgId) => {
+  if (!isValidOrgId(orgId)) return Promise.resolve(null);
+  return BillingExtraBalance().findOneAndUpdate(
     { organization: orgId },
     { $setOnInsert: { organization: orgId, ledger: [], cachedBalance: 0, cachedBalanceAt: new Date() } },
     { upsert: true, returnDocument: 'after', runValidators: true },
   );
+};
 
 /**
  * @function creditPack
@@ -43,6 +53,7 @@ const getOrCreate = (orgId) =>
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
+  if (!isValidOrgId(orgId)) return { doc: null, applied: false };
   const entry = {
     kind: 'topup',
     amount,
@@ -84,6 +95,7 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const debit = async (orgId, amount, refId) => {
+  if (!isValidOrgId(orgId)) return { doc: null, applied: false };
   const entry = {
     kind: 'debit',
     amount: -amount,
@@ -122,6 +134,7 @@ const debit = async (orgId, amount, refId) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const addExpirationEntries = async (orgId, now) => {
+  if (!isValidOrgId(orgId)) return 0;
   // Read the doc to find expired topups without a corresponding expiration entry.
   const doc = await BillingExtraBalance().findOne({ organization: orgId }).lean();
   if (!doc) return 0;
@@ -183,6 +196,7 @@ const addExpirationEntries = async (orgId, now) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const refundPartial = async (orgId, stripeSessionId, refundUnits, refId) => {
+  if (!isValidOrgId(orgId)) return { doc: null, applied: false };
   const entry = {
     kind: 'refund',
     amount: -refundUnits,
@@ -217,6 +231,7 @@ const refundPartial = async (orgId, stripeSessionId, refundUnits, refId) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const getBalance = async (orgId) => {
+  if (!isValidOrgId(orgId)) return 0;
   const doc = await BillingExtraBalance().findOne({ organization: orgId }, { cachedBalance: 1 }).lean();
   return doc ? doc.cachedBalance : 0;
 };

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -1,0 +1,190 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+/**
+ * @function BillingExtraBalance
+ * @description Lazily resolves the BillingExtraBalance Mongoose model.
+ *              Deferred to keep unit tests importable before model registration.
+ * @returns {import('mongoose').Model} The registered BillingExtraBalance model.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const BillingExtraBalance = () => mongoose.model('BillingExtraBalance');
+
+/**
+ * @function getOrCreate
+ * @description Upsert an empty balance document for the given organization.
+ *              Returns the existing document if one already exists.
+ *              Safe to call concurrently — uses findOneAndUpdate with upsert.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @returns {Promise<Object>} The ExtraBalance document.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const getOrCreate = (orgId) =>
+  BillingExtraBalance().findOneAndUpdate(
+    { organization: orgId },
+    { $setOnInsert: { organization: orgId, ledger: [], cachedBalance: 0, cachedBalanceAt: new Date() } },
+    { upsert: true, returnDocument: 'after', runValidators: true },
+  );
+
+/**
+ * @function creditPack
+ * @description Atomically credit extra meter units from a Stripe pack purchase.
+ *              Idempotent: if a ledger entry with the same stripeSessionId already
+ *              exists, the update is a no-op and applied=false is returned.
+ *              Uses a native-Mongo filter `ledger.stripeSessionId: { $ne: stripeSessionId }`
+ *              so the idempotency check is part of the atomic update, not a separate read.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {number} amount - Meter units to credit (must be > 0).
+ * @param {string} stripeSessionId - Stripe checkout session ID (idempotency key).
+ * @param {Date|null} [expiresAt=null] - Optional expiry date for the topup entry.
+ * @returns {Promise<{doc: Object, applied: boolean}>} Updated doc and whether the credit was applied.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
+  const entry = {
+    kind: 'topup',
+    amount,
+    stripeSessionId,
+    at: new Date(),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+
+  const doc = await BillingExtraBalance().findOneAndUpdate(
+    {
+      organization: orgId,
+      'ledger.stripeSessionId': { $ne: stripeSessionId },
+    },
+    {
+      $push: { ledger: entry },
+      $inc: { cachedBalance: amount },
+      $set: { cachedBalanceAt: new Date() },
+    },
+    { upsert: true, returnDocument: 'after', runValidators: true },
+  );
+
+  if (doc) return { doc, applied: true };
+
+  // No doc returned — the stripeSessionId already exists (idempotency hit).
+  const existing = await BillingExtraBalance().findOne({ organization: orgId }).lean();
+  return { doc: existing, applied: false };
+};
+
+/**
+ * @function debit
+ * @description Atomically debit meter units from the extra balance.
+ *              Guards: (1) cachedBalance >= amount, (2) no existing ledger entry with refId.
+ *              Both checks are in the atomic filter — no TOCTOU.
+ *              Returns applied=false if balance is insufficient OR refId already used.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {number} amount - Meter units to debit (must be > 0).
+ * @param {string} refId - Unique reference for this debit (idempotency key).
+ * @returns {Promise<{doc: Object|null, applied: boolean}>} Updated doc and whether debit was applied.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const debit = async (orgId, amount, refId) => {
+  const entry = {
+    kind: 'debit',
+    amount: -amount,
+    refId,
+    at: new Date(),
+  };
+
+  const doc = await BillingExtraBalance().findOneAndUpdate(
+    {
+      organization: orgId,
+      cachedBalance: { $gte: amount },
+      'ledger.refId': { $ne: refId },
+    },
+    {
+      $push: { ledger: entry },
+      $inc: { cachedBalance: -amount },
+      $set: { cachedBalanceAt: new Date() },
+    },
+    { returnDocument: 'after' },
+  );
+
+  if (doc) return { doc, applied: true };
+  return { doc: null, applied: false };
+};
+
+/**
+ * @function addExpirationEntries
+ * @description Sweep topup entries that have expired and push matching expiration
+ *              ledger entries to reduce cachedBalance.
+ *              Idempotent: each topup entry can only produce one expiration entry
+ *              (keyed by 'expire-<entryId>'). Re-running this method on already-expired
+ *              entries is a no-op because the refId filter excludes already-handled entries.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {Date} now - The current timestamp used as the expiry cutoff.
+ * @returns {Promise<number>} Number of expiration entries added.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const addExpirationEntries = async (orgId, now) => {
+  // Read the doc to find expired topups without a corresponding expiration entry.
+  const doc = await BillingExtraBalance().findOne({ organization: orgId }).lean();
+  if (!doc) return 0;
+
+  const existingExpireRefs = new Set(
+    doc.ledger.filter((e) => e.kind === 'expiration').map((e) => e.refId),
+  );
+
+  const expiredTopups = doc.ledger.filter(
+    (e) =>
+      e.kind === 'topup' &&
+      e.expiresAt &&
+      new Date(e.expiresAt) < now &&
+      !existingExpireRefs.has(`expire-${e._id}`),
+  );
+
+  if (expiredTopups.length === 0) return 0;
+
+  let applied = 0;
+  for (const topup of expiredTopups) {
+    const expireRefId = `expire-${topup._id}`;
+    const entry = {
+      kind: 'expiration',
+      amount: -topup.amount,
+      refId: expireRefId,
+      at: now,
+    };
+
+    // Atomic: only push if this expiration refId is not already present.
+    const result = await BillingExtraBalance().findOneAndUpdate(
+      {
+        organization: orgId,
+        'ledger.refId': { $ne: expireRefId },
+      },
+      {
+        $push: { ledger: entry },
+        $inc: { cachedBalance: -topup.amount },
+        $set: { cachedBalanceAt: now },
+      },
+    );
+    if (result) applied += 1;
+  }
+
+  return applied;
+};
+
+/**
+ * @function getBalance
+ * @description Return the current cachedBalance for an organization.
+ *              Cheap read — no ledger scan.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @returns {Promise<number>} The cached balance, or 0 if no document exists.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const getBalance = async (orgId) => {
+  const doc = await BillingExtraBalance().findOne({ organization: orgId }, { cachedBalance: 1 }).lean();
+  return doc ? doc.cachedBalance : 0;
+};
+
+export default {
+  getOrCreate,
+  creditPack,
+  debit,
+  addExpirationEntries,
+  getBalance,
+};

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -116,7 +116,7 @@ const findByStripeSubscriptionId = (stripeSubscriptionId) => {
  *              Returns lean plain objects (no population) for performance.
  * @param {Date} from - The start of the window (inclusive).
  * @param {Date} to - The end of the window (inclusive).
- * @returns {Promise<Array<{organizationId: string, currentPeriodStart: Date}>>}
+ * @returns {Promise<Array<{organization: string, currentPeriodStart: Date}>>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const findAllDueForReset = (from, to) =>
@@ -125,7 +125,7 @@ const findAllDueForReset = (from, to) =>
       status: { $in: ['active', 'trialing'] },
       currentPeriodStart: { $gte: from, $lte: to },
     },
-    { organizationId: 1, currentPeriodStart: 1 },
+    { organization: 1, currentPeriodStart: 1 },
   ).lean();
 
 export default {

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -109,6 +109,25 @@ const findByStripeSubscriptionId = (stripeSubscriptionId) => {
   return Subscription.findOne({ stripeSubscriptionId: normalized }).populate(defaultPopulate).exec();
 };
 
+/**
+ * @function findAllDueForReset
+ * @description Fetch active/trialing subscriptions whose currentPeriodStart falls
+ *              within the provided time window. Used by the weekly meter reset sweep.
+ *              Returns lean plain objects (no population) for performance.
+ * @param {Date} from - The start of the window (inclusive).
+ * @param {Date} to - The end of the window (inclusive).
+ * @returns {Promise<Array<{organizationId: string, currentPeriodStart: Date}>>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const findAllDueForReset = (from, to) =>
+  Subscription.find(
+    {
+      status: { $in: ['active', 'trialing'] },
+      currentPeriodStart: { $gte: from, $lte: to },
+    },
+    { organizationId: 1, currentPeriodStart: 1 },
+  ).lean();
+
 export default {
   list,
   create,
@@ -118,4 +137,5 @@ export default {
   findByOrganization,
   findByStripeCustomerId,
   findByStripeSubscriptionId,
+  findAllDueForReset,
 };

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -150,10 +150,70 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
   }
 };
 
+/**
+ * @function archiveOtherWeeks
+ * @description Atomically set archivedAt on all active usage documents for an org
+ *              whose weekKey does NOT match currentWeekKey.
+ *              Idempotent: documents already bearing archivedAt are excluded by the filter.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {string} currentWeekKey - The week key to preserve (not archived).
+ * @param {Date} archivedAt - Timestamp to stamp on archived documents.
+ * @returns {Promise<{modifiedCount: number}>} Mongoose updateMany result.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const archiveOtherWeeks = (orgId, currentWeekKey, archivedAt) =>
+  BillingUsage.updateMany(
+    {
+      organizationId: orgId,
+      weekKey: { $ne: currentWeekKey },
+      archivedAt: { $exists: false },
+    },
+    { $set: { archivedAt } },
+  );
+
+/**
+ * @function upsertWeekSnapshot
+ * @description Upsert a new weekly usage document with snapshot fields ($setOnInsert only).
+ *              If the document already exists, the operation is a no-op (idempotent).
+ *              Throws with code 11000 on a race — callers should catch and re-fetch.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {string} weekKey - The ISO week key for the new period.
+ * @param {Object} snapshotFields - Fields written only on document creation
+ *   (organizationId, weekKey, month, meterUsed, meterQuota, planVersion,
+ *    meterBreakdown, resetAt, alertedAt80, alertedAt100, consumedHistoryIds).
+ * @returns {Promise<Object>} The upserted document.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const upsertWeekSnapshot = (orgId, weekKey, snapshotFields) =>
+  BillingUsage.findOneAndUpdate(
+    { organizationId: orgId, weekKey },
+    { $setOnInsert: snapshotFields },
+    { upsert: true, returnDocument: 'after', runValidators: false },
+  );
+
+/**
+ * @function markThreshold
+ * @description Atomically set a threshold timestamp field on a usage document,
+ *              only when the field is currently null (deduplication guard).
+ *              Used by the service layer to record 80%/100% alert crossings.
+ * @param {string} docId - The BillingUsage document _id (string).
+ * @param {'alertedAt80'|'alertedAt100'} field - The threshold field to set.
+ * @returns {Promise<{modifiedCount: number}>} Mongoose updateOne result.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const markThreshold = (docId, field) =>
+  BillingUsage.updateOne(
+    { _id: docId, [field]: null },
+    { $set: { [field]: new Date() } },
+  );
+
 export default {
   get,
   increment,
   reset,
   findByWeek,
   incrementMeter,
+  archiveOtherWeeks,
+  upsertWeekSnapshot,
+  markThreshold,
 };

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -99,10 +99,11 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
   if (!mongoose.Types.ObjectId.isValid(organizationId)) return null;
 
   // Build $inc for meterUsed + per-feature breakdown keys
+  // Only include entries with a finite positive value to avoid invalid $inc operations.
   const incPayload = { meterUsed: units };
   if (breakdown && typeof breakdown === 'object') {
     for (const [key, value] of Object.entries(breakdown)) {
-      if (SAFE_KEY_RE.test(key)) {
+      if (SAFE_KEY_RE.test(key) && Number.isFinite(value) && value > 0) {
         incPayload[`meterBreakdown.${key}`] = value;
       }
     }

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -65,8 +65,95 @@ const reset = (organizationId, month) => {
   ).exec();
 };
 
+/**
+ * @function findByWeek
+ * @description Fetch a single usage document by organizationId and weekKey.
+ * @param {String} organizationId - The organization ID.
+ * @param {String} weekKey - The ISO week key in YYYY-Www format.
+ * @returns {Promise<Object|null>} The usage document (plain object) or null.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const findByWeek = (organizationId, weekKey) => {
+  if (!mongoose.Types.ObjectId.isValid(organizationId)) return null;
+  return BillingUsage.findOne({ organizationId, weekKey }).lean();
+};
+
+/**
+ * @function incrementMeter
+ * @description Atomically increment meter usage for the given org+weekKey, with upsert.
+ *              Replay protection: the idempotencyKey is appended to consumedHistoryIds;
+ *              if it is already present, the update is skipped (returns null).
+ *              baseSnapshot fields ($setOnInsert) are only written on document creation,
+ *              preserving the quota snapshot for the lifetime of the week.
+ *
+ * @param {String} organizationId - The organization ID.
+ * @param {String} weekKey - The ISO week key in YYYY-Www format.
+ * @param {Number} units - Meter units to add.
+ * @param {Object} breakdown - Feature-level breakdown map { featureKey: units }.
+ * @param {String} idempotencyKey - Unique key (usually history._id.toString()) for replay protection.
+ * @param {Object} baseSnapshot - Fields written only on first upsert: { meterQuota, planVersion, resetAt, month }.
+ * @returns {Promise<Object|null>} The updated usage document, or null if this was a replay (no-op).
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const incrementMeter = async (organizationId, weekKey, units, breakdown, idempotencyKey, baseSnapshot) => {
+  if (!mongoose.Types.ObjectId.isValid(organizationId)) return null;
+
+  // Build $inc for meterUsed + per-feature breakdown keys
+  const incPayload = { meterUsed: units };
+  if (breakdown && typeof breakdown === 'object') {
+    for (const [key, value] of Object.entries(breakdown)) {
+      if (SAFE_KEY_RE.test(key)) {
+        incPayload[`meterBreakdown.${key}`] = value;
+      }
+    }
+  }
+
+  try {
+    const doc = await BillingUsage.findOneAndUpdate(
+      {
+        organizationId,
+        weekKey,
+        consumedHistoryIds: { $ne: idempotencyKey },
+      },
+      {
+        $inc: incPayload,
+        $push: { consumedHistoryIds: idempotencyKey },
+        $setOnInsert: {
+          organizationId,
+          weekKey,
+          month: baseSnapshot?.month ?? weekKey.slice(0, 7),
+          meterQuota: baseSnapshot?.meterQuota ?? 0,
+          planVersion: baseSnapshot?.planVersion ?? null,
+          resetAt: baseSnapshot?.resetAt ?? null,
+        },
+      },
+      { upsert: true, returnDocument: 'after', runValidators: false },
+    );
+    return doc;
+  } catch (err) {
+    if (err.code === 11000) {
+      // Duplicate key on upsert race — retry without upsert
+      return BillingUsage.findOneAndUpdate(
+        {
+          organizationId,
+          weekKey,
+          consumedHistoryIds: { $ne: idempotencyKey },
+        },
+        {
+          $inc: incPayload,
+          $push: { consumedHistoryIds: idempotencyKey },
+        },
+        { returnDocument: 'after' },
+      );
+    }
+    throw err;
+  }
+};
+
 export default {
   get,
   increment,
   reset,
+  findByWeek,
+  incrementMeter,
 };

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -121,10 +121,19 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
         $setOnInsert: {
           organizationId,
           weekKey,
-          month: baseSnapshot?.month ?? weekKey.slice(0, 7),
+          // Derive a valid YYYY-MM month from the weekKey as fallback.
+          // weekKey has format 'YYYY-Www' (e.g. '2026-W18'); slicing 7 chars gives 'YYYY-W'
+          // which is not a valid month. Instead parse the year from weekKey and use current month.
+          month: baseSnapshot?.month ?? (() => {
+            const now = new Date();
+            return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+          })(),
           meterQuota: baseSnapshot?.meterQuota ?? 0,
           planVersion: baseSnapshot?.planVersion ?? null,
           resetAt: baseSnapshot?.resetAt ?? null,
+          meterBreakdown: {},
+          alertedAt80: null,
+          alertedAt100: null,
         },
       },
       { upsert: true, returnDocument: 'after', runValidators: false },

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -1,0 +1,166 @@
+/**
+ * Module dependencies
+ */
+import config from '../../../config/index.js';
+import BillingExtraBalanceRepository from '../repositories/billing.extraBalance.repository.js';
+
+/**
+ * @function creditPack
+ * @description Credit extra meter units from a purchased pack.
+ *              Looks up the pack definition from config.billing.packs by packId,
+ *              computes expiresAt from pack.expiryDays (null if not set),
+ *              and delegates to the repository for atomic idempotent write.
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {string} packId - The pack identifier (must exist in config.billing.packs).
+ * @param {string} stripeSessionId - Stripe checkout session ID (idempotency key).
+ * @returns {Promise<{doc: Object, applied: boolean}>} Updated doc and whether the credit was applied.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const creditPack = async (orgId, packId, stripeSessionId) => {
+  const packs = config?.billing?.packs ?? [];
+  const pack = packs.find((p) => p.packId === packId);
+  if (!pack) throw new Error(`Pack not found: ${packId}`);
+
+  const amount = pack.meterUnits ?? pack.computeUnits;
+  if (!amount || amount <= 0) throw new Error(`Pack ${packId} has no valid meterUnits`);
+
+  let expiresAt = null;
+  if (pack.expiryDays != null) {
+    expiresAt = new Date(Date.now() + pack.expiryDays * 24 * 60 * 60 * 1000);
+  }
+
+  return BillingExtraBalanceRepository.creditPack(orgId, amount, stripeSessionId, expiresAt);
+};
+
+/**
+ * @function debit
+ * @description Debit meter units from the extra balance.
+ *              Returns applied=false if balance is insufficient or refId already used.
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {number} units - Meter units to debit (must be > 0).
+ * @param {string} refId - Unique reference for this debit (idempotency key).
+ * @returns {Promise<{doc: Object|null, applied: boolean}>} Updated doc and whether debit was applied.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const debit = (orgId, units, refId) =>
+  BillingExtraBalanceRepository.debit(orgId, units, refId);
+
+/**
+ * @function expireOldEntries
+ * @description Sweep expired topup entries for an organization and push
+ *              corresponding expiration ledger entries to reduce the balance.
+ *              Idempotent: re-running does not create duplicate expiration entries.
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @returns {Promise<number>} Number of expiration entries added.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const expireOldEntries = (orgId) =>
+  BillingExtraBalanceRepository.addExpirationEntries(orgId, new Date());
+
+/**
+ * @function refundPartial
+ * @description Proportionally refund meter units when a pack purchase is partially refunded.
+ *              Formula: refundUnits = round((amountRefundedCents / 100) / pack.priceUsd * pack.meterUnits)
+ *              Pushes a negative 'refund' ledger entry. The balance may go negative if the
+ *              original units were already consumed — this is the correct economic reflection
+ *              (the debt persists until the next creditPack replenishes it).
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {string} stripeSessionId - Stripe session ID of the original purchase (to find the pack).
+ * @param {number} amountRefundedCents - Amount refunded in cents (integer).
+ * @returns {Promise<{doc: Object, applied: boolean, refundUnits: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
+  // Find the topup ledger entry for this session to identify the pack
+  const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
+  const topupEntry = doc.ledger?.find(
+    (e) => e.kind === 'topup' && e.stripeSessionId === stripeSessionId,
+  );
+
+  if (!topupEntry) {
+    // No matching topup — nothing to refund
+    return { doc, applied: false, refundUnits: 0 };
+  }
+
+  // Find the pack config to compute proportion
+  const packs = config?.billing?.packs ?? [];
+  // Try to match by amount (meterUnits) since we don't store packId on the entry
+  const matchingPack = packs.find(
+    (p) => (p.meterUnits ?? p.computeUnits) === topupEntry.amount,
+  );
+
+  let refundUnits;
+  if (matchingPack && matchingPack.priceUsd && matchingPack.priceUsd > 0) {
+    const packUnits = matchingPack.meterUnits ?? matchingPack.computeUnits;
+    refundUnits = Math.round((amountRefundedCents / 100 / matchingPack.priceUsd) * packUnits);
+  } else {
+    // Fallback: proportional to topup amount (assume full refund if pack not found)
+    refundUnits = topupEntry.amount;
+  }
+
+  if (refundUnits <= 0) return { doc, applied: false, refundUnits: 0 };
+
+  const refundRefId = `refund-${stripeSessionId}-${amountRefundedCents}`;
+  const refundEntry = {
+    kind: 'refund',
+    amount: -refundUnits,
+    stripeSessionId,
+    refId: refundRefId,
+    at: new Date(),
+  };
+
+  // Atomic push with refId dedup — use repository via dynamic import to avoid circular
+  const { default: mongoose } = await import('mongoose');
+  const updatedDoc = await mongoose.model('BillingExtraBalance').findOneAndUpdate(
+    {
+      organization: orgId,
+      'ledger.refId': { $ne: refundRefId },
+    },
+    {
+      $push: { ledger: refundEntry },
+      $inc: { cachedBalance: -refundUnits },
+      $set: { cachedBalanceAt: new Date() },
+    },
+    { returnDocument: 'after' },
+  );
+
+  if (updatedDoc) return { doc: updatedDoc, applied: true, refundUnits };
+  return { doc, applied: false, refundUnits: 0 };
+};
+
+/**
+ * @function listLedger
+ * @description Return a paginated slice of the ledger for an organization.
+ *              Entries are returned in reverse chronological order (newest first).
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {Object} [options={}] - Pagination options.
+ * @param {number} [options.page=1] - 1-based page number.
+ * @param {number} [options.limit=20] - Entries per page.
+ * @returns {Promise<{entries: Object[], total: number, balance: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const listLedger = async (orgId, { page = 1, limit = 20 } = {}) => {
+  const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
+  const ledger = doc.ledger ?? [];
+  const total = ledger.length;
+
+  // Sort descending by at date
+  const sorted = [...ledger].sort((a, b) => new Date(b.at) - new Date(a.at));
+  const start = (page - 1) * limit;
+  const entries = sorted.slice(start, start + limit);
+
+  return { entries, total, balance: doc.cachedBalance ?? 0 };
+};
+
+export default {
+  creditPack,
+  debit,
+  expireOldEntries,
+  refundPartial,
+  listLedger,
+};

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -86,49 +86,43 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
     return { doc, applied: false, refundUnits: 0 };
   }
 
-  // Find the pack config to compute proportion
+  // Find the pack config to compute proportion.
+  // Ambiguity guard: if 0 or >1 packs share the same meterUnits, fall back to
+  // applied=false rather than using a wrong priceUsd.
+  // TODO PR-N3: webhook handler will pass packId from session metadata, removing the need for this heuristic.
   const packs = config?.billing?.packs ?? [];
-  // Try to match by amount (meterUnits) since we don't store packId on the entry
-  const matchingPack = packs.find(
+  const matchingPacks = packs.filter(
     (p) => (p.meterUnits ?? p.computeUnits) === topupEntry.amount,
   );
 
+  if (matchingPacks.length !== 1) {
+    // Ambiguous or unknown pack — cannot compute proportional refund safely.
+    return { doc, applied: false, reason: 'ambiguous_pack_match', refundUnits: 0 };
+  }
+
+  const matchingPack = matchingPacks[0];
   let refundUnits;
-  if (matchingPack && matchingPack.priceUsd && matchingPack.priceUsd > 0) {
+  if (matchingPack.priceUsd && matchingPack.priceUsd > 0) {
     const packUnits = matchingPack.meterUnits ?? matchingPack.computeUnits;
     refundUnits = Math.round((amountRefundedCents / 100 / matchingPack.priceUsd) * packUnits);
   } else {
-    // Fallback: proportional to topup amount (assume full refund if pack not found)
+    // Fallback: proportional to topup amount (assume full refund if no priceUsd)
     refundUnits = topupEntry.amount;
   }
 
   if (refundUnits <= 0) return { doc, applied: false, refundUnits: 0 };
 
   const refundRefId = `refund-${stripeSessionId}-${amountRefundedCents}`;
-  const refundEntry = {
-    kind: 'refund',
-    amount: -refundUnits,
-    stripeSessionId,
-    refId: refundRefId,
-    at: new Date(),
-  };
 
-  // Atomic push with refId dedup — use repository via dynamic import to avoid circular
-  const { default: mongoose } = await import('mongoose');
-  const updatedDoc = await mongoose.model('BillingExtraBalance').findOneAndUpdate(
-    {
-      organization: orgId,
-      'ledger.refId': { $ne: refundRefId },
-    },
-    {
-      $push: { ledger: refundEntry },
-      $inc: { cachedBalance: -refundUnits },
-      $set: { cachedBalanceAt: new Date() },
-    },
-    { returnDocument: 'after' },
+  // Delegate atomic write to repository — no mongoose import in service layer.
+  const { doc: updatedDoc, applied } = await BillingExtraBalanceRepository.refundPartial(
+    orgId,
+    stripeSessionId,
+    refundUnits,
+    refundRefId,
   );
 
-  if (updatedDoc) return { doc: updatedDoc, applied: true, refundUnits };
+  if (applied) return { doc: updatedDoc, applied: true, refundUnits };
   return { doc, applied: false, refundUnits: 0 };
 };
 

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -77,6 +77,7 @@ const expireOldEntries = (orgId) =>
 const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
   // Find the topup ledger entry for this session to identify the pack
   const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
+  if (!doc) return { doc: null, applied: false, reason: 'invalid_org', refundUnits: 0 };
   const topupEntry = doc.ledger?.find(
     (e) => e.kind === 'topup' && e.stripeSessionId === stripeSessionId,
   );
@@ -112,7 +113,10 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
 
   if (refundUnits <= 0) return { doc, applied: false, refundUnits: 0 };
 
-  const refundRefId = `refund-${stripeSessionId}-${amountRefundedCents}`;
+  // Include topup entry _id to make the key unique across distinct partial refunds
+  // for the same session+amount. Two partial refunds of identical cents on different
+  // topup entries (or a retry after a failed refund) will produce different keys.
+  const refundRefId = `refund-${stripeSessionId}-${amountRefundedCents}-${topupEntry._id ?? Date.now()}`;
 
   // Delegate atomic write to repository — no mongoose import in service layer.
   const { doc: updatedDoc, applied } = await BillingExtraBalanceRepository.refundPartial(
@@ -140,6 +144,7 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const listLedger = async (orgId, { page = 1, limit = 20 } = {}) => {
   const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
+  if (!doc) return { entries: [], total: 0, balance: 0 };
   const ledger = doc.ledger ?? [];
   const total = ledger.length;
 

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -1,0 +1,120 @@
+/**
+ * Module dependencies
+ */
+import config from '../../../config/index.js';
+import BillingPlanService from './billing.plan.service.js';
+
+/**
+ * Floor charge per run — configurable via config.billing.meter.runBaseUnits.
+ * Guarantees every attributed event costs at least 1 unit regardless of costs.
+ */
+export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
+
+/**
+ * @function unitsFromCosts
+ * @description Convert a feature-keyed cost map (in USD) to meter units using
+ *              a frozen plan ratio version. Ratios define how many units per
+ *              dollar for each feature key.
+ *
+ *              Formula per key: floor(cost[key] * ratio[key] * dollarsToUnitRatio)
+ *              Total: max(sum(per-key units), METER_RUN_BASE)
+ *
+ * @param {Object} costs - Feature-keyed cost map: { featureKey: usdCost }.
+ * @param {string} planId - Logical plan identifier (e.g. "pro").
+ * @param {string} ratioVersion - Specific plan version for the ratio lookup.
+ * @returns {Promise<{totalUnits: number, breakdown: Object}>} Computed units and per-feature breakdown.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const unitsFromCosts = async (costs, planId, ratioVersion) => {
+  if (!costs || typeof costs !== 'object') {
+    return { totalUnits: METER_RUN_BASE, breakdown: {} };
+  }
+
+  const dollarsToUnitRatio = config?.billing?.meter?.dollarsToUnitRatio ?? 1000;
+
+  // Fetch the frozen plan snapshot for the given version
+  const plan = await BillingPlanService.getPlanByVersion(planId, ratioVersion);
+  const ratios = (plan && typeof plan.ratios === 'object' && !Array.isArray(plan.ratios)) ? plan.ratios : {};
+
+  const breakdown = {};
+  let rawTotal = 0;
+
+  for (const [key, cost] of Object.entries(costs)) {
+    if (typeof cost !== 'number' || !Number.isFinite(cost) || cost <= 0) continue;
+
+    const ratio = typeof ratios[key] === 'number' && ratios[key] >= 0 ? ratios[key] : 1;
+    const units = Math.floor(cost * ratio * dollarsToUnitRatio);
+
+    if (units > 0) {
+      breakdown[key] = units;
+      rawTotal += units;
+    }
+  }
+
+  const totalUnits = Math.max(rawTotal, METER_RUN_BASE);
+
+  return { totalUnits, breakdown };
+};
+
+/**
+ * @function attribute
+ * @description Attribute meter units from a History-like input to a Usage document
+ *              for the given organization. If the plan quota is exceeded, falls back
+ *              to BillingExtraService.debit. If extras are also exhausted, throws
+ *              MeterQuotaExhausted.
+ *
+ *              Idempotent on history._id — a second call with the same history object
+ *              is a no-op (replay protection via consumedHistoryIds).
+ *
+ * @param {Object} history - History-like object with _id, costs, planId, planVersion fields.
+ * @param {string} organizationId - The organization ObjectId (string).
+ * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const attribute = async (history, organizationId) => {
+  if (!config?.billing?.meterMode) {
+    return { applied: false, meterUsed: 0, extrasConsumed: 0 };
+  }
+
+  // Lazy imports to avoid circular deps — these services import billing.meter.service
+  const { default: BillingUsageService } = await import('./billing.usage.service.js');
+  const { default: BillingExtraService } = await import('./billing.extra.service.js');
+
+  const planId = history.planId ?? config?.billing?.plans?.[0] ?? 'pro';
+  const ratioVersion = history.planVersion ?? null;
+
+  let totalUnits = METER_RUN_BASE;
+  let breakdown = {};
+
+  if (history.costs && ratioVersion) {
+    ({ totalUnits, breakdown } = await unitsFromCosts(history.costs, planId, ratioVersion));
+  }
+
+  const idempotencyKey = history._id?.toString?.() ?? String(history._id);
+
+  const result = await BillingUsageService.incrementMeter(
+    organizationId,
+    totalUnits,
+    breakdown,
+    idempotencyKey,
+  );
+
+  if (!result.applied) {
+    // Replay — already attributed
+    return { applied: false, meterUsed: result.meterUsed ?? 0, extrasConsumed: 0 };
+  }
+
+  let extrasConsumed = 0;
+  if (result.extrasConsumed > 0) {
+    extrasConsumed = result.extrasConsumed;
+    await BillingExtraService.debit(organizationId, extrasConsumed, idempotencyKey);
+  }
+
+  return { applied: true, meterUsed: result.meterUsed, extrasConsumed };
+};
+
+export default {
+  unitsFromCosts,
+  attribute,
+  METER_RUN_BASE,
+};

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -106,8 +106,14 @@ const attribute = async (history, organizationId) => {
 
   let extrasConsumed = 0;
   if (result.extrasConsumed > 0) {
-    extrasConsumed = result.extrasConsumed;
-    await BillingExtraService.debit(organizationId, extrasConsumed, idempotencyKey);
+    const debitResult = await BillingExtraService.debit(organizationId, result.extrasConsumed, idempotencyKey);
+    if (debitResult.applied) {
+      extrasConsumed = result.extrasConsumed;
+    } else {
+      // Debit was not applied (balance exhausted or idempotency hit).
+      // Report extrasConsumed=0 so callers are not misled about charge application.
+      return { applied: true, meterUsed: result.meterUsed, extrasConsumed: 0, reason: 'extras_exhausted' };
+    }
   }
 
   return { applied: true, meterUsed: result.meterUsed, extrasConsumed };

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -60,8 +60,8 @@ const unitsFromCosts = async (costs, planId, ratioVersion) => {
  * @function attribute
  * @description Attribute meter units from a History-like input to a Usage document
  *              for the given organization. If the plan quota is exceeded, falls back
- *              to BillingExtraService.debit. If extras are also exhausted, throws
- *              MeterQuotaExhausted.
+ *              to BillingExtraService.debit (best-effort — does not throw when extras
+ *              are exhausted; extrasConsumed=0 is returned instead).
  *
  *              Idempotent on history._id — a second call with the same history object
  *              is a no-op (replay protection via consumedHistoryIds).

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -126,9 +126,42 @@ const invalidateCache = (planId) => {
   cache.delete(planId);
 };
 
+/**
+ * @desc Wrap bumpVersion with exponential backoff retry on E11000 duplicate key errors.
+ *       Two concurrent bumpVersion calls on the same planId can both derive the same
+ *       version number before either insert lands — the unique (planId, version) index
+ *       makes one winner and one loser (E11000). The loser retries with a fresh count.
+ *
+ * @param {string} planId - The logical plan identifier.
+ * @param {Object} fields - New plan fields (same as bumpVersion).
+ * @param {Object} [options={}] - Retry options.
+ * @param {number} [options.maxAttempts=3] - Maximum number of attempts (including the first).
+ * @returns {Promise<Object>} The newly created BillingPlan document.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) => {
+  const backoffMs = [100, 300, 900];
+  let lastErr;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await bumpVersion(planId, fields);
+    } catch (err) {
+      const isE11000 = err.code === 11000 || (err.message && err.message.includes('E11000'));
+      if (!isE11000 || attempt === maxAttempts - 1) throw err;
+      lastErr = err;
+      const delay = backoffMs[attempt] ?? 900;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastErr;
+};
+
 export default {
   getActivePlan,
   getPlanByVersion,
   bumpVersion,
+  bumpVersionWithRetry,
   invalidateCache,
 };

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -140,6 +140,9 @@ const invalidateCache = (planId) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) => {
+  if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
+    throw new Error('maxAttempts must be a positive integer');
+  }
   const backoffMs = [100, 300, 900];
   let lastErr;
 

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -37,7 +37,7 @@ const isoWeekKey = (date) => {
  *
  * @param {string} orgId - The organization ObjectId (string).
  * @param {Date} periodStart - The start of the new billing period (used to derive newWeekKey).
- * @returns {Promise<Object>} The upserted usage document for the new week.
+ * @returns {Promise<Object|null>} The upserted usage document for the new week, or null when meter mode is off.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const resetWeek = async (orgId, periodStart) => {

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -3,6 +3,7 @@
  */
 import config from '../../../config/index.js';
 import BillingUsageRepository from '../repositories/billing.usage.repository.js';
+import BillingSubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import BillingPlanService from './billing.plan.service.js';
 
 /**
@@ -46,17 +47,8 @@ const resetWeek = async (orgId, periodStart) => {
   const newWeekKey = isoWeekKey(periodStart);
 
   // Step 1 — Archive any existing docs for this org that are NOT the new week key.
-  // This is a best-effort archive: documents without archivedAt are considered active.
-  // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — dynamic model access
-  const { default: mongoose } = await import('mongoose');
-  await mongoose.model('BillingUsage').updateMany(
-    {
-      organizationId: orgId,
-      weekKey: { $ne: newWeekKey },
-      archivedAt: { $exists: false },
-    },
-    { $set: { archivedAt: now } },
-  );
+  // Delegates to repository — no mongoose import in service layer.
+  await BillingUsageRepository.archiveOtherWeeks(orgId, newWeekKey, now);
 
   // Step 2 — Fetch the active plan to snapshot quota/planVersion.
   const planId = config?.billing?.plans?.[0] ?? 'pro';
@@ -75,25 +67,19 @@ const resetWeek = async (orgId, periodStart) => {
   if (newDoc) return newDoc; // Already exists — idempotent
 
   try {
-    return await mongoose.model('BillingUsage').findOneAndUpdate(
-      { organizationId: orgId, weekKey: newWeekKey },
-      {
-        $setOnInsert: {
-          organizationId: orgId,
-          weekKey: newWeekKey,
-          month: monthKey,
-          meterUsed: 0,
-          meterQuota,
-          planVersion,
-          meterBreakdown: {},
-          resetAt,
-          alertedAt80: null,
-          alertedAt100: null,
-          consumedHistoryIds: [],
-        },
-      },
-      { upsert: true, returnDocument: 'after', runValidators: false },
-    );
+    return await BillingUsageRepository.upsertWeekSnapshot(orgId, newWeekKey, {
+      organizationId: orgId,
+      weekKey: newWeekKey,
+      month: monthKey,
+      meterUsed: 0,
+      meterQuota,
+      planVersion,
+      meterBreakdown: {},
+      resetAt,
+      alertedAt80: null,
+      alertedAt100: null,
+      consumedHistoryIds: [],
+    });
   } catch (err) {
     if (err.code === 11000) {
       // Race: another pod already created this week's doc
@@ -115,19 +101,12 @@ const resetWeek = async (orgId, periodStart) => {
 const resetAllDue = async () => {
   if (!config?.billing?.meterMode) return { processed: 0, errors: 0 };
 
-  const { default: mongoose } = await import('mongoose');
-  const Subscription = mongoose.model('BillingSubscription');
   const now = new Date();
   const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
 
-  // Find subscriptions whose period started within the last week
-  const subs = await Subscription.find(
-    {
-      status: { $in: ['active', 'trialing'] },
-      currentPeriodStart: { $gte: oneWeekAgo, $lte: now },
-    },
-    { organizationId: 1, currentPeriodStart: 1 },
-  ).lean();
+  // Find subscriptions whose period started within the last week.
+  // TODO PR-N5: replace window query with lastResetAt field for scheduler-delay resilience.
+  const subs = await BillingSubscriptionRepository.findAllDueForReset(oneWeekAgo, now);
 
   let processed = 0;
   let errors = 0;

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -1,0 +1,152 @@
+/**
+ * Module dependencies
+ */
+import config from '../../../config/index.js';
+import BillingUsageRepository from '../repositories/billing.usage.repository.js';
+import BillingPlanService from './billing.plan.service.js';
+
+/**
+ * Compute the ISO week key (YYYY-Www) for a given date.
+ * ISO 8601: week starts on Monday; week 1 contains the first Thursday.
+ * @param {Date} date - The date to compute the week key for.
+ * @returns {string} The week key in YYYY-Www format (e.g. "2026-W18").
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const isoWeekKey = (date) => {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // Move to the nearest Thursday (ISO week definition anchor)
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+};
+
+/**
+ * @function resetWeek
+ * @description Atomic archive-then-upsert pattern for weekly meter reset.
+ *              1. Archives the old week document (sets archivedAt = now).
+ *              2. Upserts a new week document with snapshot quota/planVersion.
+ *              Both operations are idempotent — re-running for the same periodStart
+ *              is safe: if the old doc is already archived and the new doc exists,
+ *              both operations are no-ops.
+ *
+ *              Race: if resetWeek and incrementMeter race on the same weekKey,
+ *              incrementMeter uses $ne on consumedHistoryIds so a duplicate upsert
+ *              will hit the 11000 path in incrementMeter's retry branch.
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {Date} periodStart - The start of the new billing period (used to derive newWeekKey).
+ * @returns {Promise<Object>} The upserted usage document for the new week.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const resetWeek = async (orgId, periodStart) => {
+  if (!config?.billing?.meterMode) return null;
+
+  const now = new Date();
+  const newWeekKey = isoWeekKey(periodStart);
+
+  // Step 1 — Archive any existing docs for this org that are NOT the new week key.
+  // This is a best-effort archive: documents without archivedAt are considered active.
+  // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — dynamic model access
+  const { default: mongoose } = await import('mongoose');
+  await mongoose.model('BillingUsage').updateMany(
+    {
+      organizationId: orgId,
+      weekKey: { $ne: newWeekKey },
+      archivedAt: { $exists: false },
+    },
+    { $set: { archivedAt: now } },
+  );
+
+  // Step 2 — Fetch the active plan to snapshot quota/planVersion.
+  const planId = config?.billing?.plans?.[0] ?? 'pro';
+  const activePlan = await BillingPlanService.getActivePlan(planId);
+  const meterQuota = activePlan?.meterQuota ?? 0;
+  const planVersion = activePlan?.version ?? null;
+
+  // Compute resetAt = start of next week (7 days after periodStart)
+  const resetAt = new Date(periodStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  // Month key for the new week (YYYY-MM of periodStart)
+  const monthKey = `${periodStart.getUTCFullYear()}-${String(periodStart.getUTCMonth() + 1).padStart(2, '0')}`;
+
+  // Step 3 — Upsert the new week document with snapshot fields.
+  const newDoc = await BillingUsageRepository.findByWeek(orgId, newWeekKey);
+  if (newDoc) return newDoc; // Already exists — idempotent
+
+  try {
+    return await mongoose.model('BillingUsage').findOneAndUpdate(
+      { organizationId: orgId, weekKey: newWeekKey },
+      {
+        $setOnInsert: {
+          organizationId: orgId,
+          weekKey: newWeekKey,
+          month: monthKey,
+          meterUsed: 0,
+          meterQuota,
+          planVersion,
+          meterBreakdown: {},
+          resetAt,
+          alertedAt80: null,
+          alertedAt100: null,
+          consumedHistoryIds: [],
+        },
+      },
+      { upsert: true, returnDocument: 'after', runValidators: false },
+    );
+  } catch (err) {
+    if (err.code === 11000) {
+      // Race: another pod already created this week's doc
+      return BillingUsageRepository.findByWeek(orgId, newWeekKey);
+    }
+    throw err;
+  }
+};
+
+/**
+ * @function resetAllDue
+ * @description Iterate active subscriptions where current_period_start has crossed
+ *              a weekly boundary and call resetWeek for each.
+ *              Only runs when meterMode is enabled.
+ *
+ * @returns {Promise<{processed: number, errors: number}>} Summary of the sweep.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const resetAllDue = async () => {
+  if (!config?.billing?.meterMode) return { processed: 0, errors: 0 };
+
+  const { default: mongoose } = await import('mongoose');
+  const Subscription = mongoose.model('BillingSubscription');
+  const now = new Date();
+  const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // Find subscriptions whose period started within the last week
+  const subs = await Subscription.find(
+    {
+      status: { $in: ['active', 'trialing'] },
+      currentPeriodStart: { $gte: oneWeekAgo, $lte: now },
+    },
+    { organizationId: 1, currentPeriodStart: 1 },
+  ).lean();
+
+  let processed = 0;
+  let errors = 0;
+
+  for (const sub of subs) {
+    try {
+      await resetWeek(String(sub.organizationId), new Date(sub.currentPeriodStart));
+      processed += 1;
+    } catch (err) {
+      errors += 1;
+      console.error(`[billing.reset] resetWeek failed for org ${sub.organizationId}:`, err);
+    }
+  }
+
+  return { processed, errors };
+};
+
+export default {
+  resetWeek,
+  resetAllDue,
+  isoWeekKey,
+};

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -113,11 +113,11 @@ const resetAllDue = async () => {
 
   for (const sub of subs) {
     try {
-      await resetWeek(String(sub.organizationId), new Date(sub.currentPeriodStart));
+      await resetWeek(String(sub.organization), new Date(sub.currentPeriodStart));
       processed += 1;
     } catch (err) {
       errors += 1;
-      console.error(`[billing.reset] resetWeek failed for org ${sub.organizationId}:`, err);
+      console.error(`[billing.reset] resetWeek failed for org ${sub.organization}:`, err);
     }
   }
 

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -1,7 +1,23 @@
 /**
  * Module dependencies
  */
+import config from '../../../config/index.js';
 import UsageRepository from '../repositories/billing.usage.repository.js';
+import BillingPlanService from './billing.plan.service.js';
+
+/**
+ * Billing events emitter — used for threshold crossing notifications.
+ * Lazy import to avoid circular dependency at module load time.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const getBillingEvents = async () => {
+  try {
+    const { default: billingEvents } = await import('../lib/events.js');
+    return billingEvents;
+  } catch {
+    return null;
+  }
+};
 
 /**
  * Compute the current month string in YYYY-MM format.
@@ -12,6 +28,23 @@ const currentMonth = () => {
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, '0');
   return `${year}-${month}`;
+};
+
+/**
+ * @function currentWeekKey
+ * @description Compute the current ISO 8601 week key in YYYY-Www format.
+ *              ISO week starts on Monday; week 1 contains the first Thursday.
+ * @returns {string} e.g. '2026-W18'
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const currentWeekKey = () => {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  // Shift to nearest Thursday (ISO anchor)
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
 };
 
 /**
@@ -41,8 +74,158 @@ const get = async (organizationId) => {
  */
 const reset = (organizationId) => UsageRepository.reset(organizationId, currentMonth());
 
+/**
+ * @function incrementMeter
+ * @description Full meter attribution flow for a given organization.
+ *              1. Computes the current ISO weekKey.
+ *              2. Fetches the active plan snapshot (meterQuota + planVersion).
+ *              3. Calls repo.incrementMeter atomically with replay protection.
+ *              4. If quota is exceeded, overflows into extras balance.
+ *              5. Detects 80%/100% threshold crossings (emits meter.threshold_crossed event, once per cycle).
+ *
+ *              Returns applied=false when the idempotencyKey was already consumed (replay).
+ *
+ * @param {string} organizationId - The organization ObjectId (string).
+ * @param {number} units - Meter units to attribute.
+ * @param {Object} breakdown - Feature-keyed breakdown: { featureKey: units }.
+ * @param {string} idempotencyKey - Unique key for replay protection (usually history._id).
+ * @returns {Promise<{applied: boolean, meterUsed: number, meterQuota: number, extrasConsumed: number, alertCrossed: string|null}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) => {
+  if (!config?.billing?.meterMode) {
+    return { applied: false, meterUsed: 0, meterQuota: 0, extrasConsumed: 0, alertCrossed: null };
+  }
+
+  const weekKey = currentWeekKey();
+  const monthKey = currentMonth();
+
+  // Fetch active plan for quota snapshot
+  const planId = config?.billing?.plans?.[0] ?? 'pro';
+  const activePlan = await BillingPlanService.getActivePlan(planId);
+  const meterQuota = activePlan?.meterQuota ?? 0;
+  const planVersion = activePlan?.version ?? null;
+
+  // Compute reset date: start of next week from now
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const dayOfWeek = d.getUTCDay() || 7; // 1=Mon, 7=Sun
+  const daysUntilNextMonday = 8 - dayOfWeek;
+  const resetAt = new Date(d.getTime() + daysUntilNextMonday * 24 * 60 * 60 * 1000);
+
+  const baseSnapshot = { month: monthKey, meterQuota, planVersion, resetAt };
+
+  const updatedDoc = await UsageRepository.incrementMeter(
+    organizationId,
+    weekKey,
+    units,
+    breakdown,
+    idempotencyKey,
+    baseSnapshot,
+  );
+
+  if (!updatedDoc) {
+    // Replay — idempotencyKey already consumed
+    const existing = await UsageRepository.findByWeek(organizationId, weekKey);
+    return {
+      applied: false,
+      meterUsed: existing?.meterUsed ?? 0,
+      meterQuota: existing?.meterQuota ?? meterQuota,
+      extrasConsumed: 0,
+      alertCrossed: null,
+    };
+  }
+
+  const newMeterUsed = updatedDoc.meterUsed ?? 0;
+  const effectiveQuota = updatedDoc.meterQuota ?? meterQuota;
+
+  // Overflow detection: units consumed beyond the plan quota go to extras
+  let extrasConsumed = 0;
+  if (effectiveQuota > 0 && newMeterUsed > effectiveQuota) {
+    const previousUsed = newMeterUsed - units;
+    const overflowStart = Math.max(previousUsed, effectiveQuota);
+    extrasConsumed = newMeterUsed - overflowStart;
+  }
+
+  // Threshold detection — emit event at 80% and 100%, deduplicated per cycle
+  let alertCrossed = null;
+  const billingEvents = await getBillingEvents();
+
+  if (effectiveQuota > 0) {
+    const pct = newMeterUsed / effectiveQuota;
+
+    if (pct >= 1.0 && !updatedDoc.alertedAt100) {
+      alertCrossed = '100';
+      // Mark the threshold so we don't re-emit this cycle
+      try {
+        const { default: mongoose } = await import('mongoose');
+        await mongoose.model('BillingUsage').updateOne(
+          { _id: updatedDoc._id, alertedAt100: null },
+          { $set: { alertedAt100: new Date() } },
+        );
+      } catch {
+        // Best-effort
+      }
+      if (billingEvents) {
+        billingEvents.emit('meter.threshold_crossed', {
+          organizationId,
+          weekKey,
+          threshold: 100,
+          meterUsed: newMeterUsed,
+          meterQuota: effectiveQuota,
+        });
+      }
+    } else if (pct >= 0.8 && !updatedDoc.alertedAt80) {
+      alertCrossed = '80';
+      try {
+        const { default: mongoose } = await import('mongoose');
+        await mongoose.model('BillingUsage').updateOne(
+          { _id: updatedDoc._id, alertedAt80: null },
+          { $set: { alertedAt80: new Date() } },
+        );
+      } catch {
+        // Best-effort
+      }
+      if (billingEvents) {
+        billingEvents.emit('meter.threshold_crossed', {
+          organizationId,
+          weekKey,
+          threshold: 80,
+          meterUsed: newMeterUsed,
+          meterQuota: effectiveQuota,
+        });
+      }
+    }
+  }
+
+  return {
+    applied: true,
+    meterUsed: newMeterUsed,
+    meterQuota: effectiveQuota,
+    extrasConsumed,
+    alertCrossed,
+  };
+};
+
+/**
+ * @function getMeter
+ * @description Return the current week's meter document for an organization,
+ *              including the plan quota snapshot.
+ * @param {string} organizationId - The organization ObjectId (string).
+ * @returns {Promise<Object|null>} The usage document with meter fields, or null.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const getMeter = async (organizationId) => {
+  if (!config?.billing?.meterMode) return null;
+  const weekKey = currentWeekKey();
+  return UsageRepository.findByWeek(organizationId, weekKey);
+};
+
 export default {
   increment,
   get,
   reset,
+  currentWeekKey,
+  incrementMeter,
+  getMeter,
 };

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -6,8 +6,12 @@ import UsageRepository from '../repositories/billing.usage.repository.js';
 import BillingPlanService from './billing.plan.service.js';
 
 /**
- * Billing events emitter — used for threshold crossing notifications.
- * Lazy import to avoid circular dependency at module load time.
+ * @function getBillingEvents
+ * @description Lazily import the billing events emitter to avoid circular dependency
+ *              at module load time. Returns the emitter instance, or null if the
+ *              import fails (e.g. events module not available in test env).
+ * @async
+ * @returns {Promise<import('node:events').EventEmitter|null>} The billing event emitter, or null.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const getBillingEvents = async () => {

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -156,13 +156,9 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
 
     if (pct >= 1.0 && !updatedDoc.alertedAt100) {
       alertCrossed = '100';
-      // Mark the threshold so we don't re-emit this cycle
+      // Mark the threshold so we don't re-emit this cycle (best-effort via repository)
       try {
-        const { default: mongoose } = await import('mongoose');
-        await mongoose.model('BillingUsage').updateOne(
-          { _id: updatedDoc._id, alertedAt100: null },
-          { $set: { alertedAt100: new Date() } },
-        );
+        await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt100');
       } catch {
         // Best-effort
       }
@@ -178,11 +174,7 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
     } else if (pct >= 0.8 && !updatedDoc.alertedAt80) {
       alertCrossed = '80';
       try {
-        const { default: mongoose } = await import('mongoose');
-        await mongoose.model('BillingUsage').updateOne(
-          { _id: updatedDoc._id, alertedAt80: null },
-          { $set: { alertedAt80: new Date() } },
-        );
+        await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt80');
       } catch {
         // Best-effort
       }

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -159,37 +159,46 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
     const pct = newMeterUsed / effectiveQuota;
 
     if (pct >= 1.0 && !updatedDoc.alertedAt100) {
-      alertCrossed = '100';
-      // Mark the threshold so we don't re-emit this cycle (best-effort via repository)
+      // Only emit when we win the dedup race (modifiedCount > 0).
+      // If another pod already set alertedAt100, markThreshold returns modifiedCount=0 — skip emit.
+      let marked = false;
       try {
-        await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt100');
+        const markResult = await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt100');
+        marked = markResult?.modifiedCount > 0;
       } catch {
-        // Best-effort
+        // Best-effort — if mark fails, skip emit to avoid double-fire
       }
-      if (billingEvents) {
-        billingEvents.emit('meter.threshold_crossed', {
-          organizationId,
-          weekKey,
-          threshold: 100,
-          meterUsed: newMeterUsed,
-          meterQuota: effectiveQuota,
-        });
+      if (marked) {
+        alertCrossed = '100';
+        if (billingEvents) {
+          billingEvents.emit('meter.threshold_crossed', {
+            organizationId,
+            weekKey,
+            threshold: 100,
+            meterUsed: newMeterUsed,
+            meterQuota: effectiveQuota,
+          });
+        }
       }
     } else if (pct >= 0.8 && !updatedDoc.alertedAt80) {
-      alertCrossed = '80';
+      let marked = false;
       try {
-        await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt80');
+        const markResult = await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt80');
+        marked = markResult?.modifiedCount > 0;
       } catch {
-        // Best-effort
+        // Best-effort — if mark fails, skip emit to avoid double-fire
       }
-      if (billingEvents) {
-        billingEvents.emit('meter.threshold_crossed', {
-          organizationId,
-          weekKey,
-          threshold: 80,
-          meterUsed: newMeterUsed,
-          meterQuota: effectiveQuota,
-        });
+      if (marked) {
+        alertCrossed = '80';
+        if (billingEvents) {
+          billingEvents.emit('meter.threshold_crossed', {
+            organizationId,
+            weekKey,
+            threshold: 80,
+            meterUsed: newMeterUsed,
+            meterQuota: effectiveQuota,
+          });
+        }
       }
     }
   }

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -40,6 +40,7 @@ describe('BillingExtraService unit tests:', () => {
       debit: jest.fn(),
       addExpirationEntries: jest.fn(),
       getOrCreate: jest.fn(),
+      refundPartial: jest.fn(),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -219,19 +220,20 @@ describe('BillingExtraService unit tests:', () => {
       };
       const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 500000 });
       mockRepository.getOrCreate.mockResolvedValue(doc);
-
-      // Mock mongoose model for the findOneAndUpdate in refundPartial
-      const mockMongoose = {
-        model: jest.fn().mockReturnValue({
-          findOneAndUpdate: jest.fn().mockResolvedValue(makeDoc({ cachedBalance: 0 })),
-        }),
-      };
-      jest.unstable_mockModule('mongoose', () => ({ default: mockMongoose }));
+      const updatedDoc = makeDoc({ cachedBalance: 0 });
+      mockRepository.refundPartial.mockResolvedValue({ doc: updatedDoc, applied: true });
 
       const result = await BillingExtraService.refundPartial(orgId, 'cs_refund_test', 4900);
 
       // $49 / $49 * 500000 = 500000 units
       expect(result.refundUnits).toBe(500000);
+      expect(result.applied).toBe(true);
+      expect(mockRepository.refundPartial).toHaveBeenCalledWith(
+        orgId,
+        'cs_refund_test',
+        500000,
+        'refund-cs_refund_test-4900',
+      );
     });
 
     test('refundPartial with already-consumed balance still applies (economic reflection)', async () => {
@@ -244,17 +246,33 @@ describe('BillingExtraService unit tests:', () => {
       };
       const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 0 });
       mockRepository.getOrCreate.mockResolvedValue(doc);
-
-      const mockMongoose = {
-        model: jest.fn().mockReturnValue({
-          findOneAndUpdate: jest.fn().mockResolvedValue(makeDoc({ cachedBalance: -500000 })),
-        }),
-      };
-      jest.unstable_mockModule('mongoose', () => ({ default: mockMongoose }));
+      mockRepository.refundPartial.mockResolvedValue({ doc: makeDoc({ cachedBalance: -500000 }), applied: true });
 
       const result = await BillingExtraService.refundPartial(orgId, 'cs_consumed', 4900);
       // Applied (even with negative resulting balance — correct economic reflection)
       expect(result.applied).toBe(true);
+    });
+
+    test('should return applied=false with reason ambiguous_pack_match when multiple packs have same meterUnits', async () => {
+      // Simulate two packs with identical meterUnits
+      mockConfig.billing.packs = [
+        { packId: 'pack_a', meterUnits: 500000, priceUsd: 49 },
+        { packId: 'pack_b', meterUnits: 500000, priceUsd: 39 }, // promo duplicate
+      ];
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439ccc',
+        kind: 'topup',
+        amount: 500000,
+        stripeSessionId: 'cs_ambiguous',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 500000 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_ambiguous', 4900);
+      expect(result.applied).toBe(false);
+      expect(result.reason).toBe('ambiguous_pack_match');
+      expect(result.refundUnits).toBe(0);
+      expect(mockRepository.refundPartial).not.toHaveBeenCalled();
     });
   });
 });

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -1,0 +1,260 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.extra.service.js
+ */
+describe('BillingExtraService unit tests:', () => {
+  let BillingExtraService;
+  let mockRepository;
+  let mockConfig;
+
+  const orgId = '507f1f77bcf86cd799439011';
+
+  const makeDoc = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439099',
+    organization: orgId,
+    ledger: [],
+    cachedBalance: 0,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['pro'],
+        packs: [
+          { packId: 'pack_500k', meterUnits: 500000, priceUsd: 49, stripePriceId: 'price_abc' },
+          { packId: 'pack_2m', meterUnits: 2000000, priceUsd: 149, stripePriceId: 'price_def', expiryDays: 365 },
+        ],
+      },
+    };
+
+    mockRepository = {
+      creditPack: jest.fn(),
+      debit: jest.fn(),
+      addExpirationEntries: jest.fn(),
+      getOrCreate: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.extraBalance.repository.js', () => ({
+      default: mockRepository,
+    }));
+
+    const mod = await import('../services/billing.extra.service.js');
+    BillingExtraService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('creditPack', () => {
+    test('should delegate to repository with correct amount', async () => {
+      const doc = makeDoc({ cachedBalance: 500000 });
+      mockRepository.creditPack.mockResolvedValue({ doc, applied: true });
+
+      const result = await BillingExtraService.creditPack(orgId, 'pack_500k', 'cs_abc');
+
+      expect(mockRepository.creditPack).toHaveBeenCalledWith(orgId, 500000, 'cs_abc', null);
+      expect(result.applied).toBe(true);
+    });
+
+    test('should compute expiresAt when pack has expiryDays', async () => {
+      const doc = makeDoc({ cachedBalance: 2000000 });
+      mockRepository.creditPack.mockResolvedValue({ doc, applied: true });
+
+      const before = Date.now();
+      await BillingExtraService.creditPack(orgId, 'pack_2m', 'cs_def');
+      const after = Date.now();
+
+      const [, , , expiresAt] = mockRepository.creditPack.mock.calls[0];
+      expect(expiresAt).toBeInstanceOf(Date);
+      const ms = expiresAt.getTime();
+      expect(ms).toBeGreaterThanOrEqual(before + 365 * 24 * 60 * 60 * 1000 - 100);
+      expect(ms).toBeLessThanOrEqual(after + 365 * 24 * 60 * 60 * 1000 + 100);
+    });
+
+    test('should return applied=false on idempotent re-call (same stripeSessionId)', async () => {
+      const doc = makeDoc({ cachedBalance: 500000 });
+      mockRepository.creditPack.mockResolvedValue({ doc, applied: false });
+
+      const result = await BillingExtraService.creditPack(orgId, 'pack_500k', 'cs_abc_duplicate');
+      expect(result.applied).toBe(false);
+    });
+
+    test('should throw when packId is unknown', async () => {
+      await expect(BillingExtraService.creditPack(orgId, 'pack_unknown', 'cs_abc')).rejects.toThrow('Pack not found');
+    });
+  });
+
+  describe('debit', () => {
+    test('should delegate to repository', async () => {
+      const doc = makeDoc({ cachedBalance: 400000 });
+      mockRepository.debit.mockResolvedValue({ doc, applied: true });
+
+      const result = await BillingExtraService.debit(orgId, 100000, 'ref_hist_123');
+
+      expect(mockRepository.debit).toHaveBeenCalledWith(orgId, 100000, 'ref_hist_123');
+      expect(result.applied).toBe(true);
+    });
+
+    test('should return applied=false when balance is insufficient', async () => {
+      mockRepository.debit.mockResolvedValue({ doc: null, applied: false });
+
+      const result = await BillingExtraService.debit(orgId, 999999999, 'ref_overflow');
+      expect(result.applied).toBe(false);
+    });
+
+    test('debit same refId twice → second is no-op', async () => {
+      const doc = makeDoc({ cachedBalance: 400000 });
+      mockRepository.debit
+        .mockResolvedValueOnce({ doc, applied: true })
+        .mockResolvedValueOnce({ doc: null, applied: false });
+
+      const r1 = await BillingExtraService.debit(orgId, 100, 'ref_same');
+      const r2 = await BillingExtraService.debit(orgId, 100, 'ref_same');
+
+      expect(r1.applied).toBe(true);
+      expect(r2.applied).toBe(false);
+    });
+  });
+
+  describe('expireOldEntries', () => {
+    test('should delegate to repository with current date', async () => {
+      mockRepository.addExpirationEntries.mockResolvedValue(2);
+
+      const result = await BillingExtraService.expireOldEntries(orgId);
+
+      expect(mockRepository.addExpirationEntries).toHaveBeenCalledWith(orgId, expect.any(Date));
+      expect(result).toBe(2);
+    });
+
+    test('should return 0 when nothing expired', async () => {
+      mockRepository.addExpirationEntries.mockResolvedValue(0);
+
+      const result = await BillingExtraService.expireOldEntries(orgId);
+      expect(result).toBe(0);
+    });
+
+    test('expireOldEntries is idempotent — re-run returns 0 the second time', async () => {
+      mockRepository.addExpirationEntries
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0);
+
+      const r1 = await BillingExtraService.expireOldEntries(orgId);
+      const r2 = await BillingExtraService.expireOldEntries(orgId);
+
+      expect(r1).toBe(1);
+      expect(r2).toBe(0); // idempotent
+    });
+  });
+
+  describe('listLedger', () => {
+    test('should return paginated ledger entries in reverse chronological order', async () => {
+      const t1 = new Date('2026-05-01T10:00:00Z');
+      const t2 = new Date('2026-05-02T10:00:00Z');
+      const doc = makeDoc({
+        cachedBalance: 900000,
+        ledger: [
+          { kind: 'topup', amount: 500000, at: t1 },
+          { kind: 'topup', amount: 500000, at: t2 },
+          { kind: 'debit', amount: -100000, at: new Date('2026-05-03T10:00:00Z') },
+        ],
+      });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const result = await BillingExtraService.listLedger(orgId, { page: 1, limit: 2 });
+
+      expect(result.total).toBe(3);
+      expect(result.balance).toBe(900000);
+      expect(result.entries).toHaveLength(2);
+      // Newest first
+      expect(result.entries[0].kind).toBe('debit');
+    });
+
+    test('should return second page correctly', async () => {
+      const doc = makeDoc({
+        cachedBalance: 0,
+        ledger: [
+          { kind: 'topup', amount: 100, at: new Date('2026-01-01') },
+          { kind: 'topup', amount: 100, at: new Date('2026-02-01') },
+          { kind: 'topup', amount: 100, at: new Date('2026-03-01') },
+        ],
+      });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const result = await BillingExtraService.listLedger(orgId, { page: 2, limit: 2 });
+
+      expect(result.entries).toHaveLength(1);
+    });
+  });
+
+  describe('refundPartial', () => {
+    test('should return applied=false when no matching topup entry found', async () => {
+      const doc = makeDoc({ ledger: [] });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_notfound', 4900);
+      expect(result.applied).toBe(false);
+      expect(result.refundUnits).toBe(0);
+    });
+
+    test('should compute proportional refund units when pack is found', async () => {
+      // pack_500k: 500000 units, $49 price — full refund of $49 = 500000 units back
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439aaa',
+        kind: 'topup',
+        amount: 500000,
+        stripeSessionId: 'cs_refund_test',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 500000 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      // Mock mongoose model for the findOneAndUpdate in refundPartial
+      const mockMongoose = {
+        model: jest.fn().mockReturnValue({
+          findOneAndUpdate: jest.fn().mockResolvedValue(makeDoc({ cachedBalance: 0 })),
+        }),
+      };
+      jest.unstable_mockModule('mongoose', () => ({ default: mockMongoose }));
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_refund_test', 4900);
+
+      // $49 / $49 * 500000 = 500000 units
+      expect(result.refundUnits).toBe(500000);
+    });
+
+    test('refundPartial with already-consumed balance still applies (economic reflection)', async () => {
+      // The balance is 0 (units already consumed) but a refund should still be recorded
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439bbb',
+        kind: 'topup',
+        amount: 500000,
+        stripeSessionId: 'cs_consumed',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 0 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const mockMongoose = {
+        model: jest.fn().mockReturnValue({
+          findOneAndUpdate: jest.fn().mockResolvedValue(makeDoc({ cachedBalance: -500000 })),
+        }),
+      };
+      jest.unstable_mockModule('mongoose', () => ({ default: mockMongoose }));
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_consumed', 4900);
+      // Applied (even with negative resulting balance — correct economic reflection)
+      expect(result.applied).toBe(true);
+    });
+  });
+});

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -13,6 +13,10 @@ describe('BillingExtraService unit tests:', () => {
 
   const orgId = '507f1f77bcf86cd799439011';
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub document.
+   * @returns {Object} A stub ExtraBalance document.
+   */
   const makeDoc = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439099',
     organization: orgId,
@@ -161,6 +165,13 @@ describe('BillingExtraService unit tests:', () => {
   });
 
   describe('listLedger', () => {
+    test('should return empty result when getOrCreate returns null (malformed orgId)', async () => {
+      mockRepository.getOrCreate.mockResolvedValue(null);
+
+      const result = await BillingExtraService.listLedger('bad-org-id');
+      expect(result).toEqual({ entries: [], total: 0, balance: 0 });
+    });
+
     test('should return paginated ledger entries in reverse chronological order', async () => {
       const t1 = new Date('2026-05-01T10:00:00Z');
       const t2 = new Date('2026-05-02T10:00:00Z');
@@ -228,11 +239,12 @@ describe('BillingExtraService unit tests:', () => {
       // $49 / $49 * 500000 = 500000 units
       expect(result.refundUnits).toBe(500000);
       expect(result.applied).toBe(true);
+      // Key includes topupEntry._id to prevent collision across partial refunds of same amount
       expect(mockRepository.refundPartial).toHaveBeenCalledWith(
         orgId,
         'cs_refund_test',
         500000,
-        'refund-cs_refund_test-4900',
+        'refund-cs_refund_test-4900-507f1f77bcf86cd799439aaa',
       );
     });
 
@@ -251,6 +263,15 @@ describe('BillingExtraService unit tests:', () => {
       const result = await BillingExtraService.refundPartial(orgId, 'cs_consumed', 4900);
       // Applied (even with negative resulting balance — correct economic reflection)
       expect(result.applied).toBe(true);
+    });
+
+    test('should return invalid_org when getOrCreate returns null (malformed orgId)', async () => {
+      mockRepository.getOrCreate.mockResolvedValue(null);
+
+      const result = await BillingExtraService.refundPartial('bad-org-id', 'cs_test', 4900);
+      expect(result.applied).toBe(false);
+      expect(result.reason).toBe('invalid_org');
+      expect(result.refundUnits).toBe(0);
     });
 
     test('should return applied=false with reason ambiguous_pack_match when multiple packs have same meterUnits', async () => {

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -1,0 +1,346 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.extraBalance.repository.js and billing.extraBalance.schema.js
+ */
+describe('BillingExtraBalance unit tests:', () => {
+  // ─── Schema tests ──────────────────────────────────────────────────────────
+
+  describe('Schema validation', () => {
+    let schema;
+
+    beforeEach(async () => {
+      const mod = await import('../models/billing.extraBalance.schema.js');
+      schema = mod.default;
+    });
+
+    describe('BillingExtraBalance', () => {
+      test('should be valid with minimal required fields', () => {
+        const result = schema.BillingExtraBalance.safeParse({
+          organization: '507f1f77bcf86cd799439011',
+        });
+        expect(result.error).toBeFalsy();
+        expect(result.data.cachedBalance).toBe(0);
+        expect(result.data.ledger).toEqual([]);
+      });
+
+      test('should reject invalid organizationId', () => {
+        const result = schema.BillingExtraBalance.safeParse({
+          organization: 'not-valid',
+        });
+        expect(result.error).toBeDefined();
+      });
+
+      test('should accept a valid ledger entry', () => {
+        const result = schema.BillingExtraBalance.safeParse({
+          organization: '507f1f77bcf86cd799439011',
+          ledger: [
+            {
+              kind: 'topup',
+              amount: 500000,
+              stripeSessionId: 'cs_test_abc123',
+            },
+          ],
+          cachedBalance: 500000,
+        });
+        expect(result.error).toBeFalsy();
+        expect(result.data.ledger[0].kind).toBe('topup');
+        expect(result.data.ledger[0].amount).toBe(500000);
+      });
+
+      test('should reject invalid ledger kind', () => {
+        const result = schema.BillingExtraBalance.safeParse({
+          organization: '507f1f77bcf86cd799439011',
+          ledger: [{ kind: 'invalid', amount: 100 }],
+        });
+        expect(result.error).toBeDefined();
+      });
+
+      test('should accept all valid ledger kinds', () => {
+        for (const kind of ['topup', 'debit', 'refund', 'expiration', 'adjustment']) {
+          const result = schema.LedgerEntry.safeParse({ kind, amount: 100 });
+          expect(result.error).toBeFalsy();
+        }
+      });
+
+      test('should accept negative amount for debit kind', () => {
+        const result = schema.LedgerEntry.safeParse({ kind: 'debit', amount: -500 });
+        expect(result.error).toBeFalsy();
+        expect(result.data.amount).toBe(-500);
+      });
+    });
+
+    describe('ExtraBalanceCreditPack', () => {
+      test('should be valid with required fields', () => {
+        const result = schema.ExtraBalanceCreditPack.safeParse({
+          orgId: '507f1f77bcf86cd799439011',
+          amount: 500000,
+          stripeSessionId: 'cs_test_abc',
+        });
+        expect(result.error).toBeFalsy();
+      });
+
+      test('should reject amount of 0', () => {
+        const result = schema.ExtraBalanceCreditPack.safeParse({
+          orgId: '507f1f77bcf86cd799439011',
+          amount: 0,
+          stripeSessionId: 'cs_test_abc',
+        });
+        expect(result.error).toBeDefined();
+      });
+
+      test('should accept optional expiresAt', () => {
+        const result = schema.ExtraBalanceCreditPack.safeParse({
+          orgId: '507f1f77bcf86cd799439011',
+          amount: 500000,
+          stripeSessionId: 'cs_test_abc',
+          expiresAt: '2027-01-01T00:00:00Z',
+        });
+        expect(result.error).toBeFalsy();
+        expect(result.data.expiresAt).toBeInstanceOf(Date);
+      });
+    });
+
+    describe('ExtraBalanceDebit', () => {
+      test('should be valid with required fields', () => {
+        const result = schema.ExtraBalanceDebit.safeParse({
+          orgId: '507f1f77bcf86cd799439011',
+          amount: 1000,
+          refId: 'history_abc123',
+        });
+        expect(result.error).toBeFalsy();
+      });
+
+      test('should reject empty refId', () => {
+        const result = schema.ExtraBalanceDebit.safeParse({
+          orgId: '507f1f77bcf86cd799439011',
+          amount: 1000,
+          refId: '',
+        });
+        expect(result.error).toBeDefined();
+      });
+    });
+  });
+
+  // ─── Repository tests ──────────────────────────────────────────────────────
+
+  describe('Repository', () => {
+    let BillingExtraBalanceRepository;
+    let mockModel;
+
+    const orgId = '507f1f77bcf86cd799439011';
+    const makeDoc = (overrides = {}) => ({
+      _id: '507f1f77bcf86cd799439099',
+      organization: orgId,
+      ledger: [],
+      cachedBalance: 0,
+      cachedBalanceAt: new Date(),
+      ...overrides,
+    });
+
+    beforeEach(async () => {
+      jest.resetModules();
+
+      mockModel = {
+        findOne: jest.fn(),
+        findOneAndUpdate: jest.fn(),
+        updateOne: jest.fn(),
+        updateMany: jest.fn(),
+      };
+
+      jest.unstable_mockModule('mongoose', () => ({
+        default: {
+          model: jest.fn(() => mockModel),
+          Types: {
+            ObjectId: {
+              isValid: jest.fn(() => true),
+            },
+          },
+        },
+      }));
+
+      const mod = await import('../repositories/billing.extraBalance.repository.js');
+      BillingExtraBalanceRepository = mod.default;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('getOrCreate', () => {
+      test('should call findOneAndUpdate with upsert', async () => {
+        const doc = makeDoc();
+        mockModel.findOneAndUpdate.mockResolvedValue(doc);
+
+        const result = await BillingExtraBalanceRepository.getOrCreate(orgId);
+
+        expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+          { organization: orgId },
+          expect.objectContaining({ $setOnInsert: expect.any(Object) }),
+          expect.objectContaining({ upsert: true, returnDocument: 'after' }),
+        );
+        expect(result).toBe(doc);
+      });
+    });
+
+    describe('creditPack — idempotency', () => {
+      test('should apply credit when stripeSessionId is new', async () => {
+        const updatedDoc = makeDoc({ cachedBalance: 500000, ledger: [{ kind: 'topup', amount: 500000, stripeSessionId: 'cs_abc' }] });
+        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+        const result = await BillingExtraBalanceRepository.creditPack(orgId, 500000, 'cs_abc', null);
+
+        expect(result.applied).toBe(true);
+        expect(result.doc.cachedBalance).toBe(500000);
+      });
+
+      test('should return applied=false when stripeSessionId already exists (idempotency)', async () => {
+        // First findOneAndUpdate returns null (filter excluded — session already present)
+        mockModel.findOneAndUpdate.mockResolvedValue(null);
+        // creditPack fallback uses findOne().lean() to fetch existing doc
+        const existingDoc = makeDoc({ cachedBalance: 500000, ledger: [{ kind: 'topup', amount: 500000, stripeSessionId: 'cs_abc' }] });
+        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(existingDoc) });
+
+        const result = await BillingExtraBalanceRepository.creditPack(orgId, 500000, 'cs_abc', null);
+
+        expect(result.applied).toBe(false);
+        expect(result.doc).toBe(existingDoc);
+      });
+
+      test('should set expiresAt on topup entry when provided', async () => {
+        const expiresAt = new Date('2027-01-01');
+        let capturedUpdate;
+        mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+          capturedUpdate = update;
+          return Promise.resolve(makeDoc({ cachedBalance: 1000, ledger: [{ kind: 'topup', amount: 1000, stripeSessionId: 'cs_xyz', expiresAt }] }));
+        });
+
+        await BillingExtraBalanceRepository.creditPack(orgId, 1000, 'cs_xyz', expiresAt);
+
+        expect(capturedUpdate.$push.ledger.expiresAt).toBe(expiresAt);
+      });
+    });
+
+    describe('debit', () => {
+      test('should apply debit when balance is sufficient and refId is new', async () => {
+        const updatedDoc = makeDoc({ cachedBalance: 400000, ledger: [{ kind: 'debit', amount: -100000, refId: 'ref_1' }] });
+        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+        const result = await BillingExtraBalanceRepository.debit(orgId, 100000, 'ref_1');
+
+        expect(result.applied).toBe(true);
+        expect(result.doc).toBe(updatedDoc);
+      });
+
+      test('should return applied=false when balance is insufficient', async () => {
+        mockModel.findOneAndUpdate.mockResolvedValue(null);
+
+        const result = await BillingExtraBalanceRepository.debit(orgId, 999999, 'ref_big');
+
+        expect(result.applied).toBe(false);
+        expect(result.doc).toBeNull();
+      });
+
+      test('should return applied=false when refId already used (replay protection)', async () => {
+        // The filter `ledger.refId: { $ne: refId }` won't match if refId exists
+        mockModel.findOneAndUpdate.mockResolvedValue(null);
+
+        const result = await BillingExtraBalanceRepository.debit(orgId, 100, 'ref_duplicate');
+
+        expect(result.applied).toBe(false);
+      });
+
+      test('should push a negative amount entry to the ledger', async () => {
+        let capturedUpdate;
+        mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+          capturedUpdate = update;
+          return Promise.resolve(makeDoc({ cachedBalance: 0 }));
+        });
+
+        await BillingExtraBalanceRepository.debit(orgId, 500, 'ref_check');
+
+        expect(capturedUpdate.$push.ledger.amount).toBe(-500);
+        expect(capturedUpdate.$push.ledger.kind).toBe('debit');
+        expect(capturedUpdate.$inc.cachedBalance).toBe(-500);
+      });
+    });
+
+    describe('addExpirationEntries — idempotency', () => {
+      test('should return 0 when no document exists', async () => {
+        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+
+        const result = await BillingExtraBalanceRepository.addExpirationEntries(orgId, new Date());
+        expect(result).toBe(0);
+      });
+
+      test('should return 0 when no topup entries have expired', async () => {
+        const future = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+        const doc = makeDoc({
+          ledger: [{ _id: '507f1f77bcf86cd799439abc', kind: 'topup', amount: 1000, expiresAt: future }],
+        });
+        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+        const result = await BillingExtraBalanceRepository.addExpirationEntries(orgId, new Date());
+        expect(result).toBe(0);
+      });
+
+      test('should expire a topup entry and return 1', async () => {
+        const past = new Date(Date.now() - 1000);
+        const entryId = '507f1f77bcf86cd799439abc';
+        const doc = makeDoc({
+          ledger: [{ _id: entryId, kind: 'topup', amount: 1000, expiresAt: past }],
+        });
+        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+        mockModel.findOneAndUpdate.mockResolvedValue(makeDoc({ cachedBalance: 0 }));
+
+        const result = await BillingExtraBalanceRepository.addExpirationEntries(orgId, new Date());
+        expect(result).toBe(1);
+
+        // Verify expiration entry references the topup id
+        const call = mockModel.findOneAndUpdate.mock.calls[0];
+        expect(call[1].$push.ledger.refId).toBe(`expire-${entryId}`);
+        expect(call[1].$push.ledger.kind).toBe('expiration');
+        expect(call[1].$push.ledger.amount).toBe(-1000);
+      });
+
+      test('should NOT add a second expiration entry when already expired (idempotent)', async () => {
+        const past = new Date(Date.now() - 1000);
+        const entryId = '507f1f77bcf86cd799439abc';
+        const doc = makeDoc({
+          ledger: [
+            { _id: entryId, kind: 'topup', amount: 1000, expiresAt: past },
+            { kind: 'expiration', amount: -1000, refId: `expire-${entryId}` },
+          ],
+        });
+        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+
+        const result = await BillingExtraBalanceRepository.addExpirationEntries(orgId, new Date());
+        expect(result).toBe(0);
+        expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getBalance', () => {
+      test('should return cached balance', async () => {
+        mockModel.findOne.mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ cachedBalance: 123456 }),
+        });
+
+        const balance = await BillingExtraBalanceRepository.getBalance(orgId);
+        expect(balance).toBe(123456);
+      });
+
+      test('should return 0 when no document exists', async () => {
+        mockModel.findOne.mockReturnValue({
+          lean: jest.fn().mockResolvedValue(null),
+        });
+
+        const balance = await BillingExtraBalanceRepository.getBalance(orgId);
+        expect(balance).toBe(0);
+      });
+    });
+  });
+});

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -184,6 +184,15 @@ describe('BillingExtraBalance unit tests:', () => {
         );
         expect(result).toBe(doc);
       });
+
+      test('should return null for malformed orgId (ObjectId guard)', async () => {
+        const { default: mongoose } = await import('mongoose');
+        mongoose.Types.ObjectId.isValid = jest.fn(() => false);
+
+        const result = await BillingExtraBalanceRepository.getOrCreate('not-valid-id');
+        expect(result).toBeNull();
+        expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
+      });
     });
 
     describe('creditPack — idempotency', () => {

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -342,5 +342,53 @@ describe('BillingExtraBalance unit tests:', () => {
         expect(balance).toBe(0);
       });
     });
+
+    describe('refundPartial', () => {
+      test('should apply refund atomically when refId is new', async () => {
+        const updatedDoc = makeDoc({ cachedBalance: 0 });
+        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+        const result = await BillingExtraBalanceRepository.refundPartial(
+          orgId,
+          'cs_refund_test',
+          500000,
+          'refund-cs_refund_test-4900',
+        );
+
+        expect(result.applied).toBe(true);
+        expect(result.doc).toBe(updatedDoc);
+
+        const call = mockModel.findOneAndUpdate.mock.calls[0];
+        expect(call[0]).toEqual({ organization: orgId, 'ledger.refId': { $ne: 'refund-cs_refund_test-4900' } });
+        expect(call[1].$push.ledger.kind).toBe('refund');
+        expect(call[1].$push.ledger.amount).toBe(-500000);
+        expect(call[1].$push.ledger.stripeSessionId).toBe('cs_refund_test');
+        expect(call[1].$push.ledger.refId).toBe('refund-cs_refund_test-4900');
+        expect(call[1].$inc.cachedBalance).toBe(-500000);
+      });
+
+      test('should return applied=false when refId already used (idempotent)', async () => {
+        mockModel.findOneAndUpdate.mockResolvedValue(null);
+
+        const result = await BillingExtraBalanceRepository.refundPartial(
+          orgId,
+          'cs_refund_test',
+          500000,
+          'refund-cs_refund_test-4900',
+        );
+
+        expect(result.applied).toBe(false);
+        expect(result.doc).toBeNull();
+      });
+
+      test('should allow negative resulting balance (economic reflection)', async () => {
+        const updatedDoc = makeDoc({ cachedBalance: -500000 });
+        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+        const result = await BillingExtraBalanceRepository.refundPartial(orgId, 'cs_neg', 500000, 'refund-cs_neg-4900');
+        expect(result.applied).toBe(true);
+        expect(result.doc.cachedBalance).toBe(-500000);
+      });
+    });
   });
 });

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -59,9 +59,17 @@ describe('BillingExtraBalance unit tests:', () => {
         expect(result.error).toBeDefined();
       });
 
-      test('should accept all valid ledger kinds', () => {
-        for (const kind of ['topup', 'debit', 'refund', 'expiration', 'adjustment']) {
-          const result = schema.LedgerEntry.safeParse({ kind, amount: 100 });
+      test('should accept all valid ledger kinds with correct sign', () => {
+        // topup/adjustment require positive amount; debit/expiration/refund require negative
+        const cases = [
+          { kind: 'topup', amount: 100 },
+          { kind: 'adjustment', amount: 100 },
+          { kind: 'debit', amount: -100 },
+          { kind: 'expiration', amount: -100 },
+          { kind: 'refund', amount: -100 },
+        ];
+        for (const entry of cases) {
+          const result = schema.LedgerEntry.safeParse(entry);
           expect(result.error).toBeFalsy();
         }
       });
@@ -132,6 +140,10 @@ describe('BillingExtraBalance unit tests:', () => {
     let mockModel;
 
     const orgId = '507f1f77bcf86cd799439011';
+    /**
+     * @param {Object} [overrides={}] - Fields to override on the stub document.
+     * @returns {Object} A stub ExtraBalance document.
+     */
     const makeDoc = (overrides = {}) => ({
       _id: '507f1f77bcf86cd799439099',
       organization: orgId,
@@ -397,6 +409,58 @@ describe('BillingExtraBalance unit tests:', () => {
         const result = await BillingExtraBalanceRepository.refundPartial(orgId, 'cs_neg', 500000, 'refund-cs_neg-4900');
         expect(result.applied).toBe(true);
         expect(result.doc.cachedBalance).toBe(-500000);
+      });
+
+      test('should throw on zero refundUnits', async () => {
+        await expect(
+          BillingExtraBalanceRepository.refundPartial(orgId, 'cs_abc', 0, 'refund-key'),
+        ).rejects.toThrow('invalid argument: refundUnits must be a positive finite number');
+      });
+
+      test('should throw on empty refId', async () => {
+        await expect(
+          BillingExtraBalanceRepository.refundPartial(orgId, 'cs_abc', 100, ''),
+        ).rejects.toThrow('invalid argument: refId must be a non-empty string');
+      });
+    });
+
+    describe('creditPack — input guards', () => {
+      test('should throw on zero amount', async () => {
+        await expect(
+          BillingExtraBalanceRepository.creditPack(orgId, 0, 'cs_test', null),
+        ).rejects.toThrow('invalid argument: amount must be a positive finite number');
+      });
+
+      test('should throw on negative amount', async () => {
+        await expect(
+          BillingExtraBalanceRepository.creditPack(orgId, -100, 'cs_test', null),
+        ).rejects.toThrow('invalid argument: amount must be a positive finite number');
+      });
+
+      test('should throw on empty stripeSessionId', async () => {
+        await expect(
+          BillingExtraBalanceRepository.creditPack(orgId, 100, '', null),
+        ).rejects.toThrow('invalid argument: stripeSessionId must be a non-empty string');
+      });
+    });
+
+    describe('debit — input guards', () => {
+      test('should throw on zero amount', async () => {
+        await expect(
+          BillingExtraBalanceRepository.debit(orgId, 0, 'ref_test'),
+        ).rejects.toThrow('invalid argument: amount must be a positive finite number');
+      });
+
+      test('should throw on negative amount', async () => {
+        await expect(
+          BillingExtraBalanceRepository.debit(orgId, -50, 'ref_test'),
+        ).rejects.toThrow('invalid argument: amount must be a positive finite number');
+      });
+
+      test('should throw on empty refId', async () => {
+        await expect(
+          BillingExtraBalanceRepository.debit(orgId, 100, ''),
+        ).rejects.toThrow('invalid argument: refId must be a non-empty string');
       });
     });
   });

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -1,0 +1,154 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.meter.service.js
+ */
+describe('BillingMeterService unit tests:', () => {
+  let BillingMeterService;
+  let mockBillingPlanService;
+  let mockConfig;
+
+  const orgId = '507f1f77bcf86cd799439011';
+
+  const makePlan = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439022',
+    planId: 'pro',
+    version: 'v1',
+    meterQuota: 500000,
+    ratios: { scrap: 1, autofix: 2, wizard: 5 },
+    active: true,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['pro'],
+        meter: {
+          runBaseUnits: 1,
+          dollarsToUnitRatio: 1000,
+          maxUnitsPerOperation: 10000,
+        },
+        packs: [],
+      },
+    };
+
+    mockBillingPlanService = {
+      getPlanByVersion: jest.fn(),
+      getActivePlan: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockBillingPlanService,
+    }));
+
+    const mod = await import('../services/billing.meter.service.js');
+    BillingMeterService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('METER_RUN_BASE constant', () => {
+    test('should export METER_RUN_BASE from config', async () => {
+      const mod = await import('../services/billing.meter.service.js');
+      expect(mod.METER_RUN_BASE).toBe(1);
+    });
+  });
+
+  describe('unitsFromCosts', () => {
+    test('should compute units correctly using plan ratios', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan());
+
+      const costs = { scrap: 0.001, autofix: 0.002 };
+      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
+
+      expect(mockBillingPlanService.getPlanByVersion).toHaveBeenCalledWith('pro', 'v1');
+      // scrap: floor(0.001 * 1 * 1000) = 1
+      // autofix: floor(0.002 * 2 * 1000) = 4
+      // total = 5
+      expect(result.totalUnits).toBe(5);
+      expect(result.breakdown.scrap).toBe(1);
+      expect(result.breakdown.autofix).toBe(4);
+    });
+
+    test('should use ratio=1 as default when feature key not in plan ratios', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: {} }));
+
+      const costs = { unknown_feature: 0.001 };
+      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
+
+      // floor(0.001 * 1 * 1000) = 1
+      expect(result.totalUnits).toBe(1);
+      expect(result.breakdown.unknown_feature).toBe(1);
+    });
+
+    test('should enforce METER_RUN_BASE floor when costs are tiny', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+
+      // 0.000001 * 1 * 1000 = 0.001 → floor = 0 → total = 0, floor to METER_RUN_BASE
+      const costs = { scrap: 0.000001 };
+      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
+
+      expect(result.totalUnits).toBe(1); // METER_RUN_BASE
+    });
+
+    test('should return METER_RUN_BASE when costs is empty object', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan());
+
+      const result = await BillingMeterService.unitsFromCosts({}, 'pro', 'v1');
+      expect(result.totalUnits).toBe(1);
+      expect(result.breakdown).toEqual({});
+    });
+
+    test('should return METER_RUN_BASE when costs is null', async () => {
+      const result = await BillingMeterService.unitsFromCosts(null, 'pro', 'v1');
+      expect(result.totalUnits).toBe(1);
+    });
+
+    test('should use ratio=1 when plan not found (null)', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(null);
+
+      const costs = { scrap: 0.001 };
+      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
+
+      // ratio defaults to 1: floor(0.001 * 1 * 1000) = 1
+      expect(result.totalUnits).toBe(1);
+    });
+
+    test('should skip cost entries with non-numeric or zero values', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+
+      const costs = { scrap: 0.001, bad: 'notanumber', zero: 0, neg: -1 };
+      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
+
+      expect(result.breakdown.bad).toBeUndefined();
+      expect(result.breakdown.zero).toBeUndefined();
+      expect(result.breakdown.neg).toBeUndefined();
+      expect(result.breakdown.scrap).toBe(1);
+    });
+  });
+
+  describe('attribute — no-op when meterMode=false', () => {
+    test('should return applied=false when meterMode is disabled', async () => {
+      mockConfig.billing.meterMode = false;
+
+      const history = { _id: '507f1f77bcf86cd799439033', costs: { scrap: 0.001 }, planId: 'pro', planVersion: 'v1' };
+      const result = await BillingMeterService.attribute(history, orgId);
+
+      expect(result.applied).toBe(false);
+      expect(result.meterUsed).toBe(0);
+    });
+  });
+});

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -13,6 +13,10 @@ describe('BillingMeterService unit tests:', () => {
 
   const orgId = '507f1f77bcf86cd799439011';
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub plan.
+   * @returns {Object} A stub BillingPlan document.
+   */
   const makePlan = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439022',
     planId: 'pro',

--- a/modules/billing/tests/billing.plan.service.bumpretry.unit.tests.js
+++ b/modules/billing/tests/billing.plan.service.bumpretry.unit.tests.js
@@ -10,6 +10,10 @@ describe('BillingPlanService — bumpVersionWithRetry unit tests:', () => {
   let BillingPlanService;
   let mockBillingPlanRepository;
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub plan document.
+   * @returns {Object} A stub BillingPlan document.
+   */
   const makeDoc = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439011',
     planId: 'pro',
@@ -120,6 +124,24 @@ describe('BillingPlanService — bumpVersionWithRetry unit tests:', () => {
       const result = await BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 });
       expect(result).toBeDefined();
       expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(3);
+    });
+
+    test('should throw when maxAttempts is 0', async () => {
+      await expect(
+        BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 }, { maxAttempts: 0 }),
+      ).rejects.toThrow('maxAttempts must be a positive integer');
+    });
+
+    test('should throw when maxAttempts is negative', async () => {
+      await expect(
+        BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 }, { maxAttempts: -1 }),
+      ).rejects.toThrow('maxAttempts must be a positive integer');
+    });
+
+    test('should throw when maxAttempts is non-integer', async () => {
+      await expect(
+        BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 }, { maxAttempts: 1.5 }),
+      ).rejects.toThrow('maxAttempts must be a positive integer');
     });
   });
 });

--- a/modules/billing/tests/billing.plan.service.bumpretry.unit.tests.js
+++ b/modules/billing/tests/billing.plan.service.bumpretry.unit.tests.js
@@ -1,0 +1,125 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for bumpVersionWithRetry in billing.plan.service.js
+ */
+describe('BillingPlanService — bumpVersionWithRetry unit tests:', () => {
+  let BillingPlanService;
+  let mockBillingPlanRepository;
+
+  const makeDoc = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439011',
+    planId: 'pro',
+    version: 'v2',
+    meterQuota: 500000,
+    ratios: { scrap: 1 },
+    effectiveFrom: new Date('2026-05-01'),
+    effectiveUntil: null,
+    active: true,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockBillingPlanRepository = {
+      findActive: jest.fn(),
+      findByVersion: jest.fn(),
+      deactivateAll: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+      count: jest.fn().mockResolvedValue(1),
+      create: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../repositories/billing.plan.repository.js', () => ({
+      default: mockBillingPlanRepository,
+    }));
+
+    const mod = await import('../services/billing.plan.service.js');
+    BillingPlanService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('bumpVersionWithRetry', () => {
+    test('should succeed on first attempt when no E11000', async () => {
+      const newDoc = makeDoc({ version: 'v2' });
+      mockBillingPlanRepository.create.mockResolvedValue([newDoc]);
+
+      const result = await BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 500000 });
+
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(1);
+      expect(result.version).toBe('v2');
+    });
+
+    test('should retry on E11000 and succeed on second attempt', async () => {
+      const e11000 = new Error('E11000 duplicate key');
+      e11000.code = 11000;
+      const newDoc = makeDoc({ version: 'v3' });
+
+      mockBillingPlanRepository.create
+        .mockRejectedValueOnce(e11000)
+        .mockResolvedValueOnce([newDoc]);
+
+      const result = await BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 500000 }, { maxAttempts: 3 });
+
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(2);
+      expect(result.version).toBe('v3');
+    });
+
+    test('should retry up to maxAttempts then throw', async () => {
+      const e11000 = new Error('E11000 duplicate key');
+      e11000.code = 11000;
+      mockBillingPlanRepository.create.mockRejectedValue(e11000);
+
+      await expect(
+        BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 500000 }, { maxAttempts: 2 }),
+      ).rejects.toThrow('E11000');
+
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(2);
+    });
+
+    test('should propagate non-E11000 errors immediately without retry', async () => {
+      const networkErr = new Error('network timeout');
+      mockBillingPlanRepository.create.mockRejectedValue(networkErr);
+
+      await expect(
+        BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 500000 }, { maxAttempts: 3 }),
+      ).rejects.toThrow('network timeout');
+
+      // Should not retry for non-E11000 errors
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('should also retry on E11000 in error message string', async () => {
+      const err = new Error('E11000 duplicate key error collection ...');
+      // No code property — only message
+      const newDoc = makeDoc({ version: 'v2' });
+      mockBillingPlanRepository.create
+        .mockRejectedValueOnce(err)
+        .mockResolvedValueOnce([newDoc]);
+
+      const result = await BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 }, { maxAttempts: 3 });
+      expect(result.version).toBe('v2');
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(2);
+    });
+
+    test('should use default maxAttempts=3 when not specified', async () => {
+      const e11000 = new Error('E11000 duplicate key');
+      e11000.code = 11000;
+      const newDoc = makeDoc();
+      mockBillingPlanRepository.create
+        .mockRejectedValueOnce(e11000)
+        .mockRejectedValueOnce(e11000)
+        .mockResolvedValueOnce([newDoc]);
+
+      const result = await BillingPlanService.bumpVersionWithRetry('pro', { meterQuota: 1 });
+      expect(result).toBeDefined();
+      expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -11,7 +11,6 @@ describe('BillingResetService unit tests:', () => {
   let mockUsageRepository;
   let mockPlanService;
   let mockConfig;
-  let mockMongooseUsage;
   let mockMongooseSubscription;
 
   const orgId = '507f1f77bcf86cd799439011';
@@ -50,19 +49,16 @@ describe('BillingResetService unit tests:', () => {
       get: jest.fn(),
       reset: jest.fn(),
       incrementMeter: jest.fn(),
+      archiveOtherWeeks: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      upsertWeekSnapshot: jest.fn(),
     };
 
     mockPlanService = {
       getActivePlan: jest.fn(),
     };
 
-    mockMongooseUsage = {
-      updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
-      findOneAndUpdate: jest.fn(),
-    };
-
     mockMongooseSubscription = {
-      find: jest.fn(),
+      findAllDueForReset: jest.fn(),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -73,18 +69,12 @@ describe('BillingResetService unit tests:', () => {
       default: mockUsageRepository,
     }));
 
-    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
-      default: mockPlanService,
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockMongooseSubscription,
     }));
 
-    jest.unstable_mockModule('mongoose', () => ({
-      default: {
-        model: jest.fn((name) => {
-          if (name === 'BillingUsage') return mockMongooseUsage;
-          if (name === 'BillingSubscription') return mockMongooseSubscription;
-          return {};
-        }),
-      },
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockPlanService,
     }));
 
     const mod = await import('../services/billing.reset.service.js');
@@ -126,13 +116,14 @@ describe('BillingResetService unit tests:', () => {
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       const newDoc = makeUsageDoc({ weekKey: '2026-W18' });
-      mockMongooseUsage.findOneAndUpdate.mockResolvedValue(newDoc);
+      mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(newDoc);
 
       const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
-      expect(mockMongooseUsage.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({ organizationId: orgId, weekKey: { $ne: '2026-W18' } }),
-        { $set: { archivedAt: expect.any(Date) } },
+      expect(mockUsageRepository.archiveOtherWeeks).toHaveBeenCalledWith(
+        orgId,
+        '2026-W18',
+        expect.any(Date),
       );
       expect(result).toBe(newDoc);
     });
@@ -144,39 +135,39 @@ describe('BillingResetService unit tests:', () => {
 
       const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
-      // Should not call findOneAndUpdate since doc already exists
-      expect(mockMongooseUsage.findOneAndUpdate).not.toHaveBeenCalled();
+      // Should not call upsertWeekSnapshot since doc already exists
+      expect(mockUsageRepository.upsertWeekSnapshot).not.toHaveBeenCalled();
       expect(result).toBe(existingDoc);
     });
 
     test('should snapshot meterQuota and planVersion from active plan', async () => {
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 1000000, version: 'v3' }));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
-      let capturedUpdate;
-      mockMongooseUsage.findOneAndUpdate.mockImplementation((filter, update) => {
-        capturedUpdate = update;
+      let capturedSnapshot;
+      mockUsageRepository.upsertWeekSnapshot.mockImplementation((orgId, weekKey, snapshot) => {
+        capturedSnapshot = snapshot;
         return Promise.resolve(makeUsageDoc());
       });
 
       await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
-      expect(capturedUpdate.$setOnInsert.meterQuota).toBe(1000000);
-      expect(capturedUpdate.$setOnInsert.planVersion).toBe('v3');
+      expect(capturedSnapshot.meterQuota).toBe(1000000);
+      expect(capturedSnapshot.planVersion).toBe('v3');
     });
 
     test('should use meterQuota=0 when no active plan exists', async () => {
       mockPlanService.getActivePlan.mockResolvedValue(null);
       mockUsageRepository.findByWeek.mockResolvedValue(null);
-      let capturedUpdate;
-      mockMongooseUsage.findOneAndUpdate.mockImplementation((filter, update) => {
-        capturedUpdate = update;
+      let capturedSnapshot;
+      mockUsageRepository.upsertWeekSnapshot.mockImplementation((orgId, weekKey, snapshot) => {
+        capturedSnapshot = snapshot;
         return Promise.resolve(makeUsageDoc({ meterQuota: 0 }));
       });
 
       await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
-      expect(capturedUpdate.$setOnInsert.meterQuota).toBe(0);
-      expect(capturedUpdate.$setOnInsert.planVersion).toBeNull();
+      expect(capturedSnapshot.meterQuota).toBe(0);
+      expect(capturedSnapshot.planVersion).toBeNull();
     });
 
     test('should handle E11000 race by falling back to findByWeek', async () => {
@@ -186,7 +177,7 @@ describe('BillingResetService unit tests:', () => {
         .mockResolvedValueOnce(makeUsageDoc()); // Second call after E11000: doc exists
       const e11000 = new Error('E11000 duplicate key');
       e11000.code = 11000;
-      mockMongooseUsage.findOneAndUpdate.mockRejectedValue(e11000);
+      mockUsageRepository.upsertWeekSnapshot.mockRejectedValue(e11000);
 
       const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
@@ -206,15 +197,14 @@ describe('BillingResetService unit tests:', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
 
-      const leanMock = jest.fn().mockResolvedValue([
+      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
         { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
         { organizationId: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
       ]);
-      mockMongooseSubscription.find.mockReturnValue({ lean: leanMock });
 
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
-      mockMongooseUsage.findOneAndUpdate.mockResolvedValue(makeUsageDoc());
+      mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc());
 
       const result = await BillingResetService.resetAllDue();
       expect(result.processed).toBe(2);
@@ -223,10 +213,9 @@ describe('BillingResetService unit tests:', () => {
 
     test('should count errors when resetWeek fails for a subscription', async () => {
       const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
-      const leanMock = jest.fn().mockResolvedValue([
+      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
         { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
-      mockMongooseSubscription.find.mockReturnValue({ lean: leanMock });
       mockPlanService.getActivePlan.mockRejectedValue(new Error('DB error'));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
 

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -15,6 +15,10 @@ describe('BillingResetService unit tests:', () => {
 
   const orgId = '507f1f77bcf86cd799439011';
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub plan.
+   * @returns {Object} A stub BillingPlan document.
+   */
   const makePlan = (overrides = {}) => ({
     planId: 'pro',
     version: 'v1',
@@ -23,6 +27,10 @@ describe('BillingResetService unit tests:', () => {
     ...overrides,
   });
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub usage document.
+   * @returns {Object} A stub BillingUsage document.
+   */
   const makeUsageDoc = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439099',
     organizationId: orgId,
@@ -198,8 +206,8 @@ describe('BillingResetService unit tests:', () => {
       const periodStart = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
 
       mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
-        { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
-        { organizationId: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
+        { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
+        { organization: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
       ]);
 
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
@@ -214,7 +222,7 @@ describe('BillingResetService unit tests:', () => {
     test('should count errors when resetWeek fails for a subscription', async () => {
       const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
       mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
-        { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
+        { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
       mockPlanService.getActivePlan.mockRejectedValue(new Error('DB error'));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
@@ -222,6 +230,28 @@ describe('BillingResetService unit tests:', () => {
       const result = await BillingResetService.resetAllDue();
       expect(result.errors).toBe(1);
       expect(result.processed).toBe(0);
+    });
+
+    test('should pass undefined orgId when sub uses organizationId (wrong field) — regression guard', async () => {
+      // This test ensures the service reads sub.organization, not sub.organizationId.
+      // If someone reverts to sub.organizationId, String(undefined) = 'undefined' → resetWeek
+      // would receive 'undefined' as orgId, which fails ObjectId validation and skips archive+upsert.
+      // We verify that when the correct field `organization` is present, it is forwarded correctly.
+      const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      const capturedOrgIds = [];
+      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
+        { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
+      ]);
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockImplementation((orgId) => {
+        capturedOrgIds.push(orgId);
+        return Promise.resolve(makeUsageDoc({ organizationId: orgId }));
+      });
+
+      await BillingResetService.resetAllDue();
+
+      // The orgId forwarded to the repo must be the real ObjectId, not 'undefined'
+      expect(capturedOrgIds[0]).toBe('507f1f77bcf86cd799439011');
     });
   });
 });

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -1,0 +1,238 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.reset.service.js
+ */
+describe('BillingResetService unit tests:', () => {
+  let BillingResetService;
+  let mockUsageRepository;
+  let mockPlanService;
+  let mockConfig;
+  let mockMongooseUsage;
+  let mockMongooseSubscription;
+
+  const orgId = '507f1f77bcf86cd799439011';
+
+  const makePlan = (overrides = {}) => ({
+    planId: 'pro',
+    version: 'v1',
+    meterQuota: 500000,
+    active: true,
+    ...overrides,
+  });
+
+  const makeUsageDoc = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439099',
+    organizationId: orgId,
+    weekKey: '2026-W18',
+    meterUsed: 0,
+    meterQuota: 500000,
+    planVersion: 'v1',
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['pro'],
+      },
+    };
+
+    mockUsageRepository = {
+      findByWeek: jest.fn(),
+      increment: jest.fn(),
+      get: jest.fn(),
+      reset: jest.fn(),
+      incrementMeter: jest.fn(),
+    };
+
+    mockPlanService = {
+      getActivePlan: jest.fn(),
+    };
+
+    mockMongooseUsage = {
+      updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    mockMongooseSubscription = {
+      find: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.usage.repository.js', () => ({
+      default: mockUsageRepository,
+    }));
+
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockPlanService,
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        model: jest.fn((name) => {
+          if (name === 'BillingUsage') return mockMongooseUsage;
+          if (name === 'BillingSubscription') return mockMongooseSubscription;
+          return {};
+        }),
+      },
+    }));
+
+    const mod = await import('../services/billing.reset.service.js');
+    BillingResetService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isoWeekKey', () => {
+    test('should return correct week key for a known Monday', () => {
+      // 2026-04-27 is a Monday, ISO week 18
+      const result = BillingResetService.isoWeekKey(new Date('2026-04-27'));
+      expect(result).toBe('2026-W18');
+    });
+
+    test('should return correct week key for a Sunday (same ISO week as preceding Monday)', () => {
+      // 2026-05-03 is Sunday, still ISO week 18
+      const result = BillingResetService.isoWeekKey(new Date('2026-05-03'));
+      expect(result).toBe('2026-W18');
+    });
+
+    test('should compute week 1 for first week of year', () => {
+      // 2026-01-01 is Thursday — ISO week 1 of 2026
+      const result = BillingResetService.isoWeekKey(new Date('2026-01-01'));
+      expect(result).toBe('2026-W01');
+    });
+  });
+
+  describe('resetWeek', () => {
+    test('should return null when meterMode is disabled', async () => {
+      mockConfig.billing.meterMode = false;
+      const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+      expect(result).toBeNull();
+    });
+
+    test('should archive old week docs and upsert new week doc', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+      const newDoc = makeUsageDoc({ weekKey: '2026-W18' });
+      mockMongooseUsage.findOneAndUpdate.mockResolvedValue(newDoc);
+
+      const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(mockMongooseUsage.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: orgId, weekKey: { $ne: '2026-W18' } }),
+        { $set: { archivedAt: expect.any(Date) } },
+      );
+      expect(result).toBe(newDoc);
+    });
+
+    test('should be idempotent — return existing doc if week already exists', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      const existingDoc = makeUsageDoc({ weekKey: '2026-W18' });
+      mockUsageRepository.findByWeek.mockResolvedValue(existingDoc);
+
+      const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      // Should not call findOneAndUpdate since doc already exists
+      expect(mockMongooseUsage.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(result).toBe(existingDoc);
+    });
+
+    test('should snapshot meterQuota and planVersion from active plan', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 1000000, version: 'v3' }));
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+      let capturedUpdate;
+      mockMongooseUsage.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc());
+      });
+
+      await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(capturedUpdate.$setOnInsert.meterQuota).toBe(1000000);
+      expect(capturedUpdate.$setOnInsert.planVersion).toBe('v3');
+    });
+
+    test('should use meterQuota=0 when no active plan exists', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(null);
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+      let capturedUpdate;
+      mockMongooseUsage.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc({ meterQuota: 0 }));
+      });
+
+      await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(capturedUpdate.$setOnInsert.meterQuota).toBe(0);
+      expect(capturedUpdate.$setOnInsert.planVersion).toBeNull();
+    });
+
+    test('should handle E11000 race by falling back to findByWeek', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek
+        .mockResolvedValueOnce(null) // First call: doc not yet created
+        .mockResolvedValueOnce(makeUsageDoc()); // Second call after E11000: doc exists
+      const e11000 = new Error('E11000 duplicate key');
+      e11000.code = 11000;
+      mockMongooseUsage.findOneAndUpdate.mockRejectedValue(e11000);
+
+      const result = await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(result).toBeDefined();
+      expect(mockUsageRepository.findByWeek).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('resetAllDue', () => {
+    test('should return processed=0, errors=0 when meterMode is disabled', async () => {
+      mockConfig.billing.meterMode = false;
+      const result = await BillingResetService.resetAllDue();
+      expect(result).toEqual({ processed: 0, errors: 0 });
+    });
+
+    test('should call resetWeek for each active subscription', async () => {
+      const now = new Date();
+      const periodStart = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+      const leanMock = jest.fn().mockResolvedValue([
+        { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
+        { organizationId: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
+      ]);
+      mockMongooseSubscription.find.mockReturnValue({ lean: leanMock });
+
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+      mockMongooseUsage.findOneAndUpdate.mockResolvedValue(makeUsageDoc());
+
+      const result = await BillingResetService.resetAllDue();
+      expect(result.processed).toBe(2);
+      expect(result.errors).toBe(0);
+    });
+
+    test('should count errors when resetWeek fails for a subscription', async () => {
+      const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      const leanMock = jest.fn().mockResolvedValue([
+        { organizationId: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
+      ]);
+      mockMongooseSubscription.find.mockReturnValue({ lean: leanMock });
+      mockPlanService.getActivePlan.mockRejectedValue(new Error('DB error'));
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+
+      const result = await BillingResetService.resetAllDue();
+      expect(result.errors).toBe(1);
+      expect(result.processed).toBe(0);
+    });
+  });
+});

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -13,6 +13,10 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
   const orgId = '507f1f77bcf86cd799439011';
   const weekKey = '2026-W18';
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub usage document.
+   * @returns {Object} A stub BillingUsage document.
+   */
   const makeUsageDoc = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439099',
     organizationId: orgId,
@@ -140,6 +144,30 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
 
       expect(capturedUpdate.$inc['meterBreakdown.scrap']).toBe(100);
       expect(capturedUpdate.$inc['meterBreakdown.autofix']).toBe(50);
+    });
+
+    test('should drop breakdown entries with non-positive or non-finite values', async () => {
+      let capturedUpdate;
+      mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc());
+      });
+
+      await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        10,
+        { good: 10, zero: 0, negative: -5, infinite: Infinity, nan: NaN },
+        'hist_invalid_breakdown',
+        {},
+      );
+
+      // Only 'good' should be included
+      expect(capturedUpdate.$inc['meterBreakdown.good']).toBe(10);
+      expect(capturedUpdate.$inc['meterBreakdown.zero']).toBeUndefined();
+      expect(capturedUpdate.$inc['meterBreakdown.negative']).toBeUndefined();
+      expect(capturedUpdate.$inc['meterBreakdown.infinite']).toBeUndefined();
+      expect(capturedUpdate.$inc['meterBreakdown.nan']).toBeUndefined();
     });
 
     test('should return null when idempotencyKey already present (replay)', async () => {

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -240,4 +240,91 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
       }
     });
   });
+
+  describe('archiveOtherWeeks', () => {
+    test('should call updateMany excluding currentWeekKey on docs without archivedAt', async () => {
+      mockModel.updateMany.mockResolvedValue({ modifiedCount: 2 });
+      const archivedAt = new Date('2026-04-28T00:00:00Z');
+
+      const result = await BillingUsageRepository.archiveOtherWeeks(orgId, weekKey, archivedAt);
+
+      expect(mockModel.updateMany).toHaveBeenCalledWith(
+        {
+          organizationId: orgId,
+          weekKey: { $ne: weekKey },
+          archivedAt: { $exists: false },
+        },
+        { $set: { archivedAt } },
+      );
+      expect(result.modifiedCount).toBe(2);
+    });
+
+    test('should return modifiedCount=0 when nothing to archive', async () => {
+      mockModel.updateMany.mockResolvedValue({ modifiedCount: 0 });
+
+      const result = await BillingUsageRepository.archiveOtherWeeks(orgId, weekKey, new Date());
+      expect(result.modifiedCount).toBe(0);
+    });
+  });
+
+  describe('upsertWeekSnapshot', () => {
+    test('should call findOneAndUpdate with upsert and $setOnInsert', async () => {
+      const snapshotFields = {
+        organizationId: orgId,
+        weekKey,
+        month: '2026-05',
+        meterUsed: 0,
+        meterQuota: 500000,
+        planVersion: 'v1',
+        meterBreakdown: {},
+        resetAt: new Date(),
+        alertedAt80: null,
+        alertedAt100: null,
+        consumedHistoryIds: [],
+      };
+      const newDoc = makeUsageDoc();
+      mockModel.findOneAndUpdate.mockResolvedValue(newDoc);
+
+      const result = await BillingUsageRepository.upsertWeekSnapshot(orgId, weekKey, snapshotFields);
+
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { organizationId: orgId, weekKey },
+        { $setOnInsert: snapshotFields },
+        expect.objectContaining({ upsert: true, returnDocument: 'after' }),
+      );
+      expect(result).toBe(newDoc);
+    });
+  });
+
+  describe('markThreshold', () => {
+    test('should call updateOne with field null filter and $set to current date', async () => {
+      mockModel.updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+
+      const result = await BillingUsageRepository.markThreshold('507f1f77bcf86cd799439099', 'alertedAt80');
+
+      expect(mockModel.updateOne).toHaveBeenCalledWith(
+        { _id: '507f1f77bcf86cd799439099', alertedAt80: null },
+        { $set: { alertedAt80: expect.any(Date) } },
+      );
+      expect(result.modifiedCount).toBe(1);
+    });
+
+    test('should use the correct field name for alertedAt100', async () => {
+      mockModel.updateOne = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+
+      await BillingUsageRepository.markThreshold('507f1f77bcf86cd799439099', 'alertedAt100');
+
+      expect(mockModel.updateOne).toHaveBeenCalledWith(
+        { _id: '507f1f77bcf86cd799439099', alertedAt100: null },
+        { $set: { alertedAt100: expect.any(Date) } },
+      );
+    });
+
+    test('should return modifiedCount=0 when threshold already set (idempotent)', async () => {
+      mockModel.updateOne = jest.fn().mockResolvedValue({ modifiedCount: 0 });
+
+      const result = await BillingUsageRepository.markThreshold('507f1f77bcf86cd799439099', 'alertedAt80');
+      expect(result.modifiedCount).toBe(0);
+    });
+  });
 });

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -227,6 +227,45 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
       expect(capturedUpdate.$setOnInsert.month).toBe('2026-05');
     });
 
+    test('should initialize alertedAt80, alertedAt100, meterBreakdown in $setOnInsert', async () => {
+      let capturedUpdate;
+      mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc());
+      });
+
+      await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        100,
+        {},
+        'hist_defaults',
+        { meterQuota: 500, planVersion: 'v1', resetAt: new Date(), month: '2026-05' },
+      );
+
+      expect(capturedUpdate.$setOnInsert.alertedAt80).toBeNull();
+      expect(capturedUpdate.$setOnInsert.alertedAt100).toBeNull();
+      expect(capturedUpdate.$setOnInsert.meterBreakdown).toEqual({});
+    });
+
+    test('should produce a valid YYYY-MM month string when baseSnapshot.month is absent', async () => {
+      let capturedUpdate;
+      mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc());
+      });
+
+      // Pass a baseSnapshot without a month field
+      await BillingUsageRepository.incrementMeter(orgId, weekKey, 50, {}, 'hist_nomonth', {
+        meterQuota: 100,
+        planVersion: null,
+        resetAt: null,
+      });
+
+      // month must be YYYY-MM (e.g. '2026-04'), not 'YYYY-W...'
+      expect(capturedUpdate.$setOnInsert.month).toMatch(/^\d{4}-\d{2}$/);
+    });
+
     test('should return null when organizationId fails isValid check', async () => {
       const { default: mongoose } = await import('mongoose');
       const origIsValid = mongoose.Types.ObjectId.isValid;

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -1,0 +1,243 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.usage.repository.js — meter extensions (PR-N2)
+ */
+describe('BillingUsageRepository — meter extensions unit tests:', () => {
+  let BillingUsageRepository;
+  let mockModel;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const weekKey = '2026-W18';
+
+  const makeUsageDoc = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439099',
+    organizationId: orgId,
+    weekKey,
+    meterUsed: 0,
+    meterQuota: 500000,
+    planVersion: 'v1',
+    consumedHistoryIds: [],
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockModel = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+      updateMany: jest.fn(),
+      countDocuments: jest.fn(),
+      create: jest.fn(),
+    };
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        model: jest.fn(() => mockModel),
+        Types: {
+          ObjectId: {
+            isValid: jest.fn(() => true),
+          },
+        },
+      },
+    }));
+
+    const mod = await import('../repositories/billing.usage.repository.js');
+    BillingUsageRepository = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('findByWeek', () => {
+    test('should call findOne with organizationId and weekKey, return lean doc', async () => {
+      const doc = makeUsageDoc();
+      const leanMock = jest.fn().mockResolvedValue(doc);
+      mockModel.findOne.mockReturnValue({ lean: leanMock });
+
+      const result = await BillingUsageRepository.findByWeek(orgId, weekKey);
+
+      expect(mockModel.findOne).toHaveBeenCalledWith({ organizationId: orgId, weekKey });
+      expect(leanMock).toHaveBeenCalled();
+      expect(result).toBe(doc);
+    });
+
+    test('should return null when no document found', async () => {
+      const leanMock = jest.fn().mockResolvedValue(null);
+      mockModel.findOne.mockReturnValue({ lean: leanMock });
+
+      const result = await BillingUsageRepository.findByWeek(orgId, '2026-W99');
+      expect(result).toBeNull();
+    });
+
+    test('should return null when organizationId fails isValid check', async () => {
+      // Mock isValid to reject the orgId in this test's already-loaded module instance.
+      // Because the module is already loaded, we verify via the mock's behavior.
+      const { default: mongoose } = await import('mongoose');
+      const origIsValid = mongoose.Types.ObjectId.isValid;
+      mongoose.Types.ObjectId.isValid = jest.fn(() => false);
+
+      try {
+        const result = await BillingUsageRepository.findByWeek('not-valid-id', weekKey);
+        expect(result).toBeNull();
+      } finally {
+        mongoose.Types.ObjectId.isValid = origIsValid;
+      }
+    });
+  });
+
+  describe('incrementMeter', () => {
+    test('should call findOneAndUpdate with correct filter including idempotency key', async () => {
+      const updatedDoc = makeUsageDoc({ meterUsed: 100, consumedHistoryIds: ['hist_001'] });
+      mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        100,
+        { scrap: 100 },
+        'hist_001',
+        { meterQuota: 500000, planVersion: 'v1', resetAt: new Date(), month: '2026-05' },
+      );
+
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: orgId,
+          weekKey,
+          consumedHistoryIds: { $ne: 'hist_001' },
+        }),
+        expect.objectContaining({
+          $inc: expect.objectContaining({ meterUsed: 100 }),
+          $push: { consumedHistoryIds: 'hist_001' },
+          $setOnInsert: expect.any(Object),
+        }),
+        expect.objectContaining({ upsert: true, returnDocument: 'after' }),
+      );
+      expect(result).toBe(updatedDoc);
+    });
+
+    test('should include breakdown in $inc payload', async () => {
+      const updatedDoc = makeUsageDoc({ meterUsed: 150 });
+      let capturedUpdate;
+      mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(updatedDoc);
+      });
+
+      await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        150,
+        { scrap: 100, autofix: 50 },
+        'hist_002',
+        {},
+      );
+
+      expect(capturedUpdate.$inc['meterBreakdown.scrap']).toBe(100);
+      expect(capturedUpdate.$inc['meterBreakdown.autofix']).toBe(50);
+    });
+
+    test('should return null when idempotencyKey already present (replay)', async () => {
+      // findOneAndUpdate returns null when filter does not match (consumedHistoryIds already contains key)
+      mockModel.findOneAndUpdate.mockResolvedValue(null);
+
+      const result = await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        100,
+        {},
+        'hist_replay',
+        {},
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test('incrementMeter same idempotencyKey twice → second returns null', async () => {
+      mockModel.findOneAndUpdate
+        .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100, consumedHistoryIds: ['hist_x'] }))
+        .mockResolvedValueOnce(null); // second: replay
+
+      const r1 = await BillingUsageRepository.incrementMeter(orgId, weekKey, 100, {}, 'hist_x', {});
+      const r2 = await BillingUsageRepository.incrementMeter(orgId, weekKey, 100, {}, 'hist_x', {});
+
+      expect(r1).toBeDefined();
+      expect(r2).toBeNull();
+    });
+
+    test('should handle E11000 race via retry without upsert', async () => {
+      const e11000 = new Error('E11000 duplicate key');
+      e11000.code = 11000;
+      const retryDoc = makeUsageDoc({ meterUsed: 100 });
+
+      mockModel.findOneAndUpdate
+        .mockRejectedValueOnce(e11000)
+        .mockResolvedValueOnce(retryDoc);
+
+      const result = await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        100,
+        {},
+        'hist_race',
+        {},
+      );
+
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
+      // Second call should not have upsert
+      const secondCall = mockModel.findOneAndUpdate.mock.calls[1];
+      expect(secondCall[2]?.upsert).toBeUndefined();
+      expect(result).toBe(retryDoc);
+    });
+
+    test('should propagate non-E11000 errors', async () => {
+      const dbErr = new Error('connection lost');
+      mockModel.findOneAndUpdate.mockRejectedValue(dbErr);
+
+      await expect(
+        BillingUsageRepository.incrementMeter(orgId, weekKey, 100, {}, 'hist_err', {}),
+      ).rejects.toThrow('connection lost');
+    });
+
+    test('should set $setOnInsert snapshot from baseSnapshot', async () => {
+      const now = new Date();
+      let capturedUpdate;
+      mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
+        capturedUpdate = update;
+        return Promise.resolve(makeUsageDoc());
+      });
+
+      await BillingUsageRepository.incrementMeter(
+        orgId,
+        weekKey,
+        50,
+        {},
+        'hist_snap',
+        { meterQuota: 999, planVersion: 'v7', resetAt: now, month: '2026-05' },
+      );
+
+      expect(capturedUpdate.$setOnInsert.meterQuota).toBe(999);
+      expect(capturedUpdate.$setOnInsert.planVersion).toBe('v7');
+      expect(capturedUpdate.$setOnInsert.resetAt).toBe(now);
+      expect(capturedUpdate.$setOnInsert.month).toBe('2026-05');
+    });
+
+    test('should return null when organizationId fails isValid check', async () => {
+      const { default: mongoose } = await import('mongoose');
+      const origIsValid = mongoose.Types.ObjectId.isValid;
+      mongoose.Types.ObjectId.isValid = jest.fn(() => false);
+
+      try {
+        const result = await BillingUsageRepository.incrementMeter('bad-id', weekKey, 100, {}, 'key', {});
+        expect(result).toBeNull();
+      } finally {
+        mongoose.Types.ObjectId.isValid = origIsValid;
+      }
+    });
+  });
+});

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -11,7 +11,6 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
   let mockUsageRepository;
   let mockPlanService;
   let mockConfig;
-  let mockMongooseModel;
 
   const orgId = '507f1f77bcf86cd799439011';
 
@@ -57,14 +56,11 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       reset: jest.fn(),
       findByWeek: jest.fn(),
       incrementMeter: jest.fn(),
+      markThreshold: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     };
 
     mockPlanService = {
       getActivePlan: jest.fn(),
-    };
-
-    mockMongooseModel = {
-      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -77,12 +73,6 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
     jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
       default: mockPlanService,
-    }));
-
-    jest.unstable_mockModule('mongoose', () => ({
-      default: {
-        model: jest.fn(() => mockMongooseModel),
-      },
     }));
 
     const mod = await import('../services/billing.usage.service.js');
@@ -199,11 +189,8 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_80pct');
 
       expect(result.alertCrossed).toBe('80');
-      // Should mark alertedAt80 atomically
-      expect(mockMongooseModel.updateOne).toHaveBeenCalledWith(
-        { _id: updatedDoc._id, alertedAt80: null },
-        { $set: { alertedAt80: expect.any(Date) } },
-      );
+      // Should mark alertedAt80 atomically via repository
+      expect(mockUsageRepository.markThreshold).toHaveBeenCalledWith(updatedDoc._id, 'alertedAt80');
     });
 
     test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -1,0 +1,281 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.usage.service.js — meter extensions (PR-N2)
+ */
+describe('BillingUsageService — meter extensions unit tests:', () => {
+  let BillingUsageService;
+  let mockUsageRepository;
+  let mockPlanService;
+  let mockConfig;
+  let mockMongooseModel;
+
+  const orgId = '507f1f77bcf86cd799439011';
+
+  const makePlan = (overrides = {}) => ({
+    planId: 'pro',
+    version: 'v1',
+    meterQuota: 500000,
+    active: true,
+    ...overrides,
+  });
+
+  const makeUsageDoc = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439099',
+    organizationId: orgId,
+    weekKey: '2026-W18',
+    month: '2026-05',
+    meterUsed: 0,
+    meterQuota: 500000,
+    planVersion: 'v1',
+    alertedAt80: null,
+    alertedAt100: null,
+    consumedHistoryIds: [],
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['pro'],
+        meter: {
+          runBaseUnits: 1,
+          dollarsToUnitRatio: 1000,
+        },
+      },
+    };
+
+    mockUsageRepository = {
+      get: jest.fn(),
+      increment: jest.fn(),
+      reset: jest.fn(),
+      findByWeek: jest.fn(),
+      incrementMeter: jest.fn(),
+    };
+
+    mockPlanService = {
+      getActivePlan: jest.fn(),
+    };
+
+    mockMongooseModel = {
+      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.usage.repository.js', () => ({
+      default: mockUsageRepository,
+    }));
+
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockPlanService,
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        model: jest.fn(() => mockMongooseModel),
+      },
+    }));
+
+    const mod = await import('../services/billing.usage.service.js');
+    BillingUsageService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('currentWeekKey', () => {
+    test('should return a string matching YYYY-Www format', () => {
+      const result = BillingUsageService.currentWeekKey();
+      expect(result).toMatch(/^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/);
+    });
+
+    test('should return consistent result on same day', () => {
+      const r1 = BillingUsageService.currentWeekKey();
+      const r2 = BillingUsageService.currentWeekKey();
+      expect(r1).toBe(r2);
+    });
+  });
+
+  describe('incrementMeter — no-op when meterMode=false', () => {
+    test('should return applied=false immediately', async () => {
+      mockConfig.billing.meterMode = false;
+
+      const result = await BillingUsageService.incrementMeter(orgId, 100, {}, 'key_1');
+      expect(result.applied).toBe(false);
+      expect(result.meterUsed).toBe(0);
+      expect(mockUsageRepository.incrementMeter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('incrementMeter — happy path', () => {
+    test('should attribute units and return applied=true', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      const updatedDoc = makeUsageDoc({ meterUsed: 100 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 100, { scrap: 100 }, 'hist_001');
+
+      expect(mockUsageRepository.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        expect.stringMatching(/^\d{4}-W\d{2}$/),
+        100,
+        { scrap: 100 },
+        'hist_001',
+        expect.objectContaining({ meterQuota: 500000, planVersion: 'v1' }),
+      );
+      expect(result.applied).toBe(true);
+      expect(result.meterUsed).toBe(100);
+      expect(result.extrasConsumed).toBe(0);
+    });
+
+    test('should return applied=false and fetch existing doc on replay', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      // repo returns null = replay
+      mockUsageRepository.incrementMeter.mockResolvedValue(null);
+      const existingDoc = makeUsageDoc({ meterUsed: 100 });
+      mockUsageRepository.findByWeek.mockResolvedValue(existingDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 100, {}, 'hist_replay');
+
+      expect(result.applied).toBe(false);
+      expect(result.meterUsed).toBe(100);
+    });
+
+    test('incrementMeter same idempotencyKey twice → second is no-op', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.incrementMeter
+        .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100 }))
+        .mockResolvedValueOnce(null); // second call: replay
+      mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ meterUsed: 100 }));
+
+      const r1 = await BillingUsageService.incrementMeter(orgId, 100, {}, 'hist_idempotent');
+      const r2 = await BillingUsageService.incrementMeter(orgId, 100, {}, 'hist_idempotent');
+
+      expect(r1.applied).toBe(true);
+      expect(r2.applied).toBe(false);
+    });
+  });
+
+  describe('incrementMeter — overflow to extras', () => {
+    test('should compute extrasConsumed when meterUsed exceeds quota', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      // meterUsed = 510000, quota = 500000 → 10000 overflow
+      const updatedDoc = makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 50000, {}, 'hist_overflow');
+
+      expect(result.extrasConsumed).toBe(10000);
+    });
+
+    test('should return extrasConsumed=0 when within quota', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 100, meterQuota: 500000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 100, {}, 'hist_within');
+
+      expect(result.extrasConsumed).toBe(0);
+    });
+  });
+
+  describe('incrementMeter — threshold detection', () => {
+    test('should emit threshold 80 alert when crossing 80% (once per cycle)', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      // 80% of 500000 = 400000 → crossing at meterUsed = 400001
+      const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_80pct');
+
+      expect(result.alertCrossed).toBe('80');
+      // Should mark alertedAt80 atomically
+      expect(mockMongooseModel.updateOne).toHaveBeenCalledWith(
+        { _id: updatedDoc._id, alertedAt80: null },
+        { $set: { alertedAt80: expect.any(Date) } },
+      );
+    });
+
+    test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({
+        meterUsed: 450000,
+        meterQuota: 500000,
+        alertedAt80: new Date(), // already alerted
+        alertedAt100: null,
+      });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_80pct_dedup');
+
+      expect(result.alertCrossed).toBeNull();
+    });
+
+    test('should emit threshold 100 alert when at 100%', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({
+        meterUsed: 500001,
+        meterQuota: 500000,
+        alertedAt80: new Date(), // 80 already sent
+        alertedAt100: null,
+      });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_100pct');
+
+      expect(result.alertCrossed).toBe('100');
+    });
+
+    test('should NOT re-emit threshold 100 when already alerted', async () => {
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({
+        meterUsed: 600000,
+        meterQuota: 500000,
+        alertedAt80: new Date(),
+        alertedAt100: new Date(), // already alerted
+      });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_100pct_dedup');
+
+      expect(result.alertCrossed).toBeNull();
+    });
+  });
+
+  describe('getMeter', () => {
+    test('should return null when meterMode is disabled', async () => {
+      mockConfig.billing.meterMode = false;
+      const result = await BillingUsageService.getMeter(orgId);
+      expect(result).toBeNull();
+    });
+
+    test('should return current week usage doc', async () => {
+      const doc = makeUsageDoc({ meterUsed: 200, meterQuota: 500000 });
+      mockUsageRepository.findByWeek.mockResolvedValue(doc);
+
+      const result = await BillingUsageService.getMeter(orgId);
+
+      expect(mockUsageRepository.findByWeek).toHaveBeenCalledWith(
+        orgId,
+        expect.stringMatching(/^\d{4}-W\d{2}$/),
+      );
+      expect(result.meterUsed).toBe(200);
+    });
+
+    test('should return null when no doc for current week', async () => {
+      mockUsageRepository.findByWeek.mockResolvedValue(null);
+      const result = await BillingUsageService.getMeter(orgId);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -14,6 +14,10 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   const orgId = '507f1f77bcf86cd799439011';
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub plan.
+   * @returns {Object} A stub BillingPlan document.
+   */
   const makePlan = (overrides = {}) => ({
     planId: 'pro',
     version: 'v1',
@@ -22,6 +26,10 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     ...overrides,
   });
 
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub usage document.
+   * @returns {Object} A stub BillingUsage document.
+   */
   const makeUsageDoc = (overrides = {}) => ({
     _id: '507f1f77bcf86cd799439099',
     organizationId: orgId,
@@ -236,6 +244,30 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_100pct_dedup');
 
       expect(result.alertCrossed).toBeNull();
+    });
+
+    test('should NOT set alertCrossed when markThreshold returns modifiedCount=0 (another pod won)', async () => {
+      // markThreshold returns modifiedCount=0 → we lost the race, must not emit
+      mockUsageRepository.markThreshold.mockResolvedValue({ modifiedCount: 0 });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_race_80');
+
+      expect(result.alertCrossed).toBeNull();
+    });
+
+    test('should set alertCrossed when markThreshold returns modifiedCount=1 (we won)', async () => {
+      // markThreshold returns modifiedCount=1 → we won the race, must emit
+      mockUsageRepository.markThreshold.mockResolvedValue({ modifiedCount: 1 });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_won_80');
+
+      expect(result.alertCrossed).toBe('80');
     });
   });
 


### PR DESCRIPTION
## Summary

PR-N2 of the Compute Pricing layer (#3533). Builds the attribution + extras balance
services on top of PR-N1 plan versioning. All new code paths are gated behind
`config.billing.meterMode = false` (backward compat absolute — non-compute downstreams
are entirely unaffected).

### New files

- `models/billing.extraBalance.model.mongoose.js` — ledger-based extra balance doc
  (topup / debit / refund / expiration / adjustment). Idempotency indexes on
  `ledger.stripeSessionId`, `ledger.historyId`, `ledger.expiresAt`.
- `models/billing.extraBalance.schema.js` — Zod mirror with full constraint symmetry.
- `repositories/billing.extraBalance.repository.js` — atomic Mongo ops:
  `getOrCreate`, `creditPack` (idempotent on stripeSessionId), `debit` (guarded by
  cachedBalance >= amount AND refId dedup), `addExpirationEntries` (idempotent sweep),
  `getBalance` (cheap read).
- `services/billing.extra.service.js` — `creditPack`, `debit`, `expireOldEntries`,
  `refundPartial` (proportional, balance may go negative = economic reflection),
  `listLedger` (paginated, newest-first).
- `services/billing.meter.service.js` — `unitsFromCosts` (frozen plan ratio lookup,
  dollarsToUnitRatio, METER_RUN_BASE floor), `attribute` (idempotent on history._id).
- `services/billing.reset.service.js` — `resetWeek` (archive-then-upsert, E11000-safe),
  `resetAllDue` (sweeps active subs by currentPeriodStart), `isoWeekKey` helper.

### Modified files

- `repositories/billing.usage.repository.js` — add `findByWeek` (lean read),
  `incrementMeter` (atomic upsert with $ne idempotency key, E11000 retry, $setOnInsert
  snapshot).
- `services/billing.usage.service.js` — add `currentWeekKey` (ISO 8601), `incrementMeter`
  (full flow: quota snapshot, overflow→extras, 80%/100% threshold events deduped per
  cycle), `getMeter`.
- `services/billing.plan.service.js` — add `bumpVersionWithRetry` (exp backoff
  100/300/900ms on E11000, max 3 attempts).

### Architecture decisions

- **Idempotency via atomic filter**: both `creditPack` and `debit` use `$ne` guards
  inside the `findOneAndUpdate` filter so the check + update is a single round-trip
  (no TOCTOU). No separate "does it exist?" read for the happy path.
- **Threshold dedup**: `alertedAt80`/`alertedAt100` are set atomically via `updateOne`
  with `{ alertedAt80: null }` filter so only one pod wins the event emit per cycle.
- **resetWeek race safety**: `$ne weekKey` archive pass + E11000 retry on upsert
  handles concurrent pod resets gracefully.
- **refundPartial negative balance**: if units already consumed, balance goes negative —
  this is the correct economic reflection and matches the design intent.

### Tests

79 new tests (739 total, baseline 660). All edge cases from the spec:
- creditPack same stripeSessionId 2× → 1 effect
- debit > balance → applied: false
- debit same refId 2× → second no-op
- incrementMeter same historyId 2× → replay (no-op)
- incrementMeter overflow → extrasConsumed correct
- threshold 80/100 deduped per cycle
- expireOldEntries idempotent
- refundPartial consumed balance → negative (applied: true)
- bumpVersionWithRetry E11000 retry then success

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 739 passing
- [ ] PR review + CodeRabbit pass
- [ ] Downstream trawl_node integration (T-N2) after merge

Refs #3533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added prepaid balance system with support for credit packs, debits, refunds, and automatic expiration.
  * Implemented weekly meter-based billing with automatic periodic resets.
  * Enhanced usage tracking with per-feature consumption breakdown.
  * Added threshold alerts at 80% and 100% of quota utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->