### PR TITLE
feat(billing): webhook idempotency + refund flow (PR-N3)

### DIFF
--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -12,6 +12,7 @@ import BillingWebhookService from '../services/billing.webhook.service.js';
  * @param {Object} res - Express response object
  * @returns {Promise<void>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
 const handleWebhook = async (req, res) => {
   const stripe = getStripe();
   if (!stripe) return res.status(400).json({ error: 'Stripe is not configured' });
@@ -29,16 +30,34 @@ const handleWebhook = async (req, res) => {
   try {
     switch (event.type) {
       case 'checkout.session.completed':
-        await BillingWebhookService.handleCheckoutCompleted(event.data.object);
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleCheckoutSessionCompleted(e),
+        );
         break;
       case 'customer.subscription.updated':
-        await BillingWebhookService.handleSubscriptionUpdated(event.data.object, event);
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleSubscriptionUpdated(e.data.object, e),
+        );
         break;
       case 'customer.subscription.deleted':
-        await BillingWebhookService.handleSubscriptionDeleted(event.data.object);
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleSubscriptionDeleted(e.data.object),
+        );
         break;
       case 'invoice.payment_failed':
-        await BillingWebhookService.handleInvoicePaymentFailed(event.data.object);
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleInvoicePaymentFailed(e.data.object),
+        );
+        break;
+      case 'invoice.payment_succeeded':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleInvoicePaymentSucceeded(e.data.object),
+        );
+        break;
+      case 'charge.refunded':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleChargeRefunded(e.data.object),
+        );
         break;
       default:
         break;

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -1,0 +1,61 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+/**
+ * Lazily resolves the ProcessedStripeEvent Mongoose model.
+ * Deferred to keep unit tests importable before model registration.
+ * @returns {import('mongoose').Model} The registered ProcessedStripeEvent model.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const ProcessedStripeEvent = () => mongoose.model('ProcessedStripeEvent');
+
+/**
+ * @function tryRecord
+ * @description Atomically insert a new processed event document.
+ *              If a document with the same eventId already exists (E11000 duplicate key),
+ *              returns `{ recorded: false }` instead of throwing — idempotency by design.
+ *              On success, returns `{ recorded: true }`.
+ * @param {string} eventId - Stripe event ID (unique idempotency key).
+ * @param {string} type - Stripe event type (e.g. 'checkout.session.completed').
+ * @returns {Promise<{recorded: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const tryRecord = async (eventId, type) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') {
+    throw new Error('invalid argument: eventId must be a non-empty string');
+  }
+  if (typeof type !== 'string' || type.trim() === '') {
+    throw new Error('invalid argument: type must be a non-empty string');
+  }
+
+  try {
+    await ProcessedStripeEvent().create({ eventId, type, processedAt: new Date() });
+    return { recorded: true };
+  } catch (err) {
+    if (err.code === 11000) {
+      return { recorded: false };
+    }
+    throw err;
+  }
+};
+
+/**
+ * @function wasProcessed
+ * @description Check whether a Stripe event has already been processed.
+ *              Optional helper — primarily useful for admin tooling and tests.
+ * @param {string} eventId - Stripe event ID to look up.
+ * @returns {Promise<boolean>} True if the event was already recorded, false otherwise.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const wasProcessed = async (eventId) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') return false;
+  const doc = await ProcessedStripeEvent().findOne({ eventId }).lean();
+  return doc !== null;
+};
+
+export default {
+  tryRecord,
+  wasProcessed,
+};

--- a/modules/billing/services/billing.refund.service.js
+++ b/modules/billing/services/billing.refund.service.js
@@ -1,0 +1,47 @@
+/**
+ * Module dependencies
+ */
+import getStripe from '../lib/stripe.js';
+
+/**
+ * @function refundCharge
+ * @description Initiate a Stripe refund for a given charge.
+ *              Wraps stripe.refunds.create with a deterministic idempotency key so
+ *              retries on network failures never create duplicate refunds.
+ *              The actual ledger debit happens via the `charge.refunded` webhook
+ *              (single source of truth) — this service ONLY initiates the Stripe refund.
+ *
+ * @param {string} stripeChargeId - Stripe charge ID (ch_xxx). Must be non-empty.
+ * @param {number|undefined} [amountCents] - Amount to refund in cents. Omit for full refund. Must be > 0 if provided.
+ * @returns {Promise<Object>} The Stripe refund object.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const refundCharge = async (stripeChargeId, amountCents) => {
+  if (typeof stripeChargeId !== 'string' || stripeChargeId.trim() === '') {
+    throw new Error('invalid argument: stripeChargeId must be a non-empty string');
+  }
+  if (amountCents !== undefined) {
+    if (!Number.isInteger(amountCents) || amountCents <= 0) {
+      throw new Error('invalid argument: amountCents must be a positive integer');
+    }
+  }
+
+  const stripe = getStripe();
+  if (!stripe) throw new Error('Stripe is not configured');
+
+  const idempotencyKey = `refund_${stripeChargeId}_${amountCents ?? 'full'}`;
+
+  const params = {
+    charge: stripeChargeId,
+    reason: 'requested_by_customer',
+  };
+  if (amountCents !== undefined) {
+    params.amount = amountCents;
+  }
+
+  return stripe.refunds.create(params, { idempotencyKey });
+};
+
+export default {
+  refundCharge,
+};

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -18,7 +18,7 @@ const Organization = mongoose.model('Organization');
 const validPlans = new Set(config.billing?.plans || ['free', 'starter', 'pro', 'enterprise']);
 
 /**
- * @desc Validate that a plan name is a known enum value.
+ * @description Validate that a plan name is a known enum value.
  * @param {string} plan - The plan name to validate.
  * @returns {string|null} The plan name if valid, null otherwise.
  */
@@ -31,7 +31,7 @@ const validatePlan = (plan) => (validPlans.has(plan) ? plan : null);
 const planRanks = Object.fromEntries((config.billing?.plans || []).map((p, i) => [p, i]));
 
 /**
- * @desc Resolve the plan name from a Stripe subscription object.
+ * @description Resolve the plan name from a Stripe subscription object.
  * In webhook payloads, price.product is typically a string ID (not expanded),
  * so we check price.metadata first, then fall back to plan.metadata.
  * @param {Object} subscription - Stripe subscription object
@@ -44,7 +44,7 @@ const resolvePlan = (subscription) => {
 };
 
 /**
- * @desc Sync the organization plan field to match the subscription plan
+ * @description Sync the organization plan field to match the subscription plan
  * @param {String} organizationId - Organization document ID
  * @param {String} plan - Plan name to set
  * @returns {Promise<void>}
@@ -55,23 +55,37 @@ const syncOrganizationPlan = async (organizationId, plan) => {
 };
 
 /**
- * @desc Wrap a webhook handler with idempotency using ProcessedStripeEvent.
- *       If the event has already been processed, returns { skipped: true, reason: 'duplicate_event' }.
- *       Otherwise records the event and delegates to handler(event).
- *       Handler receives the full Stripe event object.
+ * @description Wrap a webhook handler with idempotency using ProcessedStripeEvent.
+ *
+ * Semantics:
+ * - Pre-check via wasProcessed: short-circuits Stripe retries of identical events that already
+ *   completed — handler is not invoked again.
+ * - Record AFTER handler: if handler throws, the event remains "not processed" so Stripe can
+ *   retry and the handler can eventually succeed. Prevents silent loss.
+ * - TOCTOU between wasProcessed and tryRecord: two concurrent Stripe deliveries of the same
+ *   event can both pass wasProcessed and both run handler. Acceptable because data-layer
+ *   mutations are idempotent (creditPack uses $ne stripeSessionId, refundPartial uses $ne refId,
+ *   subscription update is last-write-wins). tryRecord is best-effort dedup after success.
+ *
  * @param {Object} event - Full Stripe event object (must have event.id and event.type).
  * @param {Function} handler - Async function (event) => result called when event is new.
- * @returns {Promise<Object>} Handler result or skip sentinel.
+ * @returns {Promise<Object>} Handler result or skip sentinel { skipped: true, reason: 'duplicate_event' }.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const withIdempotency = async (event, handler) => {
-  const { recorded } = await ProcessedStripeEventRepository.tryRecord(event.id, event.type);
-  if (!recorded) return { skipped: true, reason: 'duplicate_event' };
-  return handler(event);
+  // Pre-check: if already processed, skip (Stripe retry of the same event)
+  if (await ProcessedStripeEventRepository.wasProcessed(event.id)) {
+    return { skipped: true, reason: 'duplicate_event' };
+  }
+  // Run handler first — data-layer is already idempotent (creditPack, refundPartial, etc.)
+  const result = await handler(event);
+  // Best-effort dedup hint after success — TOCTOU is acceptable since data-layer guards prevent double-effect
+  await ProcessedStripeEventRepository.tryRecord(event.id, event.type);
+  return result;
 };
 
 /**
- * @desc Handle checkout.session.completed event — route by session.mode.
+ * @description Handle checkout.session.completed event — route by session.mode.
  *       mode='subscription' → handleCheckoutCompleted (plan subscription activation).
  *       mode='payment'      → handleCheckoutPaymentCompleted (extras pack credit).
  * @param {Object} event - Full Stripe event (data.object is the session)
@@ -87,7 +101,7 @@ const handleCheckoutSessionCompleted = async (event) => {
 };
 
 /**
- * @desc Handle checkout.session.completed for mode='subscription' — create or update subscription
+ * @description Handle checkout.session.completed for mode='subscription' — create or update subscription
  * @param {Object} session - Stripe checkout session object
  * @returns {Promise<void>}
  */
@@ -128,14 +142,16 @@ const handleCheckoutCompleted = async (session) => {
 };
 
 /**
- * @desc Handle checkout.session.completed for mode='payment' — credit extras pack.
+ * @description Handle checkout.session.completed for mode='payment' — credit extras pack.
  *       Extracts organizationId, packId, kind from session metadata.
- *       Skips silently if kind !== 'extras' or metadata is incomplete.
+ *       Skips silently if payment_status !== 'paid', kind !== 'extras', or metadata is incomplete.
  * @param {Object} session - Stripe checkout session object (mode='payment')
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleCheckoutPaymentCompleted = async (session) => {
+  if (session.payment_status !== 'paid') return;
+
   const { metadata, id: stripeSessionId } = session;
   const { organizationId, packId, kind } = metadata ?? {};
 
@@ -147,7 +163,7 @@ const handleCheckoutPaymentCompleted = async (session) => {
 };
 
 /**
- * @desc Handle customer.subscription.updated event — sync subscription state.
+ * @description Handle customer.subscription.updated event — sync subscription state.
  *       Also triggers resetWeek when current_period_start changes (billing period renewal).
  * @param {Object} subscription - Stripe subscription object
  * @param {Object} event - Full Stripe event (with data.previous_attributes for plan/period change detection)
@@ -213,7 +229,7 @@ const handleSubscriptionUpdated = async (subscription, event) => {
 };
 
 /**
- * @desc Handle customer.subscription.deleted event — cancel subscription
+ * @description Handle customer.subscription.deleted event — cancel subscription
  * @param {Object} subscription - Stripe subscription object
  * @returns {Promise<void>}
  */
@@ -232,7 +248,7 @@ const handleSubscriptionDeleted = async (subscription) => {
 };
 
 /**
- * @desc Handle invoice.payment_failed event — mark subscription as past_due
+ * @description Handle invoice.payment_failed event — mark subscription as past_due
  * @param {Object} invoice - Stripe invoice object
  * @returns {Promise<void>}
  */
@@ -251,7 +267,7 @@ const handleInvoicePaymentFailed = async (invoice) => {
 };
 
 /**
- * @desc Handle invoice.payment_succeeded event — clear degraded mode (pastDueSince).
+ * @description Handle invoice.payment_succeeded event — clear degraded mode (pastDueSince).
  *       When a past-due invoice is finally paid, remove the pastDueSince marker so
  *       the subscription exits degraded mode on next request.
  * @param {Object} invoice - Stripe invoice object
@@ -276,9 +292,16 @@ const handleInvoicePaymentSucceeded = async (invoice) => {
 };
 
 /**
- * @desc Handle charge.refunded event — debit ledger proportionally.
- *       The organizationId and stripeSessionId are expected in charge.metadata
- *       (Stripe propagates checkout session metadata to the charge automatically).
+ * @description Handle charge.refunded event — debit ledger proportionally.
+ *       Reads charge.metadata.{organizationId, stripeSessionId} which must be propagated
+ *       via the upstream session creation pattern:
+ *         stripe.checkout.sessions.create({
+ *           ...,
+ *           metadata: { organizationId, stripeSessionId, ... },
+ *           payment_intent_data: { metadata: { organizationId, stripeSessionId, ... } },
+ *         })
+ *       Without payment_intent_data.metadata, charge.metadata will be empty and refunds
+ *       silently skip. Downstream (trawl_node) is responsible for setting these at session creation.
  *       Calls BillingExtraService.refundPartial which computes refundUnits from
  *       the original topup entry and config.billing.packs.
  *       Skips if metadata is incomplete or amount_refunded is zero.
@@ -290,7 +313,8 @@ const handleChargeRefunded = async (charge) => {
   const { amount_refunded: amountRefunded, metadata } = charge;
 
   // The session ID and organizationId must have been stamped on charge metadata
-  // via checkout.session.completed (Stripe propagates session metadata to the charge).
+  // via payment_intent_data.metadata at session creation (not automatic — caller must set both
+  // session.metadata and payment_intent_data.metadata explicitly).
   const { organizationId, stripeSessionId } = metadata ?? {};
 
   if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -5,6 +5,9 @@ import mongoose from 'mongoose';
 
 import config from '../../../config/index.js';
 import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
+import ProcessedStripeEventRepository from '../repositories/billing.processedStripeEvent.repository.js';
+import BillingExtraService from './billing.extra.service.js';
+import BillingResetService from './billing.reset.service.js';
 import billingEvents from '../lib/events.js';
 
 const Organization = mongoose.model('Organization');
@@ -52,10 +55,43 @@ const syncOrganizationPlan = async (organizationId, plan) => {
 };
 
 /**
- * @desc Handle checkout.session.completed event — create or update subscription
+ * @desc Wrap a webhook handler with idempotency using ProcessedStripeEvent.
+ *       If the event has already been processed, returns { skipped: true, reason: 'duplicate_event' }.
+ *       Otherwise records the event and delegates to handler(event).
+ *       Handler receives the full Stripe event object.
+ * @param {Object} event - Full Stripe event object (must have event.id and event.type).
+ * @param {Function} handler - Async function (event) => result called when event is new.
+ * @returns {Promise<Object>} Handler result or skip sentinel.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const withIdempotency = async (event, handler) => {
+  const { recorded } = await ProcessedStripeEventRepository.tryRecord(event.id, event.type);
+  if (!recorded) return { skipped: true, reason: 'duplicate_event' };
+  return handler(event);
+};
+
+/**
+ * @desc Handle checkout.session.completed event — route by session.mode.
+ *       mode='subscription' → handleCheckoutCompleted (plan subscription activation).
+ *       mode='payment'      → handleCheckoutPaymentCompleted (extras pack credit).
+ * @param {Object} event - Full Stripe event (data.object is the session)
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleCheckoutSessionCompleted = async (event) => {
+  const session = event.data.object;
+  if (session.mode === 'payment') {
+    return handleCheckoutPaymentCompleted(session);
+  }
+  return handleCheckoutCompleted(session);
+};
+
+/**
+ * @desc Handle checkout.session.completed for mode='subscription' — create or update subscription
  * @param {Object} session - Stripe checkout session object
  * @returns {Promise<void>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleCheckoutCompleted = async (session) => {
   const { customer: stripeCustomerId, subscription: stripeSubscriptionId, metadata } = session;
   let organizationId = metadata?.organizationId;
@@ -92,23 +128,51 @@ const handleCheckoutCompleted = async (session) => {
 };
 
 /**
- * @desc Handle customer.subscription.updated event — sync subscription state
- * @param {Object} subscription - Stripe subscription object
- * @param {Object} event - Full Stripe event (with data.previous_attributes for plan change detection)
+ * @desc Handle checkout.session.completed for mode='payment' — credit extras pack.
+ *       Extracts organizationId, packId, kind from session metadata.
+ *       Skips silently if kind !== 'extras' or metadata is incomplete.
+ * @param {Object} session - Stripe checkout session object (mode='payment')
  * @returns {Promise<void>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleCheckoutPaymentCompleted = async (session) => {
+  const { metadata, id: stripeSessionId } = session;
+  const { organizationId, packId, kind } = metadata ?? {};
+
+  if (kind !== 'extras') return;
+  if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
+  if (!packId) return;
+
+  await BillingExtraService.creditPack(organizationId, packId, stripeSessionId);
+};
+
+/**
+ * @desc Handle customer.subscription.updated event — sync subscription state.
+ *       Also triggers resetWeek when current_period_start changes (billing period renewal).
+ * @param {Object} subscription - Stripe subscription object
+ * @param {Object} event - Full Stripe event (with data.previous_attributes for plan/period change detection)
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleSubscriptionUpdated = async (subscription, event) => {
   const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
   if (!existing) return;
 
   const newPlan = resolvePlan(subscription);
-  await SubscriptionRepository.update({
+  const newPeriodStart = subscription.current_period_start
+    ? new Date(subscription.current_period_start * 1000)
+    : undefined;
+
+  const updatePayload = {
     _id: existing._id,
     plan: newPlan,
     status: subscription.status,
     currentPeriodEnd: new Date(subscription.current_period_end * 1000),
     cancelAtPeriodEnd: subscription.cancel_at_period_end,
-  });
+  };
+  if (newPeriodStart) updatePayload.currentPeriodStart = newPeriodStart;
+
+  await SubscriptionRepository.update(updatePayload);
 
   const organizationId = String(existing.organization?._id || existing.organization);
   await syncOrganizationPlan(organizationId, newPlan);
@@ -134,6 +198,18 @@ const handleSubscriptionUpdated = async (subscription, event) => {
       } catch { /* listener errors must not disrupt webhook processing */ }
     }
   }
+
+  // Detect period start change — trigger weekly meter reset
+  const previousPeriodStart = event?.data?.previous_attributes?.current_period_start;
+  if (
+    previousPeriodStart !== undefined &&
+    subscription.current_period_start !== previousPeriodStart &&
+    newPeriodStart
+  ) {
+    try {
+      await BillingResetService.resetWeek(organizationId, newPeriodStart);
+    } catch { /* reset errors must not disrupt webhook processing */ }
+  }
 };
 
 /**
@@ -141,6 +217,7 @@ const handleSubscriptionUpdated = async (subscription, event) => {
  * @param {Object} subscription - Stripe subscription object
  * @returns {Promise<void>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleSubscriptionDeleted = async (subscription) => {
   const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
   if (!existing) return;
@@ -159,6 +236,7 @@ const handleSubscriptionDeleted = async (subscription) => {
  * @param {Object} invoice - Stripe invoice object
  * @returns {Promise<void>}
  */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleInvoicePaymentFailed = async (invoice) => {
   const { subscription: stripeSubscriptionId } = invoice;
   if (!stripeSubscriptionId) return;
@@ -172,9 +250,65 @@ const handleInvoicePaymentFailed = async (invoice) => {
   });
 };
 
+/**
+ * @desc Handle invoice.payment_succeeded event — clear degraded mode (pastDueSince).
+ *       When a past-due invoice is finally paid, remove the pastDueSince marker so
+ *       the subscription exits degraded mode on next request.
+ * @param {Object} invoice - Stripe invoice object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleInvoicePaymentSucceeded = async (invoice) => {
+  const { subscription: stripeSubscriptionId } = invoice;
+  if (!stripeSubscriptionId) return;
+
+  const existing = await SubscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId);
+  if (!existing) return;
+
+  // Only clear if currently past_due (avoid unnecessary writes on routine invoices)
+  if (existing.pastDueSince !== null && existing.pastDueSince !== undefined) {
+    await SubscriptionRepository.update({
+      _id: existing._id,
+      pastDueSince: null,
+      status: 'active',
+    });
+  }
+};
+
+/**
+ * @desc Handle charge.refunded event — debit ledger proportionally.
+ *       The organizationId and stripeSessionId are expected in charge.metadata
+ *       (Stripe propagates checkout session metadata to the charge automatically).
+ *       Calls BillingExtraService.refundPartial which computes refundUnits from
+ *       the original topup entry and config.billing.packs.
+ *       Skips if metadata is incomplete or amount_refunded is zero.
+ * @param {Object} charge - Stripe charge object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleChargeRefunded = async (charge) => {
+  const { amount_refunded: amountRefunded, metadata } = charge;
+
+  // The session ID and organizationId must have been stamped on charge metadata
+  // via checkout.session.completed (Stripe propagates session metadata to the charge).
+  const { organizationId, stripeSessionId } = metadata ?? {};
+
+  if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
+  if (!stripeSessionId) return;
+  if (!amountRefunded || amountRefunded <= 0) return;
+
+  // Service layer computes proportional refundUnits from config.billing.packs.
+  await BillingExtraService.refundPartial(organizationId, stripeSessionId, amountRefunded);
+};
+
 export default {
+  withIdempotency,
+  handleCheckoutSessionCompleted,
   handleCheckoutCompleted,
+  handleCheckoutPaymentCompleted,
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
+  handleInvoicePaymentSucceeded,
+  handleChargeRefunded,
 };

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -224,7 +224,10 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   ) {
     try {
       await BillingResetService.resetWeek(organizationId, newPeriodStart);
-    } catch { /* reset errors must not disrupt webhook processing */ }
+    } catch (err) {
+      // Log for monitoring — not thrown so webhook processing continues
+      console.error('[billing.webhook] resetWeek failed (non-fatal):', err?.message ?? err);
+    }
   }
 };
 
@@ -304,13 +307,15 @@ const handleInvoicePaymentSucceeded = async (invoice) => {
  *       silently skip. Downstream (trawl_node) is responsible for setting these at session creation.
  *       Calls BillingExtraService.refundPartial which computes refundUnits from
  *       the original topup entry and config.billing.packs.
- *       Skips if metadata is incomplete or amount_refunded is zero.
+ *       Uses charge.refunds.data[0].amount (this event's refund delta) rather than
+ *       charge.amount_refunded (cumulative total) to avoid over-debiting on multiple partial refunds.
+ *       Skips if metadata is incomplete or the refund amount is zero.
  * @param {Object} charge - Stripe charge object
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleChargeRefunded = async (charge) => {
-  const { amount_refunded: amountRefunded, metadata } = charge;
+  const { metadata } = charge;
 
   // The session ID and organizationId must have been stamped on charge metadata
   // via payment_intent_data.metadata at session creation (not automatic — caller must set both
@@ -319,10 +324,14 @@ const handleChargeRefunded = async (charge) => {
 
   if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
   if (!stripeSessionId) return;
-  if (!amountRefunded || amountRefunded <= 0) return;
+
+  // Use this event's refund delta (charge.refunds.data[0].amount), not the cumulative
+  // charge.amount_refunded — prevents over-debiting when multiple partial refunds occur.
+  const thisRefundAmount = charge.refunds?.data?.[0]?.amount;
+  if (!thisRefundAmount || thisRefundAmount <= 0) return;
 
   // Service layer computes proportional refundUnits from config.billing.packs.
-  await BillingExtraService.refundPartial(organizationId, stripeSessionId, amountRefunded);
+  await BillingExtraService.refundPartial(organizationId, stripeSessionId, thisRefundAmount);
 };
 
 export default {

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -16,10 +16,15 @@ describe('Billing webhook controller unit tests:', () => {
     jest.resetModules();
 
     mockBillingWebhookService = {
+      withIdempotency: jest.fn().mockImplementation(async (event, handler) => handler(event)),
+      handleCheckoutSessionCompleted: jest.fn().mockResolvedValue(),
       handleCheckoutCompleted: jest.fn().mockResolvedValue(),
+      handleCheckoutPaymentCompleted: jest.fn().mockResolvedValue(),
       handleSubscriptionUpdated: jest.fn().mockResolvedValue(),
       handleSubscriptionDeleted: jest.fn().mockResolvedValue(),
       handleInvoicePaymentFailed: jest.fn().mockResolvedValue(),
+      handleInvoicePaymentSucceeded: jest.fn().mockResolvedValue(),
+      handleChargeRefunded: jest.fn().mockResolvedValue(),
     };
 
     jest.unstable_mockModule('../services/billing.webhook.service.js', () => ({
@@ -103,7 +108,7 @@ describe('Billing webhook controller unit tests:', () => {
     const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw' };
     await BillingWebhookController.handleWebhook(req, res);
 
-    expect(mockBillingWebhookService.handleCheckoutCompleted).toHaveBeenCalledWith({ id: 'cs_123' });
+    expect(mockBillingWebhookService.handleCheckoutSessionCompleted).toHaveBeenCalledWith(eventData);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ received: true });
   });
@@ -123,6 +128,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleSubscriptionUpdated).toHaveBeenCalledWith({ id: 'sub_123' }, eventData);
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -141,6 +147,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleSubscriptionDeleted).toHaveBeenCalledWith({ id: 'sub_del' });
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -159,6 +166,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleInvoicePaymentFailed).toHaveBeenCalledWith({ id: 'inv_fail' });
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -187,7 +195,7 @@ describe('Billing webhook controller unit tests:', () => {
 
     const eventData = { type: 'checkout.session.completed', data: { object: { id: 'cs_err' } } };
     mockStripeInstance.webhooks.constructEvent.mockReturnValue(eventData);
-    mockBillingWebhookService.handleCheckoutCompleted.mockRejectedValue(new Error('DB error'));
+    mockBillingWebhookService.handleCheckoutSessionCompleted.mockRejectedValue(new Error('DB error'));
 
     const mod = await import('../controllers/billing.webhook.controller.js');
     BillingWebhookController = mod.default;

--- a/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
@@ -1,0 +1,139 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.processedStripeEvent.repository.js
+ */
+describe('ProcessedStripeEventRepository unit tests:', () => {
+  let ProcessedStripeEventRepository;
+  let mockModel;
+
+  const makeE11000 = () => {
+    const err = new Error('E11000 duplicate key error');
+    err.code = 11000;
+    return err;
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockModel = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        model: jest.fn(() => mockModel),
+      },
+    }));
+
+    const mod = await import('../repositories/billing.processedStripeEvent.repository.js');
+    ProcessedStripeEventRepository = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('tryRecord', () => {
+    test('should return { recorded: true } on first insert', async () => {
+      mockModel.create.mockResolvedValue({ eventId: 'evt_abc', type: 'checkout.session.completed' });
+
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_abc', 'checkout.session.completed');
+
+      expect(result).toEqual({ recorded: true });
+      expect(mockModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'evt_abc', type: 'checkout.session.completed' }),
+      );
+    });
+
+    test('should return { recorded: false } on duplicate eventId (E11000)', async () => {
+      mockModel.create.mockRejectedValueOnce(makeE11000());
+
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_abc', 'checkout.session.completed');
+
+      expect(result).toEqual({ recorded: false });
+    });
+
+    test('same eventId twice — second returns { recorded: false }', async () => {
+      mockModel.create
+        .mockResolvedValueOnce({ eventId: 'evt_dup', type: 'charge.refunded' })
+        .mockRejectedValueOnce(makeE11000());
+
+      const first = await ProcessedStripeEventRepository.tryRecord('evt_dup', 'charge.refunded');
+      const second = await ProcessedStripeEventRepository.tryRecord('evt_dup', 'charge.refunded');
+
+      expect(first).toEqual({ recorded: true });
+      expect(second).toEqual({ recorded: false });
+    });
+
+    test('should throw for non-duplicate errors', async () => {
+      const genericError = new Error('MongoDB connection lost');
+      mockModel.create.mockRejectedValue(genericError);
+
+      await expect(
+        ProcessedStripeEventRepository.tryRecord('evt_abc', 'checkout.session.completed'),
+      ).rejects.toThrow('MongoDB connection lost');
+    });
+
+    test('should throw for empty eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.tryRecord('', 'checkout.session.completed'),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+
+    test('should throw for non-string eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.tryRecord(null, 'checkout.session.completed'),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+
+    test('should throw for empty type', async () => {
+      await expect(
+        ProcessedStripeEventRepository.tryRecord('evt_abc', ''),
+      ).rejects.toThrow('invalid argument: type must be a non-empty string');
+    });
+
+    test('should throw for non-string type', async () => {
+      await expect(
+        ProcessedStripeEventRepository.tryRecord('evt_abc', null),
+      ).rejects.toThrow('invalid argument: type must be a non-empty string');
+    });
+  });
+
+  describe('wasProcessed', () => {
+    test('should return true when event exists', async () => {
+      mockModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ eventId: 'evt_xyz', type: 'charge.refunded' }),
+      });
+
+      const result = await ProcessedStripeEventRepository.wasProcessed('evt_xyz');
+
+      expect(result).toBe(true);
+      expect(mockModel.findOne).toHaveBeenCalledWith({ eventId: 'evt_xyz' });
+    });
+
+    test('should return false when event does not exist', async () => {
+      mockModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await ProcessedStripeEventRepository.wasProcessed('evt_missing');
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false for empty eventId', async () => {
+      const result = await ProcessedStripeEventRepository.wasProcessed('');
+      expect(result).toBe(false);
+    });
+
+    test('should return false for non-string eventId', async () => {
+      const result = await ProcessedStripeEventRepository.wasProcessed(null);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -1,0 +1,124 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.refund.service.js
+ */
+describe('BillingRefundService unit tests:', () => {
+  let BillingRefundService;
+  let mockStripeInstance;
+  let mockGetStripe;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockStripeInstance = {
+      refunds: {
+        create: jest.fn().mockResolvedValue({
+          id: 're_test_abc',
+          amount: 4900,
+          status: 'succeeded',
+        }),
+      },
+    };
+
+    mockGetStripe = jest.fn(() => mockStripeInstance);
+
+    jest.unstable_mockModule('../lib/stripe.js', () => ({
+      default: mockGetStripe,
+    }));
+
+    const mod = await import('../services/billing.refund.service.js');
+    BillingRefundService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('refundCharge', () => {
+    test('should call stripe.refunds.create with charge and reason', async () => {
+      const result = await BillingRefundService.refundCharge('ch_test_xyz');
+
+      expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
+        { charge: 'ch_test_xyz', reason: 'requested_by_customer' },
+        { idempotencyKey: 'refund_ch_test_xyz_full' },
+      );
+      expect(result.id).toBe('re_test_abc');
+    });
+
+    test('should include amount when amountCents is provided', async () => {
+      await BillingRefundService.refundCharge('ch_test_xyz', 2000);
+
+      expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
+        { charge: 'ch_test_xyz', reason: 'requested_by_customer', amount: 2000 },
+        { idempotencyKey: 'refund_ch_test_xyz_2000' },
+      );
+    });
+
+    test('idempotency key is "refund_{chargeId}_full" for full refund', async () => {
+      await BillingRefundService.refundCharge('ch_abc');
+
+      const call = mockStripeInstance.refunds.create.mock.calls[0];
+      expect(call[1].idempotencyKey).toBe('refund_ch_abc_full');
+    });
+
+    test('idempotency key is "refund_{chargeId}_{amountCents}" for partial refund', async () => {
+      await BillingRefundService.refundCharge('ch_abc', 500);
+
+      const call = mockStripeInstance.refunds.create.mock.calls[0];
+      expect(call[1].idempotencyKey).toBe('refund_ch_abc_500');
+    });
+
+    test('different amountCents produces different idempotency keys', async () => {
+      await BillingRefundService.refundCharge('ch_same', 1000);
+      await BillingRefundService.refundCharge('ch_same', 2000);
+
+      const keys = mockStripeInstance.refunds.create.mock.calls.map((c) => c[1].idempotencyKey);
+      expect(keys[0]).toBe('refund_ch_same_1000');
+      expect(keys[1]).toBe('refund_ch_same_2000');
+    });
+
+    test('should throw when Stripe is not configured', async () => {
+      mockGetStripe.mockReturnValue(null);
+
+      await expect(BillingRefundService.refundCharge('ch_test')).rejects.toThrow('Stripe is not configured');
+    });
+
+    test('should throw for empty stripeChargeId', async () => {
+      await expect(BillingRefundService.refundCharge('')).rejects.toThrow(
+        'invalid argument: stripeChargeId must be a non-empty string',
+      );
+    });
+
+    test('should throw for non-string stripeChargeId', async () => {
+      await expect(BillingRefundService.refundCharge(null)).rejects.toThrow(
+        'invalid argument: stripeChargeId must be a non-empty string',
+      );
+    });
+
+    test('should throw for zero amountCents', async () => {
+      await expect(BillingRefundService.refundCharge('ch_test', 0)).rejects.toThrow(
+        'invalid argument: amountCents must be a positive integer',
+      );
+    });
+
+    test('should throw for negative amountCents', async () => {
+      await expect(BillingRefundService.refundCharge('ch_test', -100)).rejects.toThrow(
+        'invalid argument: amountCents must be a positive integer',
+      );
+    });
+
+    test('should throw for non-integer amountCents', async () => {
+      await expect(BillingRefundService.refundCharge('ch_test', 9.99)).rejects.toThrow(
+        'invalid argument: amountCents must be a positive integer',
+      );
+    });
+
+    test('should accept undefined amountCents (full refund)', async () => {
+      await expect(BillingRefundService.refundCharge('ch_test', undefined)).resolves.toBeDefined();
+    });
+  });
+});

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -44,7 +44,10 @@ describe('Billing webhook checkout unit tests:', () => {
     }));
 
     jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
-      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+      default: {
+        wasProcessed: jest.fn().mockResolvedValue(false),
+        tryRecord: jest.fn().mockResolvedValue({ recorded: true }),
+      },
     }));
 
     jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
@@ -107,12 +110,13 @@ describe('Billing webhook checkout unit tests:', () => {
       expect(mockExtraService.creditPack).not.toHaveBeenCalled();
     });
 
-    test('mode=payment + kind=extras routes to handleCheckoutPaymentCompleted (creditPack)', async () => {
+    test('mode=payment + kind=extras + payment_status=paid routes to handleCheckoutPaymentCompleted (creditPack)', async () => {
       await BillingWebhookService.handleCheckoutSessionCompleted({
         data: {
           object: {
             id: stripeSessionId,
             mode: 'payment',
+            payment_status: 'paid',
             metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
           },
         },
@@ -128,6 +132,7 @@ describe('Billing webhook checkout unit tests:', () => {
           object: {
             id: stripeSessionId,
             mode: 'payment',
+            payment_status: 'paid',
             metadata: null,
           },
         },
@@ -143,6 +148,7 @@ describe('Billing webhook checkout unit tests:', () => {
           object: {
             id: stripeSessionId,
             mode: 'payment',
+            payment_status: 'paid',
             metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'donation' },
           },
         },
@@ -153,18 +159,30 @@ describe('Billing webhook checkout unit tests:', () => {
   });
 
   describe('handleCheckoutPaymentCompleted', () => {
-    test('should call creditPack with orgId, packId, sessionId', async () => {
+    test('should call creditPack with orgId, packId, sessionId when payment_status=paid', async () => {
       await BillingWebhookService.handleCheckoutPaymentCompleted({
         id: stripeSessionId,
+        payment_status: 'paid',
         metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
       });
 
       expect(mockExtraService.creditPack).toHaveBeenCalledWith(orgId, 'pack_500k', stripeSessionId);
     });
 
+    test('should skip creditPack when payment_status is not paid (e.g. unpaid)', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        payment_status: 'unpaid',
+        metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+
     test('should skip when kind is not extras', async () => {
       await BillingWebhookService.handleCheckoutPaymentCompleted({
         id: stripeSessionId,
+        payment_status: 'paid',
         metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'other' },
       });
 
@@ -174,15 +192,18 @@ describe('Billing webhook checkout unit tests:', () => {
     test('should skip when organizationId is invalid ObjectId', async () => {
       await BillingWebhookService.handleCheckoutPaymentCompleted({
         id: stripeSessionId,
+        payment_status: 'paid',
         metadata: { organizationId: 'not-valid', packId: 'pack_500k', kind: 'extras' },
       });
 
       expect(mockExtraService.creditPack).not.toHaveBeenCalled();
     });
 
-    test('should skip when packId is missing', async () => {
+    test('should skip silently when packId is missing', async () => {
+      // MEDIUM 3: explicit verification of the silent skip on missing packId
       await BillingWebhookService.handleCheckoutPaymentCompleted({
         id: stripeSessionId,
+        payment_status: 'paid',
         metadata: { organizationId: orgId, kind: 'extras' },
       });
 
@@ -192,6 +213,7 @@ describe('Billing webhook checkout unit tests:', () => {
     test('should skip when organizationId is missing', async () => {
       await BillingWebhookService.handleCheckoutPaymentCompleted({
         id: stripeSessionId,
+        payment_status: 'paid',
         metadata: { packId: 'pack_500k', kind: 'extras' },
       });
 

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -1,0 +1,238 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for checkout webhook handlers:
+ *   - handleCheckoutSessionCompleted routing (subscription vs payment mode)
+ *   - handleCheckoutPaymentCompleted (extras pack credit)
+ *   - handleCheckoutCompleted (subscription creation/update)
+ */
+describe('Billing webhook checkout unit tests:', () => {
+  let BillingWebhookService;
+  let mockSubscriptionRepository;
+  let mockOrganizationModel;
+  let mockExtraService;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const subId = '607f1f77bcf86cd799439022';
+  const stripeSessionId = 'cs_test_session_abc';
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
+      findByStripeCustomerId: jest.fn(),
+      findByStripeSubscriptionId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    mockOrganizationModel = {
+      findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue({}) }),
+    };
+
+    mockExtraService = {
+      creditPack: jest.fn().mockResolvedValue({ doc: {}, applied: true }),
+      refundPartial: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+    }));
+
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: mockExtraService,
+    }));
+
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({
+      default: { resetWeek: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: { emit: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: { plans: ['free', 'starter', 'pro', 'enterprise'] },
+      },
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: (name) => {
+          if (name === 'Organization') return mockOrganizationModel;
+          return {};
+        },
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('handleCheckoutSessionCompleted routing', () => {
+    test('mode=subscription routes to handleCheckoutCompleted (subscription update)', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleCheckoutSessionCompleted({
+        data: {
+          object: {
+            id: stripeSessionId,
+            mode: 'subscription',
+            customer: 'cus_123',
+            subscription: 'sub_456',
+            metadata: { organizationId: orgId, plan: 'pro' },
+          },
+        },
+      });
+
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ plan: 'pro', status: 'active' }),
+      );
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+
+    test('mode=payment + kind=extras routes to handleCheckoutPaymentCompleted (creditPack)', async () => {
+      await BillingWebhookService.handleCheckoutSessionCompleted({
+        data: {
+          object: {
+            id: stripeSessionId,
+            mode: 'payment',
+            metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
+          },
+        },
+      });
+
+      expect(mockExtraService.creditPack).toHaveBeenCalledWith(orgId, 'pack_500k', stripeSessionId);
+      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+    });
+
+    test('mode=payment without metadata skips creditPack', async () => {
+      await BillingWebhookService.handleCheckoutSessionCompleted({
+        data: {
+          object: {
+            id: stripeSessionId,
+            mode: 'payment',
+            metadata: null,
+          },
+        },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+    });
+
+    test('mode=payment + kind≠extras skips creditPack', async () => {
+      await BillingWebhookService.handleCheckoutSessionCompleted({
+        data: {
+          object: {
+            id: stripeSessionId,
+            mode: 'payment',
+            metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'donation' },
+          },
+        },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCheckoutPaymentCompleted', () => {
+    test('should call creditPack with orgId, packId, sessionId', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
+      });
+
+      expect(mockExtraService.creditPack).toHaveBeenCalledWith(orgId, 'pack_500k', stripeSessionId);
+    });
+
+    test('should skip when kind is not extras', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'other' },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+
+    test('should skip when organizationId is invalid ObjectId', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        metadata: { organizationId: 'not-valid', packId: 'pack_500k', kind: 'extras' },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+
+    test('should skip when packId is missing', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        metadata: { organizationId: orgId, kind: 'extras' },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+
+    test('should skip when organizationId is missing', async () => {
+      await BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        metadata: { packId: 'pack_500k', kind: 'extras' },
+      });
+
+      expect(mockExtraService.creditPack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCheckoutCompleted (mode=subscription)', () => {
+    test('should update existing subscription', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleCheckoutCompleted({
+        customer: 'cus_123',
+        subscription: 'sub_456',
+        metadata: { organizationId: orgId, plan: 'pro' },
+      });
+
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: subId, plan: 'pro', status: 'active' }),
+      );
+    });
+
+    test('should create subscription when none exists', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockSubscriptionRepository.create.mockResolvedValue({});
+
+      await BillingWebhookService.handleCheckoutCompleted({
+        customer: 'cus_123',
+        subscription: 'sub_456',
+        metadata: { organizationId: orgId, plan: 'starter' },
+      });
+
+      expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: orgId,
+          plan: 'starter',
+          status: 'active',
+        }),
+      );
+    });
+  });
+});

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -20,6 +20,7 @@ describe('Billing webhook idempotency unit tests:', () => {
     jest.resetModules();
 
     mockProcessedStripeEventRepository = {
+      wasProcessed: jest.fn(),
       tryRecord: jest.fn(),
     };
 
@@ -72,61 +73,88 @@ describe('Billing webhook idempotency unit tests:', () => {
   });
 
   describe('withIdempotency', () => {
-    test('should call handler when event is new (recorded=true)', async () => {
+    test('should call handler when event is new (wasProcessed=false), then record', async () => {
+      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
       mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
       const handler = jest.fn().mockResolvedValue({ ok: true });
       const event = makeEvent();
 
       const result = await BillingWebhookService.withIdempotency(event, handler);
 
-      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith('evt_test_001', 'checkout.session.completed');
+      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledWith('evt_test_001');
       expect(handler).toHaveBeenCalledWith(event);
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith('evt_test_001', 'checkout.session.completed');
       expect(result).toEqual({ ok: true });
     });
 
-    test('should skip handler and return { skipped: true } on duplicate event (recorded=false)', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false });
+    /**
+     * Stripe retry after success: wasProcessed returns true → handler not run.
+     * This is the primary dedup path for Stripe event retries after successful processing.
+     */
+    test('Stripe retry after success: wasProcessed=true → handler not run', async () => {
+      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(true);
       const handler = jest.fn();
       const event = makeEvent();
 
       const result = await BillingWebhookService.withIdempotency(event, handler);
 
+      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledWith('evt_test_001');
       expect(handler).not.toHaveBeenCalled();
+      expect(mockProcessedStripeEventRepository.tryRecord).not.toHaveBeenCalled();
       expect(result).toEqual({ skipped: true, reason: 'duplicate_event' });
     });
 
-    test('same event delivered twice — handler called exactly once', async () => {
+    /**
+     * Concurrent delivery: two simultaneous Stripe deliveries of the same event both pass
+     * wasProcessed (it's not atomic). Both handlers run (acceptable per data-layer idempotency).
+     * Only the first tryRecord succeeds; the second gets E11000 → recorded=false (best-effort).
+     */
+    test('concurrent delivery: both pass wasProcessed, both run handler, second tryRecord gets E11000', async () => {
+      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
       mockProcessedStripeEventRepository.tryRecord
         .mockResolvedValueOnce({ recorded: true })
-        .mockResolvedValueOnce({ recorded: false });
+        .mockResolvedValueOnce({ recorded: false }); // E11000 on the second concurrent delivery
 
       const handler = jest.fn().mockResolvedValue(undefined);
-      const event = makeEvent('evt_double', 'customer.subscription.updated');
+      const event = makeEvent('evt_concurrent', 'customer.subscription.updated');
 
-      await BillingWebhookService.withIdempotency(event, handler);
-      await BillingWebhookService.withIdempotency(event, handler);
+      // Both deliveries run concurrently — both pass wasProcessed
+      await Promise.all([
+        BillingWebhookService.withIdempotency(event, handler),
+        BillingWebhookService.withIdempotency(event, handler),
+      ]);
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      // Both handlers ran (acceptable — data-layer mutations are idempotent)
+      expect(handler).toHaveBeenCalledTimes(2);
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(2);
     });
 
-    test('should propagate errors thrown by handler', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+    /**
+     * Silent-loss fix proof: if handler throws, no record is persisted.
+     * Stripe will retry; the handler gets another chance → no silent event loss.
+     */
+    test('handler throws → no record persisted (silent-loss fix)', async () => {
+      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
       const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
       const event = makeEvent();
 
       await expect(
         BillingWebhookService.withIdempotency(event, handler),
       ).rejects.toThrow('handler blew up');
+
+      // tryRecord must NOT have been called — event stays unprocessed for Stripe to retry
+      expect(mockProcessedStripeEventRepository.tryRecord).not.toHaveBeenCalled();
     });
 
-    test('tryRecord called exactly once per withIdempotency invocation', async () => {
+    test('wasProcessed called exactly once per withIdempotency invocation', async () => {
+      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
       mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
       const handler = jest.fn().mockResolvedValue(undefined);
       const event = makeEvent('evt_single_check');
 
       await BillingWebhookService.withIdempotency(event, handler);
 
+      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledTimes(1);
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(1);
     });
   });

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -1,0 +1,133 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for webhook idempotency (withIdempotency guard)
+ */
+describe('Billing webhook idempotency unit tests:', () => {
+  let BillingWebhookService;
+  let mockProcessedStripeEventRepository;
+
+  const makeEvent = (id = 'evt_test_001', type = 'checkout.session.completed') => ({
+    id,
+    type,
+    data: { object: { id: 'obj_1' } },
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockProcessedStripeEventRepository = {
+      tryRecord: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: mockProcessedStripeEventRepository,
+    }));
+
+    // Minimal mocks so the service module loads without errors
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {
+        findByOrganization: jest.fn(),
+        findByStripeCustomerId: jest.fn(),
+        findByStripeSubscriptionId: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+    }));
+
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: { creditPack: jest.fn(), refundPartial: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({
+      default: { resetWeek: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: { emit: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: { plans: ['free', 'starter', 'pro', 'enterprise'] },
+      },
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: () => ({ findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn() }) }),
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('withIdempotency', () => {
+    test('should call handler when event is new (recorded=true)', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      const handler = jest.fn().mockResolvedValue({ ok: true });
+      const event = makeEvent();
+
+      const result = await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith('evt_test_001', 'checkout.session.completed');
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(result).toEqual({ ok: true });
+    });
+
+    test('should skip handler and return { skipped: true } on duplicate event (recorded=false)', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false });
+      const handler = jest.fn();
+      const event = makeEvent();
+
+      const result = await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result).toEqual({ skipped: true, reason: 'duplicate_event' });
+    });
+
+    test('same event delivered twice — handler called exactly once', async () => {
+      mockProcessedStripeEventRepository.tryRecord
+        .mockResolvedValueOnce({ recorded: true })
+        .mockResolvedValueOnce({ recorded: false });
+
+      const handler = jest.fn().mockResolvedValue(undefined);
+      const event = makeEvent('evt_double', 'customer.subscription.updated');
+
+      await BillingWebhookService.withIdempotency(event, handler);
+      await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(2);
+    });
+
+    test('should propagate errors thrown by handler', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
+      const event = makeEvent();
+
+      await expect(
+        BillingWebhookService.withIdempotency(event, handler),
+      ).rejects.toThrow('handler blew up');
+    });
+
+    test('tryRecord called exactly once per withIdempotency invocation', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      const handler = jest.fn().mockResolvedValue(undefined);
+      const event = makeEvent('evt_single_check');
+
+      await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -10,6 +10,12 @@ describe('Billing webhook idempotency unit tests:', () => {
   let BillingWebhookService;
   let mockProcessedStripeEventRepository;
 
+  /**
+   * Build a Stripe-like webhook event payload for idempotency tests.
+   * @param {string} [id='evt_test_001'] - Stripe event ID.
+   * @param {string} [type='checkout.session.completed'] - Stripe event type.
+   * @returns {{ id: string, type: string, data: { object: { id: string } } }} Minimal event object.
+   */
   const makeEvent = (id = 'evt_test_001', type = 'checkout.session.completed') => ({
     id,
     type,

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -15,13 +15,16 @@ describe('Billing webhook refund integration tests:', () => {
   const stripeSessionId = 'cs_test_session_abc';
 
   /**
+   * Build a stub Stripe charge object for charge.refunded webhook tests.
    * @param {Object} [overrides={}] - Fields to override on the stub charge object.
-   * @returns {Object} A stub Stripe charge object.
+   * @returns {Object} A stub Stripe charge object with refunds.data[0].amount set.
    */
   const makeCharge = (overrides = {}) => ({
     id: 'ch_test_001',
     amount: 4900,
     amount_refunded: 4900,
+    // charge.refunds.data[0].amount = this event's refund delta (not cumulative)
+    refunds: { data: [{ id: 'rf_test_001', amount: 4900 }] },
     metadata: {
       organizationId: orgId,
       stripeSessionId,
@@ -90,14 +93,24 @@ describe('Billing webhook refund integration tests:', () => {
   });
 
   describe('handleChargeRefunded', () => {
-    test('full refund — calls refundPartial with correct orgId, sessionId and amount', async () => {
-      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 4900 }));
+    test('full refund — calls refundPartial with correct orgId, sessionId and delta amount', async () => {
+      // refunds.data[0].amount = 4900 (this event's delta, same as total for single refund)
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({ refunds: { data: [{ id: 'rf_001', amount: 4900 }] } }),
+      );
 
       expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 4900);
     });
 
-    test('partial refund — calls refundPartial with partial amount', async () => {
-      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 2450 }));
+    test('partial refund — calls refundPartial with delta amount (not cumulative total)', async () => {
+      // Simulates 2nd of two 2450¢ partial refunds: amount_refunded=4900 (cumulative) but
+      // refunds.data[0].amount=2450 (this event's delta) — handler must use delta to avoid over-debit
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({
+          amount_refunded: 4900, // cumulative — should NOT be used
+          refunds: { data: [{ id: 'rf_002', amount: 2450 }] }, // delta — correct value
+        }),
+      );
 
       expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 2450);
     });
@@ -143,8 +156,19 @@ describe('Billing webhook refund integration tests:', () => {
       expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
     });
 
-    test('should skip when amount_refunded is zero', async () => {
-      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 0 }));
+    test('should skip when refunds.data[0].amount is absent or zero', async () => {
+      // refunds.data empty — no delta available
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({ refunds: { data: [] } }),
+      );
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should skip when refunds list is absent', async () => {
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({ refunds: undefined }),
+      );
 
       expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
     });

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -1,0 +1,140 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Integration tests for handleChargeRefunded webhook handler
+ */
+describe('Billing webhook refund integration tests:', () => {
+  let BillingWebhookService;
+  let mockExtraService;
+  let mockSubscriptionRepository;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const stripeSessionId = 'cs_test_session_abc';
+
+  /**
+   * @param {Object} [overrides={}] - Fields to override on the stub charge object.
+   * @returns {Object} A stub Stripe charge object.
+   */
+  const makeCharge = (overrides = {}) => ({
+    id: 'ch_test_001',
+    amount: 4900,
+    amount_refunded: 4900,
+    metadata: {
+      organizationId: orgId,
+      stripeSessionId,
+    },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockExtraService = {
+      creditPack: jest.fn(),
+      refundPartial: jest.fn().mockResolvedValue({ doc: {}, applied: true, refundUnits: 500000 }),
+    };
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
+      findByStripeCustomerId: jest.fn(),
+      findByStripeSubscriptionId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: mockExtraService,
+    }));
+
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({
+      default: { resetWeek: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+    }));
+
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: { emit: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: { plans: ['free', 'starter', 'pro', 'enterprise'] },
+      },
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: () => ({ findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn() }) }),
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('handleChargeRefunded', () => {
+    test('full refund — calls refundPartial with correct orgId, sessionId and amount', async () => {
+      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 4900 }));
+
+      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 4900);
+    });
+
+    test('partial refund — calls refundPartial with partial amount', async () => {
+      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 2450 }));
+
+      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 2450);
+    });
+
+    test('should skip when organizationId is missing', async () => {
+      const charge = makeCharge();
+      delete charge.metadata.organizationId;
+
+      await BillingWebhookService.handleChargeRefunded(charge);
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should skip when organizationId is invalid ObjectId', async () => {
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({ metadata: { organizationId: 'not-an-id', stripeSessionId } }),
+      );
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should skip when stripeSessionId is missing', async () => {
+      const charge = makeCharge();
+      delete charge.metadata.stripeSessionId;
+
+      await BillingWebhookService.handleChargeRefunded(charge);
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should skip when amount_refunded is zero', async () => {
+      await BillingWebhookService.handleChargeRefunded(makeCharge({ amount_refunded: 0 }));
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should skip when metadata is absent', async () => {
+      await BillingWebhookService.handleChargeRefunded(makeCharge({ metadata: undefined }));
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -58,7 +58,10 @@ describe('Billing webhook refund integration tests:', () => {
     }));
 
     jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
-      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+      default: {
+        wasProcessed: jest.fn().mockResolvedValue(false),
+        tryRecord: jest.fn().mockResolvedValue({ recorded: true }),
+      },
     }));
 
     jest.unstable_mockModule('../lib/events.js', () => ({
@@ -121,6 +124,21 @@ describe('Billing webhook refund integration tests:', () => {
       delete charge.metadata.stripeSessionId;
 
       await BillingWebhookService.handleChargeRefunded(charge);
+
+      expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    });
+
+    /**
+     * MEDIUM 4: explicit verification of the silent skip on missing stripeSessionId.
+     * Documents the upstream contract: charge.metadata.stripeSessionId is only present
+     * when the upstream session creation sets payment_intent_data.metadata explicitly.
+     * Without it, refunds silently skip — no service call, no error logged.
+     */
+    test('skips silently when charge.metadata lacks stripeSessionId (upstream contract)', async () => {
+      // Simulate a charge where payment_intent_data.metadata was NOT set at session creation
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({ metadata: { organizationId: orgId } }), // stripeSessionId absent
+      );
 
       expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
     });

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -45,7 +45,10 @@ describe('Billing webhook subscription unit tests:', () => {
     }));
 
     jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
-      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+      default: {
+        wasProcessed: jest.fn().mockResolvedValue(false),
+        tryRecord: jest.fn().mockResolvedValue({ recorded: true }),
+      },
     }));
 
     jest.unstable_mockModule('../services/billing.extra.service.js', () => ({

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -128,6 +128,7 @@ describe('Billing webhook subscription unit tests:', () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
       mockSubscriptionRepository.update.mockResolvedValue({});
 
+      // previous_attributes.current_period_start equals current value → no period change
       await BillingWebhookService.handleSubscriptionUpdated(
         {
           id: 'sub_456',
@@ -137,7 +138,7 @@ describe('Billing webhook subscription unit tests:', () => {
           cancel_at_period_end: false,
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
-        { data: { previous_attributes: {} } },
+        { data: { previous_attributes: { current_period_start: periodStart } } },
       );
 
       expect(mockResetService.resetWeek).not.toHaveBeenCalled();
@@ -163,7 +164,7 @@ describe('Billing webhook subscription unit tests:', () => {
       expect(mockResetService.resetWeek).not.toHaveBeenCalled();
     });
 
-    test('resetWeek errors should not disrupt webhook processing (swallowed)', async () => {
+    test('resetWeek errors should not disrupt webhook processing (logged, not thrown)', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
       mockSubscriptionRepository.update.mockResolvedValue({});

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -1,0 +1,277 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for subscription-related webhook handlers:
+ *   - handleSubscriptionUpdated (period_start change → resetWeek)
+ *   - handleInvoicePaymentSucceeded (pastDueSince cleared)
+ *   - handleInvoicePaymentFailed (status → past_due)
+ */
+describe('Billing webhook subscription unit tests:', () => {
+  let BillingWebhookService;
+  let mockSubscriptionRepository;
+  let mockOrganizationModel;
+  let mockResetService;
+  let mockEvents;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const subId = '607f1f77bcf86cd799439022';
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
+      findByStripeCustomerId: jest.fn(),
+      findByStripeSubscriptionId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    mockOrganizationModel = {
+      findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue({}) }),
+    };
+
+    mockResetService = {
+      resetWeek: jest.fn().mockResolvedValue({}),
+    };
+
+    mockEvents = { emit: jest.fn() };
+
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: { tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+    }));
+
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: { creditPack: jest.fn(), refundPartial: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({
+      default: mockResetService,
+    }));
+
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: mockEvents,
+    }));
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: {
+          plans: ['free', 'starter', 'pro', 'enterprise'],
+          meterMode: true,
+        },
+      },
+    }));
+
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: (name) => {
+          if (name === 'Organization') return mockOrganizationModel;
+          return {};
+        },
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('handleSubscriptionUpdated — period_start change', () => {
+    test('should call resetWeek when current_period_start changes', async () => {
+      const oldPeriodStart = 1700000000;
+      const newPeriodStart = 1700604800;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: newPeriodStart + 2592000,
+          current_period_start: newPeriodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              current_period_start: oldPeriodStart,
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).toHaveBeenCalledWith(
+        orgId,
+        new Date(newPeriodStart * 1000),
+      );
+    });
+
+    test('should NOT call resetWeek when current_period_start is unchanged', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: periodStart + 2592000,
+          current_period_start: periodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        { data: { previous_attributes: {} } },
+      );
+
+      expect(mockResetService.resetWeek).not.toHaveBeenCalled();
+    });
+
+    test('should NOT call resetWeek when previous_attributes has no current_period_start', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000 + 2592000,
+          current_period_start: 1700000000,
+          cancel_at_period_end: false,
+          items: { data: [] },
+        },
+        { data: { previous_attributes: { cancel_at_period_end: true } } },
+      );
+
+      expect(mockResetService.resetWeek).not.toHaveBeenCalled();
+    });
+
+    test('resetWeek errors should not disrupt webhook processing (swallowed)', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockResetService.resetWeek.mockRejectedValue(new Error('reset failed'));
+
+      // Should NOT throw
+      await expect(
+        BillingWebhookService.handleSubscriptionUpdated(
+          {
+            id: 'sub_456',
+            status: 'active',
+            current_period_end: 1700604800 + 2592000,
+            current_period_start: 1700604800,
+            cancel_at_period_end: false,
+            items: { data: [] },
+          },
+          { data: { previous_attributes: { current_period_start: 1700000000 } } },
+        ),
+      ).resolves.not.toThrow();
+    });
+
+    test('should update currentPeriodStart in subscription when period_start is present', async () => {
+      const newPeriodStart = 1700604800;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: newPeriodStart + 2592000,
+          current_period_start: newPeriodStart,
+          cancel_at_period_end: false,
+          items: { data: [] },
+        },
+        { data: { previous_attributes: {} } },
+      );
+
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentPeriodStart: new Date(newPeriodStart * 1000),
+        }),
+      );
+    });
+  });
+
+  describe('handleInvoicePaymentSucceeded', () => {
+    test('should clear pastDueSince and restore active status when subscription is past_due', async () => {
+      const existing = {
+        _id: subId,
+        organization: orgId,
+        pastDueSince: new Date('2026-04-01'),
+        status: 'past_due',
+      };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleInvoicePaymentSucceeded({ subscription: 'sub_456' });
+
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: subId, pastDueSince: null, status: 'active' }),
+      );
+    });
+
+    test('should NOT update when pastDueSince is null (routine invoice)', async () => {
+      const existing = {
+        _id: subId,
+        organization: orgId,
+        pastDueSince: null,
+        status: 'active',
+      };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+
+      await BillingWebhookService.handleInvoicePaymentSucceeded({ subscription: 'sub_456' });
+
+      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+    });
+
+    test('should return early when no subscription ID in invoice', async () => {
+      await BillingWebhookService.handleInvoicePaymentSucceeded({ subscription: null });
+
+      expect(mockSubscriptionRepository.findByStripeSubscriptionId).not.toHaveBeenCalled();
+    });
+
+    test('should return early when subscription not found', async () => {
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+
+      await BillingWebhookService.handleInvoicePaymentSucceeded({ subscription: 'sub_unknown' });
+
+      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleInvoicePaymentFailed', () => {
+    test('should set status to past_due', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: subId, status: 'past_due' }),
+      );
+    });
+
+    test('should return early when no subscription ID in invoice', async () => {
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: null });
+
+      expect(mockSubscriptionRepository.findByStripeSubscriptionId).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements PR-N3 of the Compute Pricing layer (#3533).

- **ProcessedStripeEventRepository** — `tryRecord(eventId, type)` atomic insert returning `{recorded: true/false}` on duplicate (E11000). `wasProcessed()` helper for admin/tests.
- **BillingRefundService** — `refundCharge(chargeId, amountCents)` wrapper around `stripe.refunds.create` with deterministic idempotency key `refund_{chargeId}_{amountCents|full}`. Input guards on both args.
- **Webhook idempotency** — `withIdempotency(event, handler)` wraps ALL handlers via ProcessedStripeEventRepository. Duplicate deliveries return `{skipped: true, reason: 'duplicate_event'}` without calling the handler.
- **New handlers**: `handleCheckoutSessionCompleted` (routes subscription vs payment), `handleCheckoutPaymentCompleted` (mode=payment + kind=extras → `creditPack`), `handleChargeRefunded` (amount_refunded → `BillingExtraService.refundPartial`), `handleInvoicePaymentSucceeded` (clears `pastDueSince` on recovery).
- **Extended `handleSubscriptionUpdated`** — persists `currentPeriodStart`, triggers `BillingResetService.resetWeek` when `previous_attributes.current_period_start` changes. Reset errors swallowed (non-blocking).
- **Controller** — extended switch with `charge.refunded` and `invoice.payment_succeeded`.

## Backward compat

All new code paths are either gated by webhook metadata (`kind === 'extras'`) or guard conditions (non-null `pastDueSince`). Idempotency wrapper is transparent to existing behavior.

## Lessons applied (PR-N1 + PR-N2 reviews)

- Repository pattern strict: `ProcessedStripeEventRepository` introduced, no new mongoose in services beyond pre-existing `Organization` model usage
- Biome FP comment on every exported arrow
- JSDoc on every exported function
- Atomic `tryRecord` embed guard in filter (no TOCTOU)
- Input guards (empty strings, non-positive amounts) throw early

## Tests

- 820 unit tests (was 783, +37)
- 286 integration tests (unchanged)
- New test files: `billing.processedStripeEvent.repository.unit.tests.js`, `billing.refund.service.unit.tests.js`, `billing.webhook.idempotency.unit.tests.js`, `billing.webhook.checkout.unit.tests.js`, `billing.webhook.subscription.unit.tests.js`, `billing.webhook.refund.integration.tests.js`

## Checklist

- [x] `npm run lint` clean
- [x] `npm run test:unit` — 820/820 pass
- [x] `npm run test:integration` — 286/286 pass
- [x] `grep "mongoose" modules/billing/services/*.js` — only pre-existing webhook service usage (Organization model + ObjectId.isValid)
- [x] All new code paths dormant when `metadata.kind !== 'extras'` (backward compat)

Closes part of #3533 (PR-N3 tasks). PR-N4 (routes + middleware) and PR-N5 (cron + dunning) remain open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added refund capability for Stripe charges with support for partial refunds.
  * Implemented idempotent webhook processing to prevent duplicate billing operations.
  * Added support for handling refund and payment success events from Stripe.

* **Improvements**
  * Enhanced subscription update handling with better period tracking and synchronization.
  * Improved payment success workflow to restore active subscription status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->