### PR TITLE
fix(billing): unblock Stripe Checkout (auto address) + admin meter bypass

### DIFF
--- a/modules/billing/middlewares/billing.requireQuota.js
+++ b/modules/billing/middlewares/billing.requireQuota.js
@@ -44,6 +44,10 @@ function requireQuota(resource, action) {
       return responses.error(res, 403, 'Forbidden', 'Organization context is required to check quota')();
     }
 
+    // Bypass for admin users or meter-exempt organizations
+    if (req.user?.roles?.includes('admin')) return next();
+    if (req.organization.meterExempt === true) return next();
+
     try {
       // ── Meter mode (meterMode: true) ──────────────────────────────────────
       if (config.billing?.meterMode === true) {

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -105,6 +105,7 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
       success_url: successUrl,
       cancel_url: cancelUrl,
       automatic_tax: { enabled: true },
+      customer_update: { address: 'auto', name: 'auto' },
       metadata: {
         organizationId: String(organization._id),
         plan: matchedPlan.planId,
@@ -221,6 +222,7 @@ const createExtrasCheckout = async (organization, packId, successUrl, cancelUrl)
       success_url: successUrl,
       cancel_url: cancelUrl,
       automatic_tax: { enabled: true },
+      customer_update: { address: 'auto', name: 'auto' },
       metadata: {
         organizationId: String(organization._id),
         packId,

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -235,6 +235,7 @@ describe('Billing service unit tests:', () => {
           success_url: 'http://ok',
           cancel_url: 'http://cancel',
           automatic_tax: { enabled: true },
+          customer_update: { address: 'auto', name: 'auto' },
           metadata: {
             organizationId: orgId,
             plan: 'starter',
@@ -242,6 +243,24 @@ describe('Billing service unit tests:', () => {
         },
         { idempotencyKey: `sub_checkout_${orgId}_price_starter_m` },
       );
+    });
+
+    test('should include customer_update in checkout session params', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_cu' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_cu_test',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
+
+      const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.customer_update).toEqual({ address: 'auto', name: 'auto' });
     });
   });
 

--- a/modules/billing/tests/billing.quota.unit.tests.js
+++ b/modules/billing/tests/billing.quota.unit.tests.js
@@ -207,6 +207,9 @@ describe('requireQuota middleware:', () => {
 
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+    // Short-circuit: no downstream quota lookups
+    expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
+    expect(mockBillingUsageService.get).not.toHaveBeenCalled();
   });
 
   test('should NOT bypass quota for non-admin user (legacy mode)', async () => {
@@ -229,6 +232,9 @@ describe('requireQuota middleware:', () => {
 
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+    // Short-circuit: no downstream quota lookups
+    expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
+    expect(mockBillingUsageService.get).not.toHaveBeenCalled();
   });
 
   test('should NOT bypass quota when meterExempt is false', async () => {
@@ -440,6 +446,10 @@ describe('requireQuota middleware:', () => {
 
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
+      // Short-circuit: no downstream meter/subscription lookups
+      expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
+      expect(mockBillingUsageService.getMeter).not.toHaveBeenCalled();
+      expect(mockBillingExtraBalanceRepository.getBalance).not.toHaveBeenCalled();
     });
 
     test('should bypass meter quota for meterExempt organization', async () => {
@@ -452,6 +462,10 @@ describe('requireQuota middleware:', () => {
 
       expect(next).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
+      // Short-circuit: no downstream meter/subscription lookups
+      expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
+      expect(mockBillingUsageService.getMeter).not.toHaveBeenCalled();
+      expect(mockBillingExtraBalanceRepository.getBalance).not.toHaveBeenCalled();
     });
 
     test('degraded J+5: still blocks if meter is exhausted', async () => {

--- a/modules/billing/tests/billing.quota.unit.tests.js
+++ b/modules/billing/tests/billing.quota.unit.tests.js
@@ -195,6 +195,53 @@ describe('requireQuota middleware:', () => {
     expect(next).toHaveBeenCalled();
   });
 
+  // ── Admin bypass ──────────────────────────────────────────────────────────
+
+  test('should bypass quota for admin user (legacy mode)', async () => {
+    req.user = { roles: ['admin'] };
+    // No subscription/usage lookups needed — should short-circuit
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+    mockBillingUsageService.get.mockResolvedValue({ counters: { 'scraps_create': 3 } });
+
+    await requireQuota('scraps', 'create')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('should NOT bypass quota for non-admin user (legacy mode)', async () => {
+    req.user = { roles: ['user'] };
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+    mockBillingUsageService.get.mockResolvedValue({ counters: { 'scraps_create': 3 } });
+
+    await requireQuota('scraps', 'create')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(429);
+  });
+
+  test('should bypass quota for meterExempt organization', async () => {
+    req.organization = { _id: '507f1f77bcf86cd799439011', meterExempt: true };
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+    mockBillingUsageService.get.mockResolvedValue({ counters: { 'scraps_create': 3 } });
+
+    await requireQuota('scraps', 'create')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('should NOT bypass quota when meterExempt is false', async () => {
+    req.organization = { _id: '507f1f77bcf86cd799439011', meterExempt: false };
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+    mockBillingUsageService.get.mockResolvedValue({ counters: { 'scraps_create': 3 } });
+
+    await requireQuota('scraps', 'create')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(429);
+  });
+
   // ── Meter mode (meterMode: true) ───────────────────────────────────────────
 
   describe('meter mode (meterMode: true)', () => {
@@ -381,6 +428,30 @@ describe('requireQuota middleware:', () => {
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(402);
+    });
+
+    test('should bypass meter quota for admin user', async () => {
+      req.user = { roles: ['admin'] };
+      // getMeter would return exhausted, but admin should bypass
+      mockBillingUsageService.getMeter.mockResolvedValue({ meterUsed: 5000, meterQuota: 5000 });
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    test('should bypass meter quota for meterExempt organization', async () => {
+      req.organization = { _id: '507f1f77bcf86cd799439011', meterExempt: true };
+      // getMeter would return exhausted, but exempt org should bypass
+      mockBillingUsageService.getMeter.mockResolvedValue({ meterUsed: 5000, meterQuota: 5000 });
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
     });
 
     test('degraded J+5: still blocks if meter is exhausted', async () => {

--- a/modules/billing/tests/billing.service.extras.unit.tests.js
+++ b/modules/billing/tests/billing.service.extras.unit.tests.js
@@ -235,6 +235,24 @@ describe('BillingService.createExtrasCheckout unit tests:', () => {
     expect(mockStripeInstance.checkout.sessions.create).toHaveBeenCalled();
   });
 
+  test('should include customer_update in extras checkout session params', async () => {
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: makeConfig(),
+    }));
+
+    const mod = await import('../services/billing.service.js');
+    BillingService = mod.default;
+
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ stripeCustomerId: 'cus_existing' });
+
+    await BillingService.createExtrasCheckout(
+      mockOrganization, 'pack_500k', 'http://success', 'http://cancel',
+    );
+
+    const [params] = mockStripeInstance.checkout.sessions.create.mock.calls[0];
+    expect(params.customer_update).toEqual({ address: 'auto', name: 'auto' });
+  });
+
   test('should handle 11000 duplicate key on subscription create gracefully', async () => {
     jest.unstable_mockModule('../../../config/index.js', () => ({
       default: makeConfig(),

--- a/modules/organizations/models/organizations.model.mongoose.js
+++ b/modules/organizations/models/organizations.model.mongoose.js
@@ -42,7 +42,6 @@ const OrganizationMongoose = new Schema(
     meterExempt: {
       type: Boolean,
       default: false,
-      sparse: true,
     },
     createdBy: {
       type: Schema.ObjectId,

--- a/modules/organizations/models/organizations.model.mongoose.js
+++ b/modules/organizations/models/organizations.model.mongoose.js
@@ -39,6 +39,11 @@ const OrganizationMongoose = new Schema(
       enum: config.billing.plans,
       default: 'free',
     },
+    meterExempt: {
+      type: Boolean,
+      default: false,
+      sparse: true,
+    },
     createdBy: {
       type: Schema.ObjectId,
       ref: 'User',

--- a/modules/organizations/models/organizations.schema.js
+++ b/modules/organizations/models/organizations.schema.js
@@ -14,7 +14,6 @@ const Organization = z.object({
   slug: z.string().trim().min(1).toLowerCase().optional(),
   domain: z.string().trim().default(''),
   plan: z.enum(config.billing.plans).default('free'),
-  meterExempt: z.boolean().default(false).optional(),
 });
 
 const OrganizationUpdate = Organization.partial();

--- a/modules/organizations/models/organizations.schema.js
+++ b/modules/organizations/models/organizations.schema.js
@@ -14,6 +14,7 @@ const Organization = z.object({
   slug: z.string().trim().min(1).toLowerCase().optional(),
   domain: z.string().trim().default(''),
   plan: z.enum(config.billing.plans).default('free'),
+  meterExempt: z.boolean().default(false).optional(),
 });
 
 const OrganizationUpdate = Organization.partial();


### PR DESCRIPTION
## Summary

- **Fix 1 — Stripe Tax `customer_update`**: both `createCheckout` (subscription mode) and `createExtrasCheckout` (payment mode) now pass `customer_update: { address: 'auto', name: 'auto' }` alongside `automatic_tax: { enabled: true }`. Without this, Stripe raises `customer_tax_location_invalid` when the customer object has no billing address, blocking checkout entirely.

- **Fix 2 — `requireQuota` admin/exempt bypass**: the middleware now short-circuits to `next()` before any quota or meter logic when `req.user?.roles?.includes('admin')` is true or `req.organization.meterExempt === true`. This is pre-organization-guard (403 still fires if org context is missing) and applies to both legacy and meter mode — the non-admin, non-exempt path is unchanged.
  - `meterExempt` field added to the Organization Mongoose model (Boolean, default false, sparse) and mirrored in the Zod schema.

## Runtime errors addressed

- `StripeInvalidRequestError: customer_tax_location_invalid` — customer has no address stored, Stripe rejects the checkout session creation.
- Admin users and internal/partner orgs hitting 402/429 quota blocks they should never see.

## Test plan

- [x] `customer_update` asserted in existing `createCheckout` full-params test + new dedicated test
- [x] `customer_update` asserted in new `createExtrasCheckout` test
- [x] Admin bypass (legacy mode): over-quota free user with `roles: ['admin']` → `next()` called, no 429
- [x] Non-admin user still blocked at quota
- [x] `meterExempt: true` org bypasses legacy mode quota
- [x] `meterExempt: false` org is not bypassed
- [x] Admin bypass in meter mode: exhausted meter with admin user → `next()` called, no 402
- [x] `meterExempt: true` org bypasses meter mode
- [x] All 928 unit tests green (`npm run test:unit`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin users and meter-exempt organizations now bypass quota enforcement entirely, allowing unlimited usage without meter restrictions.
  * Stripe checkout now automatically updates customer address and name information during the checkout process.

* **Tests**
  * Added comprehensive test coverage for quota bypass scenarios and automatic customer information updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->