### PR TITLE
test(jest): recycle workers above 512MB to bound vm-context registry growth

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -221,4 +221,11 @@ export default {
 
   // Whether to use watchman for file crawling
   // watchman: true,
+
+  // Recycle worker child processes when their RSS exceeds this threshold.
+  // Counters jest's per-vm-context module registry accumulation (~14 MB
+  // retained per loaded suite under --experimental-vm-modules) which would
+  // otherwise OOM long-lived workers on large downstream test suites.
+  // The respawn cost (~150-300 ms) is negligible vs. the OOM crash it avoids.
+  workerIdleMemoryLimit: '512MB',
 };


### PR DESCRIPTION
## Summary

- Adds `workerIdleMemoryLimit: '512MB'` to `jest.config.js`
- Tells jest to respawn worker child processes when their RSS exceeds the threshold, recycling the per-vm-context module registry that accumulates under `--experimental-vm-modules` (~14 MB retained per loaded suite)
- Complements #3549 (migration pre-warm) which addressed migration overhead but not vm-context module registry growth — that's the actual driver of the trawl_node 4.3 GB OOM on coverage runs

## Why

Jest workers are long-lived child processes. Each suite they run loads its own vm context, which jest's `GlobalProxy` cleans superficially at teardown but leaves ~14 MB of module registry pinned per loaded suite. On a worker that handles 30+ suites, that's 420+ MB just in module registry, plus the bootstrap-driven Express app + mongoose connection per suite (despite #3549's migration cache, the Express tree is still rebuilt each bootstrap because vm isolation prevents a process-level singleton).

Recycling workers when they cross 512 MB is the standard jest-blessed mitigation (added in jest 29 specifically for this case). Respawn cost (~150–300 ms) is negligible vs. an OOM crash that aborts the run.

## Test plan
- [ ] CI green (test, parallel-smoke, codecov)
- [ ] Verify devkit's own test suite still passes
- [ ] After merge + propagation to trawl_node via /update-stack: confirm trawl coverage run no longer OOMs on a single 6 Gi runner

## Related
- Stack: #3549 (per-suite migration skip via globalSetup)
- Trawl OOM context: heap climbs to ~4.3 GB on 89 integration suites with 5 ARC runners + 20 Gi total today