### PR TITLE
fix(test): set --max-old-space-size=6144 on test:coverage to prevent OOM under --runInBand

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:integration": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --testPathPatterns='integration'",
     "test:e2e": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --testPathPatterns='e2e'",
     "test:watch": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --watchAll",
-    "test:coverage": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" jest --coverage --runInBand",
+    "test:coverage": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=6144 --expose-gc\" jest --coverage --runInBand",
     "test:parallel-smoke": "cross-env NODE_ENV=test node scripts/parallel-integration.smoke.js",
     "lint": "eslint ./modules ./lib ./config ./scripts",
     "seed:dev": "cross-env NODE_ENV=development node scripts/seed.js seed",


### PR DESCRIPTION
## Summary

- Adds `--max-old-space-size=6144` to `test:coverage` `NODE_OPTIONS`
- Prevents OOM when downstream projects (trawl_node, etc.) run coverage on larger suites
- Eliminates the need for downstream patches that get silently stripped by `/update-stack --theirs`

## Why

`test:coverage` runs `jest --runInBand` — single Node process, no worker children. The `workerIdleMemoryLimit: '512MB'` added in #3550 only recycles worker processes, so it doesn't apply on coverage runs.

Without an explicit cap, Node defaults to ~2 GB old-space. Devkit's own ~18 suites fit, but trawl_node (214 suites) immediately OOMs at 1.9 GB on the `chore/update-stack-2026-05-01` propagation run today.

Trawl had a downstream patch setting 6144 — the recent `/update-stack` propagation wiped it via `--theirs` (cf. `feedback_update_stack_theirs_wipes_patches`), causing the OOM. Restoring it locally would just recreate the same drift. Fix it upstream.

## Test plan
- [ ] CI green (devkit's own coverage continues to pass — change is additive, only raises the cap)
- [ ] After merge + propagation: trawl_node #1073 update branch passes coverage with the upstream value, downstream `package.json` patch from commit 042fdc9e becomes redundant and can be dropped on the next `/update-stack`

## Related
- Stack: #3549 (migration pre-warm), #3550 (workerIdleMemoryLimit)
- Trawl: comes-io/trawl_node#1073 (propagation that exposed the gap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved memory allocation for test coverage execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->