### PR TITLE
feat(billing): plan source-of-truth + plan seed + meterExempt Zod (PR-N6)

### DIFF
--- a/modules/billing/billing.init.js
+++ b/modules/billing/billing.init.js
@@ -4,6 +4,7 @@
 import config from '../../config/index.js';
 import AnalyticsService from '../../lib/services/analytics.js';
 import billingEvents from './lib/events.js';
+import BillingPlanService from './services/billing.plan.service.js';
 
 /**
  * Billing module initialisation.
@@ -29,4 +30,13 @@ export default async (app) => {
       AnalyticsService.groupIdentify('company', String(organizationId), { plan: newPlan });
     } catch (_) { /* analytics must not break billing flow */ }
   });
+
+  try {
+    const { seeded, skipped } = await BillingPlanService.ensureSeeded();
+    if (seeded > 0) {
+      console.info(`[billing] seeded ${seeded} plan(s) from config.billing.planDefinitions (skipped ${skipped} already active)`);
+    }
+  } catch (err) {
+    console.error('[billing] ensureSeeded failed:', err);
+  }
 };

--- a/modules/billing/billing.init.js
+++ b/modules/billing/billing.init.js
@@ -38,5 +38,9 @@ export default async (app) => {
     }
   } catch (err) {
     console.error('[billing] ensureSeeded failed:', err);
+    // Fail fast when meterMode is enabled: a seeding failure means quota resolution
+    // will return 0 for all plans, silently gating all metered operations.
+    // Surfacing the crash here prevents a deploy from succeeding in a broken state.
+    if (config?.billing?.meterMode) throw err;
   }
 };

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -32,6 +32,26 @@ const config = {
      */
     meterMode: false,
     /**
+     * Default plan used when an organization has no subscription. Configurable per project.
+     */
+    defaultPlan: 'free',
+    /**
+     * URL the front-end should redirect users to when quota is exhausted or past_due.
+     * Used by middleware error responses (METER_EXHAUSTED, QUOTA_EXCEEDED).
+     */
+    upgradeUrl: '/billing/plans',
+    /**
+     * Plan definitions — DOWNSTREAM-OVERRIDE-REQUIRED for meter mode.
+     * Used by BillingPlanService.ensureSeeded() at boot to upsert BillingPlan docs.
+     * Each entry: { meterQuota: units/week, ratios: { featureKey: multiplier } }.
+     * Plans listed here must also exist in billing.plans enum.
+     */
+    planDefinitions: {
+      free: { meterQuota: 0, ratios: { default: 1 } },
+      starter: { meterQuota: 50000, ratios: { default: 1 } },
+      pro: { meterQuota: 500000, ratios: { default: 1 } },
+    },
+    /**
      * Meter unit parameters — downstream projects must override with their
      * actual unit economics before enabling meterMode in production.
      *

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -50,6 +50,7 @@ const config = {
       free: { meterQuota: 0, ratios: { default: 1 } },
       starter: { meterQuota: 50000, ratios: { default: 1 } },
       pro: { meterQuota: 500000, ratios: { default: 1 } },
+      enterprise: { meterQuota: 2000000, ratios: { default: 1 } },
     },
     /**
      * Meter unit parameters — downstream projects must override with their

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -110,6 +110,20 @@ const findByStripeSubscriptionId = (stripeSubscriptionId) => {
 };
 
 /**
+ * @function findPlan
+ * @description Lean lookup that returns only the `plan` field for a given organization.
+ *              Used on hot paths (meter attribution, weekly reset) where only the plan
+ *              identifier is needed — avoids the full populate overhead of findByOrganization.
+ * @param {String} organizationId - The organization ID.
+ * @returns {Promise<{plan: string}|null>} A lean plain object with just `plan`, or null.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const findPlan = (organizationId) => {
+  if (!mongoose.Types.ObjectId.isValid(organizationId)) return null;
+  return Subscription.findOne({ organization: organizationId }, { plan: 1 }).lean().exec();
+};
+
+/**
  * @function findAllDueForReset
  * @description Fetch active/trialing subscriptions whose currentPeriodStart falls
  *              within the provided time window. Used by the weekly meter reset sweep.
@@ -173,6 +187,7 @@ export default {
   update,
   remove,
   findByOrganization,
+  findPlan,
   findByStripeCustomerId,
   findByStripeSubscriptionId,
   findAllDueForReset,

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -167,6 +167,12 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
  * @description Upsert BillingPlan docs from config.billing.planDefinitions.
  *              For each configured planId, ensures an active plan exists.
  *              No-op when meter mode is disabled. Idempotent on re-run.
+ *
+ *              Race / E11000 safety: version is derived from the total count of
+ *              existing docs for the planId (same strategy as bumpVersion). A
+ *              try-catch on create absorbs E11000 from concurrent multi-pod
+ *              startup races — the losing pod simply increments skipped.
+ *
  * @returns {Promise<{seeded: number, skipped: number}>} Seed summary.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
@@ -184,17 +190,32 @@ const ensureSeeded = async () => {
       continue;
     }
 
-    await BillingPlanRepository.create({
-      planId,
-      version: 'v1',
-      meterQuota: def.meterQuota ?? 0,
-      ratios: def.ratios ?? { default: 1 },
-      effectiveFrom: new Date(),
-      effectiveUntil: null,
-      active: true,
-    });
-    cache.delete(planId);
-    seeded += 1;
+    try {
+      // Derive version from total count so that an inactive v1 record does not
+      // collide with the insert (same approach as bumpVersion to avoid hardcoding 'v1').
+      const total = await BillingPlanRepository.count(planId);
+      const version = `v${total + 1}`;
+
+      await BillingPlanRepository.create({
+        planId,
+        version,
+        meterQuota: def.meterQuota ?? 0,
+        ratios: def.ratios ?? { default: 1 },
+        effectiveFrom: new Date(),
+        effectiveUntil: null,
+        active: true,
+      });
+      cache.delete(planId);
+      seeded += 1;
+    } catch (err) {
+      // E11000: concurrent pod beat us to the insert — treat as skip, not fatal.
+      const isE11000 = err.code === 11000 || (err.message && err.message.includes('E11000'));
+      if (isE11000) {
+        skipped += 1;
+        continue;
+      }
+      throw err;
+    }
   }
 
   return { seeded, skipped };

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -1,6 +1,7 @@
 /**
  * Module dependencies
  */
+import config from '../../../config/index.js';
 import BillingPlanRepository from '../repositories/billing.plan.repository.js';
 
 /**
@@ -161,10 +162,49 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
   throw lastErr;
 };
 
+/**
+ * @function ensureSeeded
+ * @description Upsert BillingPlan docs from config.billing.planDefinitions.
+ *              For each configured planId, ensures an active plan exists.
+ *              No-op when meter mode is disabled. Idempotent on re-run.
+ * @returns {Promise<{seeded: number, skipped: number}>} Seed summary.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const ensureSeeded = async () => {
+  if (!config?.billing?.meterMode) return { seeded: 0, skipped: 0 };
+
+  const definitions = config?.billing?.planDefinitions ?? {};
+  let seeded = 0;
+  let skipped = 0;
+
+  for (const [planId, def] of Object.entries(definitions)) {
+    const existing = await BillingPlanRepository.findActive(planId);
+    if (existing) {
+      skipped += 1;
+      continue;
+    }
+
+    await BillingPlanRepository.create({
+      planId,
+      version: 'v1',
+      meterQuota: def.meterQuota ?? 0,
+      ratios: def.ratios ?? { default: 1 },
+      effectiveFrom: new Date(),
+      effectiveUntil: null,
+      active: true,
+    });
+    cache.delete(planId);
+    seeded += 1;
+  }
+
+  return { seeded, skipped };
+};
+
 export default {
   getActivePlan,
   getPlanByVersion,
   bumpVersion,
   bumpVersionWithRetry,
+  ensureSeeded,
   invalidateCache,
 };

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -51,7 +51,8 @@ const resetWeek = async (orgId, periodStart) => {
   await BillingUsageRepository.archiveOtherWeeks(orgId, newWeekKey, now);
 
   // Step 2 — Fetch the active plan to snapshot quota/planVersion.
-  const planId = config?.billing?.plans?.[0] ?? 'pro';
+  const subscription = await BillingSubscriptionRepository.findByOrganization(orgId);
+  const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
   const activePlan = await BillingPlanService.getActivePlan(planId);
   const meterQuota = activePlan?.meterQuota ?? 0;
   const planVersion = activePlan?.version ?? null;

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -50,8 +50,8 @@ const resetWeek = async (orgId, periodStart) => {
   // Delegates to repository — no mongoose import in service layer.
   await BillingUsageRepository.archiveOtherWeeks(orgId, newWeekKey, now);
 
-  // Step 2 — Fetch the active plan to snapshot quota/planVersion.
-  const subscription = await BillingSubscriptionRepository.findByOrganization(orgId);
+  // Step 2 — Fetch the active plan to snapshot quota/planVersion — lean projection (plan only, no populate).
+  const subscription = await BillingSubscriptionRepository.findPlan(orgId);
   const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
   const activePlan = await BillingPlanService.getActivePlan(planId);
   const meterQuota = activePlan?.meterQuota ?? 0;

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -105,8 +105,8 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
   const weekKey = currentWeekKey();
   const monthKey = currentMonth();
 
-  // Fetch active plan for quota snapshot
-  const subscription = await BillingSubscriptionRepository.findByOrganization(organizationId);
+  // Fetch active plan for quota snapshot — lean projection (plan field only, no populate)
+  const subscription = await BillingSubscriptionRepository.findPlan(organizationId);
   const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
   const activePlan = await BillingPlanService.getActivePlan(planId);
   const meterQuota = activePlan?.meterQuota ?? 0;

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -3,6 +3,7 @@
  */
 import config from '../../../config/index.js';
 import UsageRepository from '../repositories/billing.usage.repository.js';
+import BillingSubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import BillingPlanService from './billing.plan.service.js';
 
 /**
@@ -105,7 +106,8 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
   const monthKey = currentMonth();
 
   // Fetch active plan for quota snapshot
-  const planId = config?.billing?.plans?.[0] ?? 'pro';
+  const subscription = await BillingSubscriptionRepository.findByOrganization(organizationId);
+  const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
   const activePlan = await BillingPlanService.getActivePlan(planId);
   const meterQuota = activePlan?.meterQuota ?? 0;
   const planVersion = activePlan?.version ?? null;

--- a/modules/billing/tests/billing.init.unit.tests.js
+++ b/modules/billing/tests/billing.init.unit.tests.js
@@ -1,0 +1,84 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing.init ensureSeeded integration.
+ */
+describe('billing.init ensureSeeded unit tests:', () => {
+  let billingInit;
+  let mockBillingPlanService;
+  let mockConfig;
+
+  const mockApp = {};
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: false,
+        packs: [],
+      },
+    };
+
+    mockBillingPlanService = {
+      ensureSeeded: jest.fn().mockResolvedValue({ seeded: 0, skipped: 0 }),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockBillingPlanService,
+    }));
+
+    // Stub analytics and events to avoid side effects
+    jest.unstable_mockModule('../../../lib/services/analytics.js', () => ({
+      default: { groupIdentify: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: { on: jest.fn(), emit: jest.fn() },
+    }));
+
+    const mod = await import('../billing.init.js');
+    billingInit = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('ensureSeeded is called at init when meterMode=false', async () => {
+    await billingInit(mockApp);
+    expect(mockBillingPlanService.ensureSeeded).toHaveBeenCalledTimes(1);
+  });
+
+  test('ensureSeeded failure is swallowed when meterMode=false', async () => {
+    mockBillingPlanService.ensureSeeded.mockRejectedValue(new Error('DB error'));
+
+    // Should not throw — meterMode=false means graceful degradation
+    await expect(billingInit(mockApp)).resolves.toBeUndefined();
+  });
+
+  test('ensureSeeded failure re-throws when meterMode=true (fail-fast)', async () => {
+    mockConfig.billing.meterMode = true;
+    mockBillingPlanService.ensureSeeded.mockRejectedValue(new Error('seed failure'));
+
+    await expect(billingInit(mockApp)).rejects.toThrow('seed failure');
+  });
+
+  test('ensureSeeded success with seeded>0 logs info and resolves', async () => {
+    mockBillingPlanService.ensureSeeded.mockResolvedValue({ seeded: 2, skipped: 1 });
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+    await billingInit(mockApp);
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('seeded 2 plan(s)'),
+    );
+  });
+});

--- a/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
+++ b/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
@@ -1,0 +1,111 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for BillingPlanService.ensureSeeded
+ */
+describe('BillingPlanService.ensureSeeded unit tests:', () => {
+  let BillingPlanService;
+  let mockBillingPlanRepository;
+  let mockConfig;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        planDefinitions: {},
+      },
+    };
+
+    mockBillingPlanRepository = {
+      findActive: jest.fn(),
+      findByVersion: jest.fn(),
+      deactivateAll: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.plan.repository.js', () => ({
+      default: mockBillingPlanRepository,
+    }));
+
+    const mod = await import('../services/billing.plan.service.js');
+    BillingPlanService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('meterMode=false returns zeroes and never touches the repository', async () => {
+    mockConfig.billing.meterMode = false;
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 0, skipped: 0 });
+    expect(mockBillingPlanRepository.findActive).not.toHaveBeenCalled();
+    expect(mockBillingPlanRepository.create).not.toHaveBeenCalled();
+  });
+
+  test('meterMode=true with empty planDefinitions returns zeroes', async () => {
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 0, skipped: 0 });
+    expect(mockBillingPlanRepository.findActive).not.toHaveBeenCalled();
+    expect(mockBillingPlanRepository.create).not.toHaveBeenCalled();
+  });
+
+  test('meterMode=true with 3 planDefinitions and none existing seeds 3 plans', async () => {
+    mockConfig.billing.planDefinitions = {
+      free: { meterQuota: 0, ratios: { default: 1 } },
+      starter: { meterQuota: 50000, ratios: { default: 1 } },
+      pro: { meterQuota: 500000, ratios: { default: 2 } },
+    };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 3, skipped: 0 });
+    expect(mockBillingPlanRepository.findActive).toHaveBeenCalledTimes(3);
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(3);
+    expect(mockBillingPlanRepository.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ planId: 'free', version: 'v1', meterQuota: 0, ratios: { default: 1 }, active: true }),
+    );
+  });
+
+  test('meterMode=true with 3 planDefinitions and 1 existing seeds 2 and skips 1', async () => {
+    mockConfig.billing.planDefinitions = {
+      free: { meterQuota: 0, ratios: { default: 1 } },
+      starter: { meterQuota: 50000, ratios: { default: 1 } },
+      pro: { meterQuota: 500000, ratios: { default: 1 } },
+    };
+    mockBillingPlanRepository.findActive
+      .mockResolvedValueOnce({ planId: 'free', version: 'v1' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 2, skipped: 1 });
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(2);
+    expect(mockBillingPlanRepository.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ planId: 'starter', version: 'v1' }),
+    );
+    expect(mockBillingPlanRepository.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ planId: 'pro', version: 'v1' }),
+    );
+  });
+});

--- a/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
+++ b/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
@@ -70,12 +70,15 @@ describe('BillingPlanService.ensureSeeded unit tests:', () => {
       pro: { meterQuota: 500000, ratios: { default: 2 } },
     };
     mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    // count=0 → version 'v1' for each plan
+    mockBillingPlanRepository.count.mockResolvedValue(0);
     mockBillingPlanRepository.create.mockResolvedValue({});
 
     const result = await BillingPlanService.ensureSeeded();
 
     expect(result).toEqual({ seeded: 3, skipped: 0 });
     expect(mockBillingPlanRepository.findActive).toHaveBeenCalledTimes(3);
+    expect(mockBillingPlanRepository.count).toHaveBeenCalledTimes(3);
     expect(mockBillingPlanRepository.create).toHaveBeenCalledTimes(3);
     expect(mockBillingPlanRepository.create).toHaveBeenNthCalledWith(
       1,
@@ -93,6 +96,7 @@ describe('BillingPlanService.ensureSeeded unit tests:', () => {
       .mockResolvedValueOnce({ planId: 'free', version: 'v1' })
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null);
+    mockBillingPlanRepository.count.mockResolvedValue(0);
     mockBillingPlanRepository.create.mockResolvedValue({});
 
     const result = await BillingPlanService.ensureSeeded();
@@ -107,5 +111,49 @@ describe('BillingPlanService.ensureSeeded unit tests:', () => {
       2,
       expect.objectContaining({ planId: 'pro', version: 'v1' }),
     );
+  });
+
+  test('count > 0 yields next version string correctly', async () => {
+    mockConfig.billing.planDefinitions = {
+      pro: { meterQuota: 500000, ratios: { default: 1 } },
+    };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    // Existing inactive v1 is present (total count = 1)
+    mockBillingPlanRepository.count.mockResolvedValue(1);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 1, skipped: 0 });
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ planId: 'pro', version: 'v2' }),
+    );
+  });
+
+  test('E11000 on create is absorbed as a skip (concurrent pod race)', async () => {
+    mockConfig.billing.planDefinitions = {
+      free: { meterQuota: 0, ratios: { default: 1 } },
+      pro: { meterQuota: 500000, ratios: { default: 1 } },
+    };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.count.mockResolvedValue(0);
+    // First create throws E11000; second succeeds
+    const e11000 = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 });
+    mockBillingPlanRepository.create.mockRejectedValueOnce(e11000).mockResolvedValueOnce({});
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 1, skipped: 1 });
+  });
+
+  test('non-E11000 error on create propagates and aborts', async () => {
+    mockConfig.billing.planDefinitions = {
+      pro: { meterQuota: 500000, ratios: { default: 1 } },
+    };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.count.mockResolvedValue(0);
+    mockBillingPlanRepository.create.mockRejectedValue(new Error('DB connection lost'));
+
+    await expect(BillingPlanService.ensureSeeded()).rejects.toThrow('DB connection lost');
   });
 });

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -67,6 +67,7 @@ describe('BillingResetService unit tests:', () => {
 
     mockSubscriptionRepository = {
       findByOrganization: jest.fn(),
+      findPlan: jest.fn(),
       findAllDueForReset: jest.fn(),
     };
 
@@ -122,7 +123,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should archive old week docs and upsert new week doc', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       const newDoc = makeUsageDoc({ weekKey: '2026-W18' });
@@ -139,7 +140,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should be idempotent — return existing doc if week already exists', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       const existingDoc = makeUsageDoc({ weekKey: '2026-W18' });
       mockUsageRepository.findByWeek.mockResolvedValue(existingDoc);
@@ -152,7 +153,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should snapshot meterQuota and planVersion from active plan', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 1000000, version: 'v3' }));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       let capturedSnapshot;
@@ -168,18 +169,18 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should use subscribed plan as source of truth', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'pro' }));
       mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
 
       await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
 
-      expect(mockSubscriptionRepository.findByOrganization).toHaveBeenCalledWith(orgId);
+      expect(mockSubscriptionRepository.findPlan).toHaveBeenCalledWith(orgId);
       expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('pro');
     });
 
     test('should use defaultPlan when subscription is missing', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockSubscriptionRepository.findPlan.mockResolvedValue(null);
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'starter' }));
       mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
 
@@ -190,7 +191,7 @@ describe('BillingResetService unit tests:', () => {
 
     test('should fall back to free when subscription and defaultPlan are missing', async () => {
       mockConfig.billing.defaultPlan = undefined;
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockSubscriptionRepository.findPlan.mockResolvedValue(null);
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'free' }));
       mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
 
@@ -200,7 +201,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should use meterQuota=0 when no active plan exists', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(null);
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       let capturedSnapshot;
@@ -216,7 +217,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should handle E11000 race by falling back to findByWeek', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek
         .mockResolvedValueOnce(null) // First call: doc not yet created
@@ -248,7 +249,7 @@ describe('BillingResetService unit tests:', () => {
         { organization: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
       ]);
 
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc());
@@ -263,7 +264,7 @@ describe('BillingResetService unit tests:', () => {
       mockSubscriptionRepository.findAllDueForReset.mockResolvedValue([
         { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockRejectedValue(new Error('DB error'));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
 
@@ -282,7 +283,7 @@ describe('BillingResetService unit tests:', () => {
       mockSubscriptionRepository.findAllDueForReset.mockResolvedValue([
         { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockImplementation((orgId) => {
         capturedOrgIds.push(orgId);

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -11,7 +11,7 @@ describe('BillingResetService unit tests:', () => {
   let mockUsageRepository;
   let mockPlanService;
   let mockConfig;
-  let mockMongooseSubscription;
+  let mockSubscriptionRepository;
 
   const orgId = '507f1f77bcf86cd799439011';
 
@@ -47,7 +47,7 @@ describe('BillingResetService unit tests:', () => {
     mockConfig = {
       billing: {
         meterMode: true,
-        plans: ['pro'],
+        defaultPlan: 'starter',
       },
     };
 
@@ -65,7 +65,8 @@ describe('BillingResetService unit tests:', () => {
       getActivePlan: jest.fn(),
     };
 
-    mockMongooseSubscription = {
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
       findAllDueForReset: jest.fn(),
     };
 
@@ -78,7 +79,7 @@ describe('BillingResetService unit tests:', () => {
     }));
 
     jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
-      default: mockMongooseSubscription,
+      default: mockSubscriptionRepository,
     }));
 
     jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
@@ -121,6 +122,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should archive old week docs and upsert new week doc', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       const newDoc = makeUsageDoc({ weekKey: '2026-W18' });
@@ -137,6 +139,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should be idempotent — return existing doc if week already exists', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       const existingDoc = makeUsageDoc({ weekKey: '2026-W18' });
       mockUsageRepository.findByWeek.mockResolvedValue(existingDoc);
@@ -149,6 +152,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should snapshot meterQuota and planVersion from active plan', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 1000000, version: 'v3' }));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       let capturedSnapshot;
@@ -163,7 +167,40 @@ describe('BillingResetService unit tests:', () => {
       expect(capturedSnapshot.planVersion).toBe('v3');
     });
 
+    test('should use subscribed plan as source of truth', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'pro' }));
+      mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
+
+      await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(mockSubscriptionRepository.findByOrganization).toHaveBeenCalledWith(orgId);
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('pro');
+    });
+
+    test('should use defaultPlan when subscription is missing', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'starter' }));
+      mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
+
+      await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('starter');
+    });
+
+    test('should fall back to free when subscription and defaultPlan are missing', async () => {
+      mockConfig.billing.defaultPlan = undefined;
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'free' }));
+      mockUsageRepository.findByWeek.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
+
+      await BillingResetService.resetWeek(orgId, new Date('2026-04-27'));
+
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('free');
+    });
+
     test('should use meterQuota=0 when no active plan exists', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(null);
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       let capturedSnapshot;
@@ -179,6 +216,7 @@ describe('BillingResetService unit tests:', () => {
     });
 
     test('should handle E11000 race by falling back to findByWeek', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek
         .mockResolvedValueOnce(null) // First call: doc not yet created
@@ -205,11 +243,12 @@ describe('BillingResetService unit tests:', () => {
       const now = new Date();
       const periodStart = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
 
-      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
+      mockSubscriptionRepository.findAllDueForReset.mockResolvedValue([
         { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
         { organization: '507f1f77bcf86cd799439022', currentPeriodStart: periodStart },
       ]);
 
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockResolvedValue(null);
       mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc());
@@ -221,9 +260,10 @@ describe('BillingResetService unit tests:', () => {
 
     test('should count errors when resetWeek fails for a subscription', async () => {
       const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
-      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
+      mockSubscriptionRepository.findAllDueForReset.mockResolvedValue([
         { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockRejectedValue(new Error('DB error'));
       mockUsageRepository.findByWeek.mockResolvedValue(null);
 
@@ -239,9 +279,10 @@ describe('BillingResetService unit tests:', () => {
       // We verify that when the correct field `organization` is present, it is forwarded correctly.
       const periodStart = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
       const capturedOrgIds = [];
-      mockMongooseSubscription.findAllDueForReset.mockResolvedValue([
+      mockSubscriptionRepository.findAllDueForReset.mockResolvedValue([
         { organization: '507f1f77bcf86cd799439011', currentPeriodStart: periodStart },
       ]);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.findByWeek.mockImplementation((orgId) => {
         capturedOrgIds.push(orgId);

--- a/modules/billing/tests/billing.subscription.repository.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.unit.tests.js
@@ -147,6 +147,43 @@ describe('BillingSubscriptionRepository unit tests:', () => {
     });
   });
 
+  // ── findPlan ──────────────────────────────────────────────────────────────
+
+  describe('findPlan', () => {
+    test('returns plan field for a valid organizationId', async () => {
+      const planDoc = { _id: subId, plan: 'pro' };
+      const execMock = jest.fn().mockResolvedValue(planDoc);
+      const leanMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findOne.mockReturnValue({ lean: leanMock });
+
+      const result = await BillingSubscriptionRepository.findPlan(orgId);
+
+      expect(mockModel.findOne).toHaveBeenCalledWith(
+        { organization: orgId },
+        { plan: 1 },
+      );
+      expect(leanMock).toHaveBeenCalled();
+      expect(result).toEqual(planDoc);
+    });
+
+    test('returns null for an invalid organizationId without querying', async () => {
+      const result = await BillingSubscriptionRepository.findPlan('not-a-valid-id');
+
+      expect(result).toBeNull();
+      expect(mockModel.findOne).not.toHaveBeenCalled();
+    });
+
+    test('returns null when no subscription exists for the organization', async () => {
+      const execMock = jest.fn().mockResolvedValue(null);
+      const leanMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findOne.mockReturnValue({ lean: leanMock });
+
+      const result = await BillingSubscriptionRepository.findPlan(orgId);
+
+      expect(result).toBeNull();
+    });
+  });
+
   // ── findAllDueForReset (existing — smoke test) ────────────────────────────
 
   describe('findAllDueForReset', () => {

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -74,6 +74,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
     mockSubscriptionRepository = {
       findByOrganization: jest.fn(),
+      findPlan: jest.fn(),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -126,7 +127,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — happy path', () => {
     test('should attribute units and return applied=true', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       const updatedDoc = makeUsageDoc({ meterUsed: 100 });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
@@ -147,18 +148,18 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should use subscribed plan as source of truth', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
 
       await BillingUsageService.incrementMeter(orgId, 10, {}, 'hist_plan_pro');
 
-      expect(mockSubscriptionRepository.findByOrganization).toHaveBeenCalledWith(orgId);
+      expect(mockSubscriptionRepository.findPlan).toHaveBeenCalledWith(orgId);
       expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('pro');
     });
 
     test('should use defaultPlan when subscription is missing', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockSubscriptionRepository.findPlan.mockResolvedValue(null);
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'starter' }));
       mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
 
@@ -169,7 +170,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
     test('should fall back to free when subscription and defaultPlan are missing', async () => {
       mockConfig.billing.defaultPlan = undefined;
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockSubscriptionRepository.findPlan.mockResolvedValue(null);
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'free' }));
       mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
 
@@ -179,7 +180,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should return applied=false and fetch existing doc on replay', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       // repo returns null = replay
       mockUsageRepository.incrementMeter.mockResolvedValue(null);
@@ -193,7 +194,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('incrementMeter same idempotencyKey twice → second is no-op', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.incrementMeter
         .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100 }))
@@ -210,7 +211,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — overflow to extras', () => {
     test('should compute extrasConsumed when meterUsed exceeds quota', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       // meterUsed = 510000, quota = 500000 → 10000 overflow
       const updatedDoc = makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 });
@@ -222,7 +223,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should return extrasConsumed=0 when within quota', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({ meterUsed: 100, meterQuota: 500000 });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
@@ -235,7 +236,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — threshold detection', () => {
     test('should emit threshold 80 alert when crossing 80% (once per cycle)', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       // 80% of 500000 = 400000 → crossing at meterUsed = 400001
       const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
@@ -249,7 +250,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 450000,
@@ -265,7 +266,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should emit threshold 100 alert when at 100%', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 500001,
@@ -281,7 +282,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should NOT re-emit threshold 100 when already alerted', async () => {
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 600000,
@@ -299,7 +300,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     test('should NOT set alertCrossed when markThreshold returns modifiedCount=0 (another pod won)', async () => {
       // markThreshold returns modifiedCount=0 → we lost the race, must not emit
       mockUsageRepository.markThreshold.mockResolvedValue({ modifiedCount: 0 });
-      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -10,6 +10,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
   let BillingUsageService;
   let mockUsageRepository;
   let mockPlanService;
+  let mockSubscriptionRepository;
   let mockConfig;
 
   const orgId = '507f1f77bcf86cd799439011';
@@ -50,7 +51,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     mockConfig = {
       billing: {
         meterMode: true,
-        plans: ['pro'],
+        defaultPlan: 'starter',
         meter: {
           runBaseUnits: 1,
           dollarsToUnitRatio: 1000,
@@ -71,12 +72,20 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       getActivePlan: jest.fn(),
     };
 
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
+    };
+
     jest.unstable_mockModule('../../../config/index.js', () => ({
       default: mockConfig,
     }));
 
     jest.unstable_mockModule('../repositories/billing.usage.repository.js', () => ({
       default: mockUsageRepository,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
     }));
 
     jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
@@ -117,6 +126,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — happy path', () => {
     test('should attribute units and return applied=true', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       const updatedDoc = makeUsageDoc({ meterUsed: 100 });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
@@ -136,7 +146,40 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       expect(result.extrasConsumed).toBe(0);
     });
 
+    test('should use subscribed plan as source of truth', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
+
+      await BillingUsageService.incrementMeter(orgId, 10, {}, 'hist_plan_pro');
+
+      expect(mockSubscriptionRepository.findByOrganization).toHaveBeenCalledWith(orgId);
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('pro');
+    });
+
+    test('should use defaultPlan when subscription is missing', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'starter' }));
+      mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
+
+      await BillingUsageService.incrementMeter(orgId, 10, {}, 'hist_default_plan');
+
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('starter');
+    });
+
+    test('should fall back to free when subscription and defaultPlan are missing', async () => {
+      mockConfig.billing.defaultPlan = undefined;
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ planId: 'free' }));
+      mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 10 }));
+
+      await BillingUsageService.incrementMeter(orgId, 10, {}, 'hist_free_fallback');
+
+      expect(mockPlanService.getActivePlan).toHaveBeenCalledWith('free');
+    });
+
     test('should return applied=false and fetch existing doc on replay', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       // repo returns null = replay
       mockUsageRepository.incrementMeter.mockResolvedValue(null);
@@ -150,6 +193,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('incrementMeter same idempotencyKey twice → second is no-op', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan());
       mockUsageRepository.incrementMeter
         .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100 }))
@@ -166,6 +210,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — overflow to extras', () => {
     test('should compute extrasConsumed when meterUsed exceeds quota', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       // meterUsed = 510000, quota = 500000 → 10000 overflow
       const updatedDoc = makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 });
@@ -177,6 +222,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should return extrasConsumed=0 when within quota', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({ meterUsed: 100, meterQuota: 500000 });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
@@ -189,6 +235,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
   describe('incrementMeter — threshold detection', () => {
     test('should emit threshold 80 alert when crossing 80% (once per cycle)', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       // 80% of 500000 = 400000 → crossing at meterUsed = 400001
       const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
@@ -202,6 +249,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 450000,
@@ -217,6 +265,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should emit threshold 100 alert when at 100%', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 500001,
@@ -232,6 +281,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
 
     test('should NOT re-emit threshold 100 when already alerted', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({
         meterUsed: 600000,
@@ -249,6 +299,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     test('should NOT set alertCrossed when markThreshold returns modifiedCount=0 (another pod won)', async () => {
       // markThreshold returns modifiedCount=0 → we lost the race, must not emit
       mockUsageRepository.markThreshold.mockResolvedValue({ modifiedCount: 0 });
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
       const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
       mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);

--- a/modules/billing/tests/billing.usage.unit.tests.js
+++ b/modules/billing/tests/billing.usage.unit.tests.js
@@ -156,6 +156,7 @@ describe('BillingUsage unit tests:', () => {
   describe('Service layer', () => {
     let BillingUsageService;
     let mockUsageRepository;
+    let mockSubscriptionRepository;
 
     const orgId = '507f1f77bcf86cd799439011';
 
@@ -168,8 +169,16 @@ describe('BillingUsage unit tests:', () => {
         reset: jest.fn(),
       };
 
+      mockSubscriptionRepository = {
+        findByOrganization: jest.fn(),
+      };
+
       jest.unstable_mockModule('../repositories/billing.usage.repository.js', () => ({
         default: mockUsageRepository,
+      }));
+
+      jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+        default: mockSubscriptionRepository,
       }));
 
       const mod = await import('../services/billing.usage.service.js');

--- a/modules/organizations/models/organizations.schema.js
+++ b/modules/organizations/models/organizations.schema.js
@@ -14,6 +14,7 @@ const Organization = z.object({
   slug: z.string().trim().min(1).toLowerCase().optional(),
   domain: z.string().trim().default(''),
   plan: z.enum(config.billing.plans).default('free'),
+  meterExempt: z.boolean().default(false),
 });
 
 const OrganizationUpdate = Organization.partial();

--- a/modules/organizations/tests/organizations.schema.unit.tests.js
+++ b/modules/organizations/tests/organizations.schema.unit.tests.js
@@ -1,0 +1,28 @@
+/**
+ * Module dependencies.
+ */
+import { describe, expect, test } from '@jest/globals';
+
+import schema from '../models/organizations.schema.js';
+
+/**
+ * Unit tests for organizations.schema.js
+ */
+describe('organizations.schema unit tests:', () => {
+  test('Organization defaults meterExempt to false', () => {
+    const result = schema.Organization.parse({
+      name: 'Acme',
+    });
+
+    expect(result.meterExempt).toBe(false);
+  });
+
+  test('Organization accepts meterExempt=true', () => {
+    const result = schema.Organization.parse({
+      name: 'Acme',
+      meterExempt: true,
+    });
+
+    expect(result.meterExempt).toBe(true);
+  });
+});

--- a/scripts/tests/billing.cron.weeklyReset.unit.tests.js
+++ b/scripts/tests/billing.cron.weeklyReset.unit.tests.js
@@ -39,6 +39,7 @@ describe('billing.weeklyReset cron — BillingResetService.resetAllDue:', () => 
 
     mockSubscriptionRepository = {
       findAllDueForReset: jest.fn(),
+      findByOrganization: jest.fn().mockResolvedValue({ plan: 'pro' }),
     };
 
     jest.unstable_mockModule('../../config/index.js', () => ({ default: mockConfig }));

--- a/scripts/tests/billing.cron.weeklyReset.unit.tests.js
+++ b/scripts/tests/billing.cron.weeklyReset.unit.tests.js
@@ -40,6 +40,7 @@ describe('billing.weeklyReset cron — BillingResetService.resetAllDue:', () => 
     mockSubscriptionRepository = {
       findAllDueForReset: jest.fn(),
       findByOrganization: jest.fn().mockResolvedValue({ plan: 'pro' }),
+      findPlan: jest.fn().mockResolvedValue({ plan: 'pro' }),
     };
 
     jest.unstable_mockModule('../../config/index.js', () => ({ default: mockConfig }));


### PR DESCRIPTION
## Summary

P0 + P1.7 unblockers identified by `/critical-review` before activating `meterMode: true` in prod.

- **P0.1 — Plan source-of-truth**: `usage.service.js` and `reset.service.js` now read `planId` from the org's `Subscription.plan` instead of `config.billing.plans[0]` (which always returned `'free'`). Hardcoded `'pro'` fallback replaced by configurable `billing.defaultPlan`.
- **P0.2 — BillingPlan seed**: new `BillingPlanService.ensureSeeded()` upserts `BillingPlan` docs from `config.billing.planDefinitions` at boot. Idempotent. No-op when `meterMode=false`. Without this seed, `getActivePlan(planId)` returned `null` → `meterQuota=0` → all gates blocked.
- **P0.3 — meterExempt Zod**: `meterExempt` was on the Mongoose model but absent from the Zod schema → silently dropped on `PUT/PATCH /api/organizations/:id`. Now declared.
- **P1.7 — upgradeUrl in default config**: middleware already read `config.billing.upgradeUrl` with a `/billing/plans` hardcoded fallback. Now declared explicitly in default config.

## What this unblocks

Activating `meterMode: true` in prod was previously broken: every meter quota would snapshot from `'free'` plan (= 0 units) regardless of the org's actual subscription, and `BillingPlan` documents didn't exist in DB anyway. This PR fixes both before any downstream flips the flag.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 977/977 passing
- [x] New unit tests:
  - `billing.plan.ensureSeeded.unit.tests.js` — meterMode off, empty defs, all-new, partial-skip
  - `organizations.schema.unit.tests.js` — meterExempt defaults to false, accepts true
- [x] Updated existing tests:
  - `billing.usage.service.unit.tests.js` — planId resolution from subscription / defaultPlan / 'free'
  - `billing.reset.service.unit.tests.js` — same
  - `billing.cron.weeklyReset.unit.tests.js` — added missing `findByOrganization` mock
- [ ] Downstream override of `planDefinitions` per project (trawl, comes, montaine) — to do once this lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now be marked as meter-exempt for billing purposes.
  * Automatic billing plan initialization on startup from configured plan definitions.
  * Improved billing plan selection now uses organization subscription data instead of static defaults.
  * Added meter mode configuration with upgrade URL support for quota exhaustion.

* **Tests**
  * Added comprehensive unit test coverage for billing initialization, plan management, and subscription handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->