### PR TITLE
feat(billing): refund packId + attachUsageHeader + admin endpoints (PR-N7)

### DIFF
--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -41,6 +41,12 @@ const config = {
      */
     upgradeUrl: '/billing/plans',
     /**
+     * When true, mounts attachUsageContext on protected /api/billing/* routes.
+     * Emits X-Meter-Remaining on billing responses. Off by default to avoid
+     * extra DB reads on routes that do not need the header.
+     */
+    attachUsageHeader: false,
+    /**
      * Plan definitions — DOWNSTREAM-OVERRIDE-REQUIRED for meter mode.
      * Used by BillingPlanService.ensureSeeded() at boot to upsert BillingPlan docs.
      * Each entry: { meterQuota: units/week, ratios: { featureKey: multiplier } }.

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -32,10 +32,12 @@ const adminRefundCharge = async (req, res) => {
 const adminBumpPlanVersion = async (req, res) => {
   try {
     const { planId, meterQuota, ratios } = req.body;
-    const nextPlan = await BillingPlanService.bumpVersion(planId, { meterQuota, ratios });
+    const nextPlan = await BillingPlanService.bumpVersionWithRetry(planId, { meterQuota, ratios });
     responses.success(res, 'billing plan version bumped')(nextPlan);
   } catch (err) {
-    responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump billing plan version')(err);
+    const status = err.message?.startsWith('invalid argument') ? 422 : 502;
+    const title = status === 422 ? 'Unprocessable Entity' : 'Bad Gateway';
+    responses.error(res, status, title, 'Failed to bump billing plan version')(err);
   }
 };
 

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -1,0 +1,45 @@
+/**
+ * Module dependencies
+ */
+import responses from '../../../lib/helpers/responses.js';
+import BillingRefundService from '../services/billing.refund.service.js';
+import BillingPlanService from '../services/billing.plan.service.js';
+
+/**
+ * @desc Admin endpoint to trigger a Stripe refund for a charge
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+const adminRefundCharge = async (req, res) => {
+  try {
+    const { chargeId, amountCents, reason } = req.body;
+    const refund = await BillingRefundService.refundCharge(chargeId, amountCents, { reason });
+    responses.success(res, 'billing refund created')(refund);
+  } catch (err) {
+    const status = err.message?.startsWith('invalid argument') ? 422 : 502;
+    const title = status === 422 ? 'Unprocessable Entity' : 'Bad Gateway';
+    responses.error(res, status, title, 'Failed to refund charge')(err);
+  }
+};
+
+/**
+ * @desc Admin endpoint to create a new plan version
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+const adminBumpPlanVersion = async (req, res) => {
+  try {
+    const { planId, meterQuota, ratios } = req.body;
+    const nextPlan = await BillingPlanService.bumpVersion(planId, { meterQuota, ratios });
+    responses.success(res, 'billing plan version bumped')(nextPlan);
+  } catch (err) {
+    responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump billing plan version')(err);
+  }
+};
+
+export default {
+  adminRefundCharge,
+  adminBumpPlanVersion,
+};

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -76,10 +76,33 @@ const ExtrasCheckoutRequest = z
   })
   .strict();
 
+const AdminRefundRequest = z
+  .object({
+    chargeId: z.string().trim().min(1, 'chargeId is required'),
+    amountCents: z.number().int().positive(),
+    reason: z.string().trim().optional(),
+  })
+  .strict();
+
+const AdminBumpPlanRequest = z
+  .object({
+    planId: z.string().trim().min(1, 'planId is required'),
+    meterQuota: z.number().int().nonnegative().optional(),
+    ratios: z.record(z.string(), z.number().nonnegative()).optional(),
+  })
+  .strict();
+
+export {
+  AdminRefundRequest,
+  AdminBumpPlanRequest,
+};
+
 export default {
   Subscription,
   SubscriptionUpdate,
   CheckoutRequest,
   PortalRequest,
   ExtrasCheckoutRequest,
+  AdminRefundRequest,
+  AdminBumpPlanRequest,
 };

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -79,15 +79,16 @@ const ExtrasCheckoutRequest = z
 const AdminRefundRequest = z
   .object({
     chargeId: z.string().trim().min(1, 'chargeId is required'),
-    amountCents: z.number().int().positive(),
-    reason: z.string().trim().optional(),
+    amountCents: z.number().int().positive().optional(),
+    // Stripe refund reason: https://stripe.com/docs/api/refunds/create#create_refund-reason
+    reason: z.enum(['duplicate', 'fraudulent', 'requested_by_customer']).optional(),
   })
   .strict();
 
 const AdminBumpPlanRequest = z
   .object({
     planId: z.string().trim().min(1, 'planId is required'),
-    meterQuota: z.number().int().nonnegative().optional(),
+    meterQuota: z.number().int().nonnegative(),
     ratios: z.record(z.string(), z.number().nonnegative()).optional(),
   })
   .strict();

--- a/modules/billing/policies/billing.policy.js
+++ b/modules/billing/policies/billing.policy.js
@@ -19,6 +19,8 @@ export function billingSubjectRegistration({ registerPathSubject }) {
   registerPathSubject('/api/billing/extras/checkout', 'BillingExtrasCheckout');
   registerPathSubject('/api/billing/extras/balance', 'BillingExtrasBalance');
   registerPathSubject('/api/billing/extras/ledger', 'BillingExtrasLedger');
+  registerPathSubject('/api/admin/billing/refund', 'BillingAdminRefund');
+  registerPathSubject('/api/admin/billing/plans/bump', 'BillingAdminPlanBump');
   // Webhook is mounted in billing.preroute.js before body parsing and auth middleware,
   // so it bypasses policy.isAllowed entirely. Registered here for documentation completeness.
   registerPathSubject('/api/billing/webhook', 'BillingWebhook');

--- a/modules/billing/routes/billing.admin.routes.js
+++ b/modules/billing/routes/billing.admin.routes.js
@@ -1,0 +1,29 @@
+/**
+ * Module dependencies
+ */
+import passport from 'passport';
+
+import policy from '../../../lib/middlewares/policy.js';
+import model from '../../../lib/middlewares/model.js';
+import billingAdmin from '../controllers/billing.admin.controller.js';
+import {
+  AdminRefundRequest,
+  AdminBumpPlanRequest,
+} from '../models/billing.subscription.schema.js';
+
+/**
+ * Routes
+ * @param {Object} app - Express application instance
+ * @returns {void}
+ */
+export default (app) => {
+  app
+    .route('/api/admin/billing/refund')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(model.isValid(AdminRefundRequest), billingAdmin.adminRefundCharge);
+
+  app
+    .route('/api/admin/billing/plans/bump')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(model.isValid(AdminBumpPlanRequest), billingAdmin.adminBumpPlanVersion);
+};

--- a/modules/billing/routes/billing.routes.js
+++ b/modules/billing/routes/billing.routes.js
@@ -1,6 +1,7 @@
 /**
  * Module dependencies
  */
+import config from '../../../config/index.js';
 import passport from 'passport';
 
 import model from '../../../lib/middlewares/model.js';
@@ -9,6 +10,7 @@ import organization from '../../organizations/middlewares/organizations.middlewa
 import billingSchema from '../models/billing.subscription.schema.js';
 import billingPlans from '../controllers/billing.plans.controller.js';
 import billing from '../controllers/billing.controller.js';
+import attachUsageContext from '../middlewares/billing.attachUsageContext.js';
 
 /**
  * @desc Register billing routes
@@ -16,48 +18,57 @@ import billing from '../controllers/billing.controller.js';
  * @returns {void}
  */
 export default (app) => {
+  const billingGuards = [
+    passport.authenticate('jwt', { session: false }),
+    organization.resolveOrganization,
+    ...(config.billing?.meterMode === true && config.billing?.attachUsageHeader === true
+      ? [attachUsageContext]
+      : []),
+    policy.isAllowed,
+  ];
+
   // plans (public)
   app.route('/api/billing/plans').get(billingPlans.getPlans);
 
   // checkout
   app
     .route('/api/billing/checkout')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .post(model.isValid(billingSchema.CheckoutRequest), billing.checkout);
 
   // portal
   app
     .route('/api/billing/portal')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .post(model.isValid(billingSchema.PortalRequest), billing.portal);
 
   // subscription
   app
     .route('/api/billing/subscription')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .get(billing.getSubscription);
 
   // usage
   app
     .route('/api/billing/usage')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .get(billing.getUsage);
 
   // extras checkout (one-time pack purchase)
   app
     .route('/api/billing/extras/checkout')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .post(model.isValid(billingSchema.ExtrasCheckoutRequest), billing.extrasCheckout);
 
   // extras balance
   app
     .route('/api/billing/extras/balance')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .get(billing.extrasBalance);
 
   // extras ledger (paginated: ?page=1&limit=20)
   app
     .route('/api/billing/extras/ledger')
-    .all(passport.authenticate('jwt', { session: false }), organization.resolveOrganization, policy.isAllowed)
+    .all(...billingGuards)
     .get(billing.extrasLedger);
 };

--- a/modules/billing/routes/billing.routes.js
+++ b/modules/billing/routes/billing.routes.js
@@ -21,10 +21,10 @@ export default (app) => {
   const billingGuards = [
     passport.authenticate('jwt', { session: false }),
     organization.resolveOrganization,
+    policy.isAllowed,
     ...(config.billing?.meterMode === true && config.billing?.attachUsageHeader === true
       ? [attachUsageContext]
       : []),
-    policy.isAllowed,
   ];
 
   // plans (public)

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -72,7 +72,9 @@ const expireOldEntries = (orgId) =>
  * @param {string} stripeSessionId - Stripe session ID of the original purchase (to find the pack).
  * @param {number} amountRefundedCents - Amount refunded in cents (integer).
  * @param {string|undefined} [packId] - Optional pack identifier from Stripe metadata for exact correlation.
- * @returns {Promise<{doc: Object, applied: boolean, refundUnits: number}>}
+ * @returns {Promise<{doc: Object|null, applied: boolean, refundUnits: number, reason?: string}>}
+ *          `reason` is present only when `applied === false`: 'meter_mode_disabled' | 'invalid_org' |
+ *          'pack_not_found' | 'ambiguous_pack_match'.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const refundPartial = async (orgId, stripeSessionId, amountRefundedCents, packId) => {

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -71,10 +71,15 @@ const expireOldEntries = (orgId) =>
  * @param {string} orgId - The organization ObjectId (string).
  * @param {string} stripeSessionId - Stripe session ID of the original purchase (to find the pack).
  * @param {number} amountRefundedCents - Amount refunded in cents (integer).
+ * @param {string|undefined} [packId] - Optional pack identifier from Stripe metadata for exact correlation.
  * @returns {Promise<{doc: Object, applied: boolean, refundUnits: number}>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
+const refundPartial = async (orgId, stripeSessionId, amountRefundedCents, packId) => {
+  if (!config?.billing?.meterMode) {
+    return { doc: null, applied: false, reason: 'meter_mode_disabled', refundUnits: 0 };
+  }
+
   // Find the topup ledger entry for this session to identify the pack
   const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
   if (!doc) return { doc: null, applied: false, reason: 'invalid_org', refundUnits: 0 };
@@ -87,23 +92,27 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents) => {
     return { doc, applied: false, refundUnits: 0 };
   }
 
-  // Find the pack config to compute proportion using the topup entry's meterUnits.
-  // Ambiguity guard: if 0 or >1 packs share the same meterUnits, fall back to
-  // applied=false rather than using a wrong priceUsd.
-  // NOTE: packId is not passed to refundPartial — charge.refunded carries it in
-  // charge.metadata but the webhook call-site only passes (orgId, stripeSessionId, amountCents).
-  // This heuristic is therefore intentionally retained; the ambiguity guard is the safety net.
   const packs = config?.billing?.packs ?? [];
-  const matchingPacks = packs.filter(
-    (p) => (p.meterUnits ?? p.computeUnits) === topupEntry.amount,
-  );
+  let matchingPack;
 
-  if (matchingPacks.length !== 1) {
-    // Ambiguous or unknown pack — cannot compute proportional refund safely.
-    return { doc, applied: false, reason: 'ambiguous_pack_match', refundUnits: 0 };
+  if (packId) {
+    matchingPack = packs.find((p) => p.packId === packId);
+    if (!matchingPack) {
+      return { doc, applied: false, reason: 'pack_not_found', refundUnits: 0 };
+    }
+  } else {
+    const matchingPacks = packs.filter(
+      (p) => (p.meterUnits ?? p.computeUnits) === topupEntry.amount,
+    );
+
+    if (matchingPacks.length !== 1) {
+      // Ambiguous or unknown pack — cannot compute proportional refund safely.
+      return { doc, applied: false, reason: 'ambiguous_pack_match', refundUnits: 0 };
+    }
+
+    matchingPack = matchingPacks[0];
   }
 
-  const matchingPack = matchingPacks[0];
   let refundUnits;
   if (matchingPack.priceUsd && matchingPack.priceUsd > 0) {
     const packUnits = matchingPack.meterUnits ?? matchingPack.computeUnits;

--- a/modules/billing/services/billing.refund.service.js
+++ b/modules/billing/services/billing.refund.service.js
@@ -13,10 +13,12 @@ import getStripe from '../lib/stripe.js';
  *
  * @param {string} stripeChargeId - Stripe charge ID (ch_xxx). Must be non-empty.
  * @param {number|undefined} [amountCents] - Amount to refund in cents. Omit for full refund. Must be > 0 if provided.
+ * @param {Object} [options={}] - Optional Stripe refund options.
+ * @param {string} [options.reason] - Optional Stripe refund reason.
  * @returns {Promise<Object>} The Stripe refund object.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const refundCharge = async (stripeChargeId, amountCents) => {
+const refundCharge = async (stripeChargeId, amountCents, { reason } = {}) => {
   if (typeof stripeChargeId !== 'string' || stripeChargeId.trim() === '') {
     throw new Error('invalid argument: stripeChargeId must be a non-empty string');
   }
@@ -33,7 +35,7 @@ const refundCharge = async (stripeChargeId, amountCents) => {
 
   const params = {
     charge: stripeChargeId,
-    reason: 'requested_by_customer',
+    reason: reason || 'requested_by_customer',
   };
   if (amountCents !== undefined) {
     params.amount = amountCents;

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -339,12 +339,12 @@ const handleInvoicePaymentSucceeded = async (invoice) => {
 
 /**
  * @description Handle charge.refunded event — debit ledger proportionally.
- *       Reads charge.metadata.{organizationId, stripeSessionId} which must be propagated
+ *       Reads charge.metadata.{organizationId, stripeSessionId, packId} which must be propagated
  *       via the upstream session creation pattern:
  *         stripe.checkout.sessions.create({
  *           ...,
- *           metadata: { organizationId, stripeSessionId, ... },
- *           payment_intent_data: { metadata: { organizationId, stripeSessionId, ... } },
+ *           metadata: { organizationId, stripeSessionId, packId, ... },
+ *           payment_intent_data: { metadata: { organizationId, stripeSessionId, packId, ... } },
  *         })
  *       Without payment_intent_data.metadata, charge.metadata will be empty and refunds
  *       silently skip. Downstream (trawl_node) is responsible for setting these at session creation.
@@ -363,7 +363,7 @@ const handleChargeRefunded = async (charge) => {
   // The session ID and organizationId must have been stamped on charge metadata
   // via payment_intent_data.metadata at session creation (not automatic — caller must set both
   // session.metadata and payment_intent_data.metadata explicitly).
-  const { organizationId, stripeSessionId } = metadata ?? {};
+  const { organizationId, stripeSessionId, packId } = metadata ?? {};
 
   if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
   if (!stripeSessionId) return;
@@ -374,7 +374,7 @@ const handleChargeRefunded = async (charge) => {
   if (!thisRefundAmount || thisRefundAmount <= 0) return;
 
   // Service layer computes proportional refundUnits from config.billing.packs.
-  await BillingExtraService.refundPartial(organizationId, stripeSessionId, thisRefundAmount);
+  await BillingExtraService.refundPartial(organizationId, stripeSessionId, thisRefundAmount, packId);
 };
 
 export default {

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -84,7 +84,7 @@ describe('Billing admin integration tests:', () => {
     };
 
     mockBillingPlanService = {
-      bumpVersion: jest.fn().mockResolvedValue({
+      bumpVersionWithRetry: jest.fn().mockResolvedValue({
         _id: '507f1f77bcf86cd799439011',
         planId: 'pro',
         version: 'v7',
@@ -232,7 +232,7 @@ describe('Billing admin integration tests:', () => {
       res,
     );
 
-    expect(mockBillingPlanService.bumpVersion).toHaveBeenCalledWith('pro', { meterQuota: 12345, ratios: { llm: 2 } });
+    expect(mockBillingPlanService.bumpVersionWithRetry).toHaveBeenCalledWith('pro', { meterQuota: 12345, ratios: { llm: 2 } });
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -247,6 +247,58 @@ describe('Billing admin integration tests:', () => {
     await runHandlers(
       [...refundRoute.all, ...refundRoute.post],
       { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: '', amountCents: 0 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  test('invalid Stripe reason returns 422 from schema validation', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', reason: 'not_a_valid_reason' } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  test('admin user can POST full refund without amountCents', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', reason: 'requested_by_customer' } },
+      res,
+    );
+
+    expect(mockBillingRefundService.refundCharge).toHaveBeenCalledWith('ch_test_123', undefined, { reason: 'requested_by_customer' });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('bump plan without meterQuota returns 422 from schema validation', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { planId: 'pro' } },
       res,
     );
 

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -304,4 +304,80 @@ describe('Billing admin integration tests:', () => {
 
     expect(res.status).toHaveBeenCalledWith(422);
   });
+
+  test('refund service upstream error returns 502', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockBillingRefundService.refundCharge.mockRejectedValueOnce(new Error('upstream error'));
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(502);
+  });
+
+  test('refund service invalid argument error returns 422', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockBillingRefundService.refundCharge.mockRejectedValueOnce(new Error('invalid argument: amountCents must be > 0'));
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  test('bump plan service upstream error returns 502', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockBillingPlanService.bumpVersionWithRetry.mockRejectedValueOnce(new Error('E11000 duplicate key'));
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { planId: 'pro', meterQuota: 12345 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(502);
+  });
+
+  test('bump plan service invalid argument error returns 422', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockBillingPlanService.bumpVersionWithRetry.mockRejectedValueOnce(new Error('invalid argument: meterQuota must be >= 0'));
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { planId: 'pro', meterQuota: 12345 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
 });

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -1,0 +1,255 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+
+/**
+ * Integration tests for billing admin endpoints.
+ */
+describe('Billing admin integration tests:', () => {
+  let billingAdminRoutes;
+  let mockBillingRefundService;
+  let mockBillingPlanService;
+
+  /**
+   * Create a lightweight route registry compatible with app.route().
+   * @returns {{app: Object, routes: Map<string, Object>}} Mock app and collected routes.
+   */
+  const createRouteRegistry = () => {
+    const routes = new Map();
+    const app = {
+      route: jest.fn((path) => {
+        const entry = { all: [], get: [], post: [] };
+        routes.set(path, entry);
+        const routeBuilder = {
+          all: (...handlers) => {
+            entry.all.push(...handlers);
+            return routeBuilder;
+          },
+          get: (...handlers) => {
+            entry.get.push(...handlers);
+            return routeBuilder;
+          },
+          post: (...handlers) => {
+            entry.post.push(...handlers);
+            return routeBuilder;
+          },
+        };
+        return routeBuilder;
+      }),
+    };
+    return { app, routes };
+  };
+
+  /**
+   * Execute middleware/handler chain sequentially.
+   * @param {Function[]} handlers - Middleware/handlers to execute.
+   * @param {Object} req - Mock Express request.
+   * @param {Object} res - Mock Express response.
+   * @returns {Promise<void>}
+   */
+  const runHandlers = async (handlers, req, res) => {
+    const dispatch = async (index) => {
+      const handler = handlers[index];
+      if (!handler) return;
+      if (handler.length >= 3) {
+        let nextPromise = null;
+        await handler(req, res, () => {
+          nextPromise = dispatch(index + 1);
+          return nextPromise;
+        });
+        if (nextPromise) await nextPromise;
+        return;
+      }
+      await handler(req, res);
+    };
+
+    await dispatch(0);
+  };
+
+  /**
+   * Build route module with mocked dependencies.
+   * @returns {Promise<Map<string, Object>>} Collected route map.
+   */
+  const buildRoutes = async () => {
+    jest.resetModules();
+
+    mockBillingRefundService = {
+      refundCharge: jest.fn().mockResolvedValue({
+        id: 're_test_123',
+        charge: 'ch_test_123',
+        amount: 2500,
+        status: 'succeeded',
+      }),
+    };
+
+    mockBillingPlanService = {
+      bumpVersion: jest.fn().mockResolvedValue({
+        _id: '507f1f77bcf86cd799439011',
+        planId: 'pro',
+        version: 'v7',
+        meterQuota: 12345,
+        ratios: { llm: 2 },
+        active: true,
+      }),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: {
+          plans: ['free', 'starter', 'pro'],
+          statuses: ['active', 'canceled'],
+        },
+        validation: {
+          supportedMethods: ['post', 'put', 'patch'],
+        },
+      },
+    }));
+
+    jest.unstable_mockModule('passport', () => ({
+      default: {
+        authenticate: jest.fn(() => (req, _res, next) => {
+          const role = req.headers?.['x-role'] || 'user';
+          req.user = { _id: '507f1f77bcf86cd799439022', roles: [role] };
+          next();
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: {
+        isAllowed: jest.fn((req, res, next) => {
+          if (req.user?.roles?.includes('admin')) return next();
+          return res.status(403).json({
+            type: 'error',
+            message: 'Unauthorized',
+            code: 403,
+            status: 403,
+            errorCode: 'SERVER_ERROR',
+            description: 'User is not authorized',
+          });
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/model.js', () => ({
+      default: {
+        isValid: (schema) => (req, res, next) => {
+          const result = schema.safeParse(req.body);
+          if (!result.success) {
+            return res.status(422).json({
+              type: 'error',
+              message: 'Schema validation error',
+            });
+          }
+          req.body = result.data;
+          return next();
+        },
+      },
+    }));
+
+    jest.unstable_mockModule('../services/billing.refund.service.js', () => ({
+      default: mockBillingRefundService,
+    }));
+
+    jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+      default: mockBillingPlanService,
+    }));
+
+    billingAdminRoutes = (await import('../routes/billing.admin.routes.js')).default;
+
+    const { app, routes } = createRouteRegistry();
+    billingAdminRoutes(app);
+    return routes;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('non-admin user gets 403 on both admin endpoints', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+
+    const refundRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'user' }, body: { chargeId: 'ch_test_001', amountCents: 1000 } },
+      refundRes,
+    );
+
+    const bumpRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.post],
+      { method: 'POST', headers: { 'x-role': 'user' }, body: { planId: 'pro', meterQuota: 1000 } },
+      bumpRes,
+    );
+
+    expect(refundRes.status).toHaveBeenCalledWith(403);
+    expect(bumpRes.status).toHaveBeenCalledWith(403);
+  });
+
+  test('admin user can POST refund with valid body', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500, reason: 'duplicate' } },
+      res,
+    );
+
+    expect(mockBillingRefundService.refundCharge).toHaveBeenCalledWith('ch_test_123', 2500, { reason: 'duplicate' });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('admin user can POST plan bump with valid body', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { planId: 'pro', meterQuota: 12345, ratios: { llm: 2 } } },
+      res,
+    );
+
+    expect(mockBillingPlanService.bumpVersion).toHaveBeenCalledWith('pro', { meterQuota: 12345, ratios: { llm: 2 } });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('invalid body returns 422 from schema validation', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...refundRoute.all, ...refundRoute.post],
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: '', amountCents: 0 } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+});

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -234,7 +234,7 @@ describe('BillingExtraService unit tests:', () => {
       const updatedDoc = makeDoc({ cachedBalance: 0 });
       mockRepository.refundPartial.mockResolvedValue({ doc: updatedDoc, applied: true });
 
-      const result = await BillingExtraService.refundPartial(orgId, 'cs_refund_test', 4900);
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_refund_test', 4900, 'pack_500k');
 
       // $49 / $49 * 500000 = 500000 units
       expect(result.refundUnits).toBe(500000);
@@ -260,7 +260,7 @@ describe('BillingExtraService unit tests:', () => {
       mockRepository.getOrCreate.mockResolvedValue(doc);
       mockRepository.refundPartial.mockResolvedValue({ doc: makeDoc({ cachedBalance: -500000 }), applied: true });
 
-      const result = await BillingExtraService.refundPartial(orgId, 'cs_consumed', 4900);
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_consumed', 4900, 'pack_500k');
       // Applied (even with negative resulting balance — correct economic reflection)
       expect(result.applied).toBe(true);
     });
@@ -274,11 +274,31 @@ describe('BillingExtraService unit tests:', () => {
       expect(result.refundUnits).toBe(0);
     });
 
-    test('should return applied=false with reason ambiguous_pack_match when multiple packs have same meterUnits', async () => {
-      // Simulate two packs with identical meterUnits
+    test('should resolve duplicate meterUnits correctly when packId is provided', async () => {
       mockConfig.billing.packs = [
         { packId: 'pack_a', meterUnits: 500000, priceUsd: 49 },
         { packId: 'pack_b', meterUnits: 500000, priceUsd: 39 }, // promo duplicate
+      ];
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439ccc',
+        kind: 'topup',
+        amount: 500000,
+        stripeSessionId: 'cs_ambiguous',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 500000 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+      mockRepository.refundPartial.mockResolvedValue({ doc: makeDoc({ cachedBalance: 374359 }), applied: true });
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_ambiguous', 4900, 'pack_a');
+      expect(result.applied).toBe(true);
+      expect(result.refundUnits).toBe(500000);
+      expect(mockRepository.refundPartial).toHaveBeenCalled();
+    });
+
+    test('should return applied=false with reason ambiguous_pack_match when multiple packs have same meterUnits and no packId', async () => {
+      mockConfig.billing.packs = [
+        { packId: 'pack_a', meterUnits: 500000, priceUsd: 49 },
+        { packId: 'pack_b', meterUnits: 500000, priceUsd: 39 },
       ];
       const topupEntry = {
         _id: '507f1f77bcf86cd799439ccc',
@@ -294,6 +314,47 @@ describe('BillingExtraService unit tests:', () => {
       expect(result.reason).toBe('ambiguous_pack_match');
       expect(result.refundUnits).toBe(0);
       expect(mockRepository.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('should return pack_not_found when packId metadata is unknown', async () => {
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439ddd',
+        kind: 'topup',
+        amount: 500000,
+        stripeSessionId: 'cs_unknown_pack',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 500000 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_unknown_pack', 4900, 'pack_missing');
+
+      expect(result.applied).toBe(false);
+      expect(result.reason).toBe('pack_not_found');
+      expect(result.refundUnits).toBe(0);
+      expect(mockRepository.refundPartial).not.toHaveBeenCalled();
+    });
+
+    test('legacy topup with no packId still falls back to meterUnits heuristic', async () => {
+      const topupEntry = {
+        _id: '507f1f77bcf86cd799439eee',
+        kind: 'topup',
+        amount: 2000000,
+        stripeSessionId: 'cs_legacy',
+      };
+      const doc = makeDoc({ ledger: [topupEntry], cachedBalance: 2000000 });
+      mockRepository.getOrCreate.mockResolvedValue(doc);
+      mockRepository.refundPartial.mockResolvedValue({ doc: makeDoc({ cachedBalance: 1000000 }), applied: true });
+
+      const result = await BillingExtraService.refundPartial(orgId, 'cs_legacy', 7450);
+
+      expect(result.applied).toBe(true);
+      expect(result.refundUnits).toBe(1000000);
+      expect(mockRepository.refundPartial).toHaveBeenCalledWith(
+        orgId,
+        'cs_legacy',
+        1000000,
+        'refund-cs_legacy-7450-507f1f77bcf86cd799439eee',
+      );
     });
   });
 });

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -58,6 +58,15 @@ describe('BillingRefundService unit tests:', () => {
       );
     });
 
+    test('should forward an explicit reason when provided', async () => {
+      await BillingRefundService.refundCharge('ch_test_xyz', 2000, { reason: 'duplicate' });
+
+      expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
+        { charge: 'ch_test_xyz', reason: 'duplicate', amount: 2000 },
+        { idempotencyKey: 'refund_ch_test_xyz_2000' },
+      );
+    });
+
     test('idempotency key is "refund_{chargeId}_full" for full refund', async () => {
       await BillingRefundService.refundCharge('ch_abc');
 

--- a/modules/billing/tests/billing.usageHeader.integration.tests.js
+++ b/modules/billing/tests/billing.usageHeader.integration.tests.js
@@ -1,0 +1,206 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, afterEach, test, expect } from '@jest/globals';
+
+/**
+ * Integration tests for attachUsageContext route wiring.
+ */
+describe('Billing usage header integration tests:', () => {
+  let billingRoutes;
+  let mockBillingService;
+  let mockBillingUsageService;
+  let mockBillingExtraService;
+  let mockBillingExtraBalanceRepository;
+
+  /**
+   * Create a lightweight route registry compatible with app.route().
+   * @returns {{app: Object, routes: Map<string, Object>}} Mock app and collected routes.
+   */
+  const createRouteRegistry = () => {
+    const routes = new Map();
+    const app = {
+      route: jest.fn((path) => {
+        const entry = { all: [], get: [], post: [] };
+        routes.set(path, entry);
+        const routeBuilder = {
+          all: (...handlers) => {
+            entry.all.push(...handlers);
+            return routeBuilder;
+          },
+          get: (...handlers) => {
+            entry.get.push(...handlers);
+            return routeBuilder;
+          },
+          post: (...handlers) => {
+            entry.post.push(...handlers);
+            return routeBuilder;
+          },
+        };
+        return routeBuilder;
+      }),
+    };
+    return { app, routes };
+  };
+
+  /**
+   * Execute middleware/handler chain sequentially.
+   * @param {Function[]} handlers - Middleware/handlers to execute.
+   * @param {Object} req - Mock Express request.
+   * @param {Object} res - Mock Express response.
+   * @returns {Promise<void>}
+   */
+  const runHandlers = async (handlers, req, res) => {
+    const dispatch = async (index) => {
+      const handler = handlers[index];
+      if (!handler) return;
+      if (handler.length >= 3) {
+        let nextPromise = null;
+        await handler(req, res, () => {
+          nextPromise = dispatch(index + 1);
+          return nextPromise;
+        });
+        if (nextPromise) await nextPromise;
+        return;
+      }
+      await handler(req, res);
+    };
+
+    await dispatch(0);
+  };
+
+  /**
+   * Build route module with mocked dependencies.
+   * @param {boolean} attachUsageHeader - Whether the header middleware should be mounted.
+   * @returns {Promise<Map<string, Object>>} Collected route map.
+   */
+  const buildRoutes = async (attachUsageHeader) => {
+    jest.resetModules();
+
+    mockBillingService = {
+      getSubscription: jest.fn().mockResolvedValue({ plan: 'pro', status: 'active' }),
+    };
+    mockBillingUsageService = {
+      getMeter: jest.fn().mockResolvedValue({
+        meterUsed: 1200,
+        meterQuota: 5000,
+        meterBreakdown: {},
+        weekKey: '2026-W18',
+        resetAt: new Date('2026-05-04T00:00:00.000Z'),
+        planVersion: 'v2',
+      }),
+      get: jest.fn(),
+      currentWeekKey: jest.fn().mockReturnValue('2026-W18'),
+    };
+    mockBillingExtraService = {
+      listLedger: jest.fn(),
+    };
+    mockBillingExtraBalanceRepository = {
+      getBalance: jest.fn().mockResolvedValue(700),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: {
+          plans: ['free', 'starter', 'pro'],
+          statuses: ['active', 'canceled'],
+          meterMode: true,
+          attachUsageHeader,
+          packs: [],
+          quotas: {},
+        },
+      },
+    }));
+
+    jest.unstable_mockModule('passport', () => ({
+      default: {
+        authenticate: jest.fn(() => (req, _res, next) => {
+          req.user = {
+            _id: '507f1f77bcf86cd799439022',
+            currentOrganization: '507f1f77bcf86cd799439011',
+            roles: ['user'],
+          };
+          next();
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: {
+        isAllowed: jest.fn((_req, _res, next) => next()),
+      },
+    }));
+
+    jest.unstable_mockModule('../../organizations/middlewares/organizations.middleware.js', () => ({
+      default: {
+        resolveOrganization: jest.fn((req, _res, next) => {
+          req.organization = { _id: '507f1f77bcf86cd799439011' };
+          req.membership = { role: 'owner', organizationId: '507f1f77bcf86cd799439011' };
+          next();
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../services/billing.service.js', () => ({
+      default: mockBillingService,
+    }));
+
+    jest.unstable_mockModule('../services/billing.usage.service.js', () => ({
+      default: mockBillingUsageService,
+    }));
+
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: mockBillingExtraService,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.extraBalance.repository.js', () => ({
+      default: mockBillingExtraBalanceRepository,
+    }));
+
+    jest.unstable_mockModule('../lib/constants.js', () => ({
+      activeStatuses: ['active', 'trialing'],
+    }));
+
+    billingRoutes = (await import('../routes/billing.routes.js')).default;
+
+    const { app, routes } = createRouteRegistry();
+    billingRoutes(app);
+    return routes;
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('GET /api/billing/usage sets X-Meter-Remaining when attachUsageHeader=true', async () => {
+    const routes = await buildRoutes(true);
+    const usageRoute = routes.get('/api/billing/usage');
+    const req = { method: 'GET', params: {}, query: {} };
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers([...usageRoute.all, ...usageRoute.get], req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Meter-Remaining', '4500');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('GET /api/billing/usage does not set X-Meter-Remaining when attachUsageHeader=false', async () => {
+    const routes = await buildRoutes(false);
+    const usageRoute = routes.get('/api/billing/usage');
+    const req = { method: 'GET', params: {}, query: {} };
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers([...usageRoute.all, ...usageRoute.get], req, res);
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -28,6 +28,7 @@ describe('Billing webhook refund integration tests:', () => {
     metadata: {
       organizationId: orgId,
       stripeSessionId,
+      packId: 'pack_500k',
     },
     ...overrides,
   });
@@ -93,13 +94,13 @@ describe('Billing webhook refund integration tests:', () => {
   });
 
   describe('handleChargeRefunded', () => {
-    test('full refund — calls refundPartial with correct orgId, sessionId and delta amount', async () => {
+    test('full refund — calls refundPartial with correct orgId, sessionId, delta amount and packId', async () => {
       // refunds.data[0].amount = 4900 (this event's delta, same as total for single refund)
       await BillingWebhookService.handleChargeRefunded(
         makeCharge({ refunds: { data: [{ id: 'rf_001', amount: 4900 }] } }),
       );
 
-      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 4900);
+      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 4900, 'pack_500k');
     });
 
     test('partial refund — calls refundPartial with delta amount (not cumulative total)', async () => {
@@ -112,7 +113,7 @@ describe('Billing webhook refund integration tests:', () => {
         }),
       );
 
-      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 2450);
+      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 2450, 'pack_500k');
     });
 
     test('should skip when organizationId is missing', async () => {


### PR DESCRIPTION
## Summary

P1.4 + P1.5 + P1.6 from the post-PR-N5 critical-review. Builds the missing surface for activating `meterMode: true` safely (refund correlation, header for front, admin operations).

- **P1.4 — Refund correlation by packId**: `BillingExtraService.refundPartial(orgId, sessionId, amountCents, packId)` now disambiguates via `packId` (extracted from `charge.metadata` in `handleChargeRefunded`). Legacy fallback to `meterUnits` heuristic preserved for topups created before this change → backward compatible.
- **P1.5 — `attachUsageHeader` config flag**: new `billing.attachUsageHeader` flag (default `false`). When `true` and `meterMode` is also `true`, billing routes mount `attachUsageContext` → response carries `X-Meter-Remaining`.
- **P1.6 — Admin endpoints**:
  - `POST /api/admin/billing/refund` → wraps `BillingRefundService.refundCharge`
  - `POST /api/admin/billing/plans/bump` → wraps `BillingPlanService.bumpVersion`
  Both Zod-validated, gated by the existing CASL platform-admin grant (already `manage all`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit -- billing` — 975/975 passing
- [x] New: `billing.admin.integration.tests.js` (admin endpoints, role guard, validation)
- [x] New: `billing.usageHeader.integration.tests.js` (header on/off based on flag)
- [x] Updated: `billing.extra.service`, `billing.refund.service`, `billing.webhook.refund.integration` tests cover packId path + legacy fallback
- [ ] Frontend handling of `422` on admin endpoint validation errors (note for downstream)

## Notes

- `createExtrasCheckout` already stamped `packId` on both `session.metadata` and `payment_intent_data.metadata` — no session creation change needed.
- New admin route validation returns **422** (per existing `model.isValid` convention), not 400 — flag for any UI consuming these endpoints.
- CASL: existing `billing.policy.js` already grants admins `manage all`, so the new admin paths inherit that permission. No new ability declarations needed.