### PR TITLE
fix(test): ensure Migration indexes exist on per-worker DBs when migrations pre-warmed

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -77,10 +77,13 @@ const bootstrap = async () => {
     if (!migrationsAlreadyRan) {
       await migrations.run();
     } else {
-      // globalSetup already ran migrations on the base DB, but each jest worker
-      // operates on an isolated DB (JEST_WORKER_ID suffix). Ensure the unique
-      // index on Migration.name exists in this worker's DB so duplicate-rejection
-      // works correctly (e.g. migrations.integration.tests.js).
+      // globalSetup already ran migrations on a DB that may differ from the one
+      // this suite connects to (e.g. a per-worker DB identified by JEST_WORKER_ID,
+      // or the same base DB when running with --runInBand). Ensure the unique
+      // index on Migration.name exists in the currently-connected DB so
+      // duplicate-rejection works correctly (e.g. migrations.integration.tests.js).
+      // On the base DB this is a harmless no-op — indexes already exist after
+      // globalSetup ran migrations.run().
       await migrations.ensureMigrationIndexes();
     }
     app = await startExpress();

--- a/lib/app.js
+++ b/lib/app.js
@@ -76,6 +76,12 @@ const bootstrap = async () => {
       process.env.NODE_ENV === 'test' && process.env.DEVKIT_MIGRATIONS_RAN === '1';
     if (!migrationsAlreadyRan) {
       await migrations.run();
+    } else {
+      // globalSetup already ran migrations on the base DB, but each jest worker
+      // operates on an isolated DB (JEST_WORKER_ID suffix). Ensure the unique
+      // index on Migration.name exists in this worker's DB so duplicate-rejection
+      // works correctly (e.g. migrations.integration.tests.js).
+      await migrations.ensureMigrationIndexes();
     }
     app = await startExpress();
   } catch (e) {


### PR DESCRIPTION
## Summary

- When `DEVKIT_MIGRATIONS_RAN=1` (set by globalSetup), bootstrap() skipped `migrations.run()` entirely — but jest workers operate on `JEST_WORKER_ID`-suffixed DBs that had no indexes
- The unique index on `Migration.name` only existed on the base DB, causing duplicate-rejection assertions (`migrations.integration.tests.js`) to fail silently on worker DBs
- Fix: in the `migrationsAlreadyRan` branch, call `migrations.ensureMigrationIndexes()` to recreate the unique index per-worker without re-running migration files
- Related issues: <!-- Closes #N -->

## Scope

- Module(s) impacted: `lib/app.js` (bootstrap only)
- Cross-module impact: `none` — internal to test infrastructure, no production code path changed
- Risk level: `low` — the else branch only executes under `NODE_ENV=test && DEVKIT_MIGRATIONS_RAN=1`; `syncIndexes()` is idempotent

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Optional: Infra/Stack alignment details

### Before vs After (key changes only)

| Area | Before | After | Notes |
| ---- | ------ | ----- | ----- |
| `bootstrap()` when `DEVKIT_MIGRATIONS_RAN=1` | Skips migrations entirely — no index creation on worker DB | Calls `migrations.ensureMigrationIndexes()` — creates unique index on `Migration.name` | Only fires in `NODE_ENV=test` |

- Upstream parity target / source: trawl_node commit `ce541f0f72d3` (surfaced by trawl_node#1075 propagation of #3558 per-worker DB isolation)
- Automation or policy impact: none — CI matrix from #3559 is unchanged
- Rollback plan: revert `lib/app.js` to the `if (!migrationsAlreadyRan) { await migrations.run(); }` form

## Notes for reviewers

- Security considerations: none — change is scoped to `NODE_ENV=test` only
- Mergeability considerations: none — touches only `lib/app.js`, no conflicts expected with recent merges
- The fix is a one-liner (`await migrations.ensureMigrationIndexes()`) in an else branch; `ensureMigrationIndexes` already existed in `lib/services/migrations.js` (delegates to `Migration.syncIndexes()`)
- Consumers (trawl_node, comes_node, etc.) get this fix automatically via `/update-stack` — no action required on their side