### PR TITLE
fix(auth): expose billing.{enabled,meterMode} in authenticated /api/auth/config

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -573,12 +573,16 @@ const getConfig = (req, res) => {
     },
   };
 
-  // Authenticated users get extended org config
+  // Authenticated users get extended org config and billing config
   if (req.user) {
     data.organizations = {
       ...data.organizations,
       roles: config.organizations?.roles || [],
       roleDescriptions: config.organizations?.roleDescriptions || {},
+    };
+    data.billing = {
+      enabled: !!config.billing?.enabled,
+      meterMode: !!config.billing?.meterMode,
     };
   }
 

--- a/modules/auth/tests/auth.config.controller.unit.tests.js
+++ b/modules/auth/tests/auth.config.controller.unit.tests.js
@@ -1,0 +1,143 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+/**
+ * Unit tests for auth.controller getConfig()
+ *
+ * Verifies that:
+ *  1. data.billing is absent in the unauthenticated response.
+ *  2. data.billing defaults to { enabled: false, meterMode: false } when
+ *     config.billing is undefined (authenticated).
+ *  3. data.billing reflects truthful config values when both flags are set
+ *     (authenticated).
+ */
+describe('auth.controller getConfig:', () => {
+  let mockConfig;
+  let mockResponses;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockConfig = {
+      sign: { up: true, in: true },
+      jwt: { secret: 's', expiresIn: 3600 },
+      cookie: { secure: true, sameSite: 'lax' },
+      organizations: { enabled: false },
+      app: { title: 'Test', contact: 'a@b.com' },
+    };
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+    jest.unstable_mockModule('../../../modules/users/services/users.service.js', () => ({
+      default: { create: jest.fn(), getBrut: jest.fn(), update: jest.fn(), remove: jest.fn(), search: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/users/repositories/users.repository.js', () => ({
+      default: { update: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.service.js', () => ({
+      default: { handleSignupOrganization: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.crud.service.js', () => ({
+      default: { autoSetCurrentOrganization: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.membership.service.js', () => ({
+      default: { findByUserAndOrganization: jest.fn(), listPendingByUser: jest.fn().mockResolvedValue([]) },
+    }));
+    jest.unstable_mockModule('../../../modules/users/models/users.schema.js', () => ({
+      default: { User: {} },
+    }));
+    jest.unstable_mockModule('../../../lib/middlewares/model.js', () => ({
+      default: { getResultFromZod: jest.fn(), checkError: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: { defineAbilityFor: jest.fn().mockResolvedValue({}) },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/mailer/index.js', () => ({
+      default: { isConfigured: jest.fn().mockReturnValue(false), sendMail: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/errors.js', () => ({
+      default: { getMessage: jest.fn().mockReturnValue('error') },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/AppError.js', () => ({
+      default: class AppError extends Error {
+        constructor(msg, opts) {
+          super(msg);
+          this.code = opts?.code;
+          this.details = opts?.details;
+        }
+      },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/abilities.js', () => ({
+      default: jest.fn().mockReturnValue([]),
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/getBaseUrl.js', () => ({
+      default: jest.fn().mockReturnValue('http://localhost:3000'),
+    }));
+    jest.unstable_mockModule('../../../lib/services/analytics.js', () => ({
+      default: { identify: jest.fn(), groupIdentify: jest.fn() },
+    }));
+
+    // Capture what responses.success is called with
+    mockResponses = {
+      successCb: jest.fn(),
+      errorCb: jest.fn(),
+    };
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: {
+        success: jest.fn().mockReturnValue(mockResponses.successCb),
+        error: jest.fn().mockReturnValue(mockResponses.errorCb),
+      },
+    }));
+  });
+
+  test('data.billing is absent in the unauthenticated response', async () => {
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+    const { default: responses } = await import('../../../lib/helpers/responses.js');
+
+    const req = {}; // no req.user
+    const res = {};
+
+    AuthController.getConfig(req, res);
+
+    expect(responses.success).toHaveBeenCalledWith(res, 'Auth config');
+    const [data] = mockResponses.successCb.mock.calls[0];
+    expect(data.billing).toBeUndefined();
+  });
+
+  test('data.billing defaults to false/false when config.billing is undefined (authenticated)', async () => {
+    // config has no billing key
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = { user: { id: '1' } };
+    const res = {};
+
+    AuthController.getConfig(req, res);
+
+    const [data] = mockResponses.successCb.mock.calls[0];
+    expect(data.billing).toBeDefined();
+    expect(data.billing.enabled).toBe(false);
+    expect(data.billing.meterMode).toBe(false);
+  });
+
+  test('data.billing reflects config truthfully when both flags are enabled (authenticated)', async () => {
+    mockConfig.billing = { enabled: true, meterMode: true };
+
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = { user: { id: '1' } };
+    const res = {};
+
+    AuthController.getConfig(req, res);
+
+    const [data] = mockResponses.successCb.mock.calls[0];
+    expect(data.billing).toBeDefined();
+    expect(data.billing.enabled).toBe(true);
+    expect(data.billing.meterMode).toBe(true);
+  });
+});

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1506,6 +1506,21 @@ describe('Auth integration tests:', () => {
       expect(result.body.data.organizations.enabled).toBe(true);
       config.organizations.enabled = original;
     });
+
+    test('should expose billing config to authenticated users', async () => {
+      const result = await agent.get('/api/auth/config').expect(200);
+      expect(result.body.data.billing).toBeDefined();
+      expect(typeof result.body.data.billing.enabled).toBe('boolean');
+      expect(typeof result.body.data.billing.meterMode).toBe('boolean');
+    });
+
+    test('should reflect billing.meterMode=true when enabled (authenticated)', async () => {
+      const originalMeterMode = config.billing?.meterMode;
+      config.billing = { ...config.billing, meterMode: true };
+      const result = await agent.get('/api/auth/config').expect(200);
+      expect(result.body.data.billing.meterMode).toBe(true);
+      config.billing = { ...config.billing, meterMode: originalMeterMode };
+    });
   });
 
   describe('Email verification', () => {

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1507,8 +1507,38 @@ describe('Auth integration tests:', () => {
       config.organizations.enabled = original;
     });
 
-    test('should expose billing config to authenticated users', async () => {
+    test('should NOT expose billing config in unauthenticated response', async () => {
       const result = await agent.get('/api/auth/config').expect(200);
+      expect(result.body.data.billing).toBeUndefined();
+    });
+  });
+
+  describe('Config endpoint (authenticated)', () => {
+    const billingUserEmail = 'billing-config@test.com';
+    let authAgent;
+
+    beforeAll(async () => {
+      authAgent = request.agent(app);
+      await authAgent
+        .post('/api/auth/signup')
+        .send({
+          firstName: 'Billing',
+          lastName: 'Config',
+          email: billingUserEmail,
+          password: 'W@os.jsI$Aw3$0m3',
+        })
+        .expect(200);
+    });
+
+    afterAll(async () => {
+      try {
+        const u = await UserService.getBrut({ email: billingUserEmail });
+        if (u) await UserService.remove(u);
+      } catch (_) { /* cleanup – ignore errors */ }
+    });
+
+    test('should expose billing config to authenticated users', async () => {
+      const result = await authAgent.get('/api/auth/config').expect(200);
       expect(result.body.data.billing).toBeDefined();
       expect(typeof result.body.data.billing.enabled).toBe('boolean');
       expect(typeof result.body.data.billing.meterMode).toBe('boolean');
@@ -1517,9 +1547,12 @@ describe('Auth integration tests:', () => {
     test('should reflect billing.meterMode=true when enabled (authenticated)', async () => {
       const originalMeterMode = config.billing?.meterMode;
       config.billing = { ...config.billing, meterMode: true };
-      const result = await agent.get('/api/auth/config').expect(200);
-      expect(result.body.data.billing.meterMode).toBe(true);
-      config.billing = { ...config.billing, meterMode: originalMeterMode };
+      try {
+        const result = await authAgent.get('/api/auth/config').expect(200);
+        expect(result.body.data.billing.meterMode).toBe(true);
+      } finally {
+        config.billing = { ...config.billing, meterMode: originalMeterMode };
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Wires `config.billing.enabled` and `config.billing.meterMode` into the `getConfig()` response, but **only for authenticated users** — matches the UI gates (`isLoggedIn` for mini-bar, `canManage` for subscription button)
- Without this, every downstream project (trawl prod, etc.) had the billing UI permanently hidden regardless of server config
- Adds 3 unit tests covering: unauthenticated (no `data.billing`), authenticated with missing config (both `false`), authenticated with both flags enabled (both `true`)

Closes #3565

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 981 tests pass (981/981, +3 new)
- [x] `npm audit --production` — pre-existing vulnerabilities only (svix/resend/uuid, unrelated to this change)
- [x] Coverage: thresholds moved to Codecov, no local threshold to break