### PR TITLE
fix(billing): rename config flag activated → enabled to match auth controller

### DIFF
--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -5,7 +5,7 @@ const config = {
     },
   },
   billing: {
-    activated: true,
+    enabled: true,
     // Quotas — downstream projects override these per plan:
     // quotas: {
     //   free:    { documents: { create: 10, export: 50 } },


### PR DESCRIPTION
## Summary

- PR #3566 exposed `billing.{enabled,meterMode}` in `GET /api/auth/config` for authenticated users
- The auth controller correctly reads `config.billing?.enabled`, but the devkit development config declared the field as `activated: true` instead of `enabled: true`
- Result: `serverConfig.billing.enabled` was always `false` downstream → Subscriptions tab hidden everywhere

## Fix

Rename `activated → enabled` in `modules/billing/config/billing.development.config.js` (single-line change). No controller changes needed — the auth controller already uses the correct destination name.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 987 passed / 0 failed across 82 suites
- [x] Auth config controller unit tests already assert `data.billing.enabled` against a mock with `{ enabled: true }` — confirmed green
- [x] No test mocked `config.billing.activated` — no test updates needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated billing configuration property naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->