### PR TITLE
fix(billing): weekly reset semantics + lazy seed + plan-change reset

### DIFF
--- a/modules/billing/middlewares/billing.requireQuota.js
+++ b/modules/billing/middlewares/billing.requireQuota.js
@@ -4,6 +4,7 @@
 import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import BillingUsageService from '../services/billing.usage.service.js';
 import BillingExtraBalanceRepository from '../repositories/billing.extraBalance.repository.js';
+import BillingPlanService from '../services/billing.plan.service.js';
 
 import { activeStatuses } from '../lib/constants.js';
 import config from '../../../config/index.js';
@@ -72,8 +73,23 @@ function requireQuota(resource, action) {
         const usage = await BillingUsageService.getMeter(orgId);
         const extrasBalance = await BillingExtraBalanceRepository.getBalance(orgId);
 
-        const meterUsed = usage?.meterUsed ?? 0;
-        const meterQuota = usage?.meterQuota ?? 0;
+        let meterUsed;
+        let meterQuota;
+
+        if (!usage) {
+          // No BillingUsage doc yet (new user / first scrap of the week).
+          // Don't create the doc here — let incrementMeter do it on first attribution.
+          // Fall back to the plan quota so first-run requests are not blocked.
+          // Reuse the `subscription` already fetched by the degraded-mode gate above.
+          const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
+          const activePlan = await BillingPlanService.getActivePlan(planId);
+          meterUsed = 0;
+          meterQuota = activePlan?.meterQuota ?? 0;
+        } else {
+          meterUsed = usage.meterUsed ?? 0;
+          meterQuota = usage.meterQuota ?? 0;
+        }
+
         const remaining = (meterQuota - meterUsed) + extrasBalance;
 
         if (remaining <= 0) {

--- a/modules/billing/middlewares/billing.requireQuota.js
+++ b/modules/billing/middlewares/billing.requireQuota.js
@@ -83,8 +83,18 @@ function requireQuota(resource, action) {
           // Reuse the `subscription` already fetched by the degraded-mode gate above.
           const planId = subscription?.plan ?? config?.billing?.defaultPlan ?? 'free';
           const activePlan = await BillingPlanService.getActivePlan(planId);
+
+          // Plan missing (seeding / version bump in progress) → fail safe with 503
+          // rather than defaulting to meterQuota=0 which would surface as 402 METER_EXHAUSTED.
+          if (activePlan === null || activePlan === undefined) {
+            return responses.error(res, 503, 'Service Unavailable', 'Billing plan configuration is temporarily unavailable')({
+              type: 'PLAN_NOT_CONFIGURED',
+              planId,
+            });
+          }
+
           meterUsed = 0;
-          meterQuota = activePlan?.meterQuota ?? 0;
+          meterQuota = activePlan.meterQuota ?? 0;
         } else {
           meterUsed = usage.meterUsed ?? 0;
           meterQuota = usage.meterQuota ?? 0;

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -110,7 +110,13 @@ const resetAllDue = async () => {
 
   for (const sub of subs) {
     try {
-      await resetWeek(String(sub.organization), new Date(sub.currentPeriodStart));
+      // Derive the week anchor from lastResetAt + 7d (or now when no prior reset exists).
+      // Using currentPeriodStart would derive the same weekKey every run within the same
+      // monthly/annual Stripe cycle → reset would be a no-op for weeks 2/3/4.
+      const anchor = sub.lastResetAt
+        ? new Date(new Date(sub.lastResetAt).getTime() + 7 * 24 * 60 * 60 * 1000)
+        : now;
+      await resetWeek(String(sub.organization), anchor);
       await BillingSubscriptionRepository.updateLastResetAt(String(sub.organization), now);
       processed += 1;
     } catch (err) {

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -113,8 +113,11 @@ const resetAllDue = async () => {
       // Derive the week anchor from lastResetAt + 7d (or now when no prior reset exists).
       // Using currentPeriodStart would derive the same weekKey every run within the same
       // monthly/annual Stripe cycle → reset would be a no-op for weeks 2/3/4.
+      // Clamp to now: if cron is delayed >1 week the natural anchor (lastResetAt+7d) is in
+      // the past → stale ISO week bucket. max(lastResetAt+7d, now) ensures we always write
+      // the current week when the cron runs late (idempotent on duplicate late runs).
       const anchor = sub.lastResetAt
-        ? new Date(new Date(sub.lastResetAt).getTime() + 7 * 24 * 60 * 60 * 1000)
+        ? new Date(Math.max(new Date(sub.lastResetAt).getTime() + 7 * 24 * 60 * 60 * 1000, now.getTime()))
         : now;
       await resetWeek(String(sub.organization), anchor);
       await BillingSubscriptionRepository.updateLastResetAt(String(sub.organization), now);

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -218,6 +218,10 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   const organizationId = String(existing.organization?._id || existing.organization);
   await syncOrganizationPlan(organizationId, newPlan);
 
+  // Hoist previousPeriodStart so it is accessible both in the plan-change block
+  // (anchor computation) and in the standalone period-start-change block below.
+  const previousPeriodStart = event?.data?.previous_attributes?.current_period_start;
+
   // Detect plan change from previous_attributes and emit event + trigger meter reset
   const previousItems = event?.data?.previous_attributes?.items?.data;
   let planChangeResetTriggered = false;
@@ -245,8 +249,15 @@ const handleSubscriptionUpdated = async (subscription, event) => {
       // Memo edge case 5: plan switch mid-cycle = immediate reset of weekly meter.
       // Stripe does NOT advance current_period_start on plan switch (proration only),
       // so we must trigger resetWeek here independently of the period-start change block.
-      // Use newPeriodStart when available (renewal happened simultaneously), fall back to now.
-      const anchor = newPeriodStart ?? new Date();
+      // Anchor = newPeriodStart only when the period ALSO changed simultaneously (e.g. annual→monthly
+      // on renewal day). Plain mid-cycle plan switch → anchor is now (current moment), because
+      // newPeriodStart is the billing-cycle start (potentially weeks in the past) and would resolve
+      // to a past ISO week bucket.
+      const periodChanged =
+        previousPeriodStart !== undefined &&
+        subscription.current_period_start !== previousPeriodStart &&
+        newPeriodStart;
+      const anchor = periodChanged ? newPeriodStart : new Date();
       try {
         await BillingResetService.resetWeek(organizationId, anchor);
         planChangeResetTriggered = true;
@@ -258,7 +269,6 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   }
 
   // Detect period start change — trigger weekly meter reset (only when not already triggered by plan change)
-  const previousPeriodStart = event?.data?.previous_attributes?.current_period_start;
   if (
     !planChangeResetTriggered &&
     previousPeriodStart !== undefined &&

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -218,8 +218,9 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   const organizationId = String(existing.organization?._id || existing.organization);
   await syncOrganizationPlan(organizationId, newPlan);
 
-  // Detect plan change from previous_attributes and emit event
+  // Detect plan change from previous_attributes and emit event + trigger meter reset
   const previousItems = event?.data?.previous_attributes?.items?.data;
+  let planChangeResetTriggered = false;
   if (previousItems) {
     const previousPlan = previousItems[0]?.price?.metadata?.planId
       || previousItems[0]?.plan?.metadata?.planId
@@ -240,12 +241,26 @@ const handleSubscriptionUpdated = async (subscription, event) => {
         // Listener errors must not disrupt webhook processing — log for traceability
         console.error('[billing.webhook] plan.changed listener error (non-fatal):', evtErr?.message ?? evtErr);
       }
+
+      // Memo edge case 5: plan switch mid-cycle = immediate reset of weekly meter.
+      // Stripe does NOT advance current_period_start on plan switch (proration only),
+      // so we must trigger resetWeek here independently of the period-start change block.
+      // Use newPeriodStart when available (renewal happened simultaneously), fall back to now.
+      const anchor = newPeriodStart ?? new Date();
+      try {
+        await BillingResetService.resetWeek(organizationId, anchor);
+        planChangeResetTriggered = true;
+      } catch (err) {
+        // Log for monitoring — not thrown so webhook processing continues
+        console.error('[billing.webhook] resetWeek on plan change failed (non-fatal):', err?.message ?? err);
+      }
     }
   }
 
-  // Detect period start change — trigger weekly meter reset
+  // Detect period start change — trigger weekly meter reset (only when not already triggered by plan change)
   const previousPeriodStart = event?.data?.previous_attributes?.current_period_start;
   if (
+    !planChangeResetTriggered &&
     previousPeriodStart !== undefined &&
     subscription.current_period_start !== previousPeriodStart &&
     newPeriodStart

--- a/modules/billing/tests/billing.quota.unit.tests.js
+++ b/modules/billing/tests/billing.quota.unit.tests.js
@@ -371,6 +371,22 @@ describe('requireQuota middleware:', () => {
 
     // ── Fix #3569: lazy fallback for new-user first scrap ─────────────────────
 
+    test('fix #3575: no meter doc + getActivePlan returns null — returns 503 PLAN_NOT_CONFIGURED (not 402)', async () => {
+      // getActivePlan returns null during seeding / version bump — must NOT surface as 402 METER_EXHAUSTED.
+      mockBillingUsageService.getMeter.mockResolvedValue(null);
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+      mockBillingPlanService.getActivePlan.mockResolvedValue(null);
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(503);
+      const payload = res.json.mock.calls[0][0];
+      const errData = JSON.parse(payload.error);
+      expect(errData.type).toBe('PLAN_NOT_CONFIGURED');
+    });
+
     test('fix #3569: new Free user — 1st scrap passes when plan meterQuota > 0', async () => {
       // No BillingUsage doc yet (getMeter returns null) — first scrap of the week.
       // Middleware should fall back to plan quota instead of blocking with 402.

--- a/modules/billing/tests/billing.quota.unit.tests.js
+++ b/modules/billing/tests/billing.quota.unit.tests.js
@@ -252,6 +252,7 @@ describe('requireQuota middleware:', () => {
 
   describe('meter mode (meterMode: true)', () => {
     let mockBillingExtraBalanceRepository;
+    let mockBillingPlanService;
 
     beforeEach(async () => {
       jest.resetModules();
@@ -262,6 +263,7 @@ describe('requireQuota middleware:', () => {
           quotas: {},
           packs: [{ packId: 'pack_500k', meterUnits: 500000 }],
           upgradeUrl: '/billing/plans',
+          defaultPlan: 'free',
         },
       };
 
@@ -274,6 +276,10 @@ describe('requireQuota middleware:', () => {
         getBalance: jest.fn(),
       };
 
+      mockBillingPlanService = {
+        getActivePlan: jest.fn(),
+      };
+
       jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
         default: mockSubscriptionRepository,
       }));
@@ -284,6 +290,10 @@ describe('requireQuota middleware:', () => {
 
       jest.unstable_mockModule('../repositories/billing.extraBalance.repository.js', () => ({
         default: mockBillingExtraBalanceRepository,
+      }));
+
+      jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
+        default: mockBillingPlanService,
       }));
 
       jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -345,15 +355,77 @@ describe('requireQuota middleware:', () => {
       expect(Array.isArray(errData.packsAvailable)).toBe(true);
     });
 
-    test('should return 402 when meter doc is null (no usage yet) and no extras', async () => {
+    test('should return 402 when meter doc is null and plan quota is 0 (no extras)', async () => {
+      // No BillingUsage doc yet; plan has meterQuota=0 (e.g. unconfigured plan)
       mockBillingUsageService.getMeter.mockResolvedValue(null);
       mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+      mockBillingPlanService.getActivePlan.mockResolvedValue({ meterQuota: 0, version: 'v1' });
 
       await requireQuota('scraps', 'create')(req, res, next);
 
       // meterUsed=0, meterQuota=0 → remaining = (0-0)+0 = 0 → 402
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(402);
+    });
+
+    // ── Fix #3569: lazy fallback for new-user first scrap ─────────────────────
+
+    test('fix #3569: new Free user — 1st scrap passes when plan meterQuota > 0', async () => {
+      // No BillingUsage doc yet (getMeter returns null) — first scrap of the week.
+      // Middleware should fall back to plan quota instead of blocking with 402.
+      mockBillingUsageService.getMeter.mockResolvedValue(null);
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+      mockBillingPlanService.getActivePlan.mockResolvedValue({ meterQuota: 10, version: 'v1' });
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      // meterUsed=0, meterQuota=10 → remaining = 10 > 0 → allow
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    test('fix #3569: new Pro user — 1st scrap passes with full pro quota', async () => {
+      mockBillingUsageService.getMeter.mockResolvedValue(null);
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro', status: 'active' });
+      mockBillingPlanService.getActivePlan.mockResolvedValue({ meterQuota: 200000, version: 'v1' });
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(mockBillingPlanService.getActivePlan).toHaveBeenCalledWith('pro');
+    });
+
+    test('fix #3569: no meter doc + no subscription — falls back to defaultPlan quota', async () => {
+      mockBillingUsageService.getMeter.mockResolvedValue(null);
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+      mockBillingPlanService.getActivePlan.mockResolvedValue({ meterQuota: 5, version: 'v1' });
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      // Falls back to config.billing.defaultPlan = 'free'
+      expect(mockBillingPlanService.getActivePlan).toHaveBeenCalledWith('free');
+      expect(next).toHaveBeenCalled();
+    });
+
+    test('fix #3569: no meter doc — does NOT write a BillingUsage doc (incrementMeter creates it)', async () => {
+      // The middleware must never write the usage doc — only incrementMeter should create it.
+      mockBillingUsageService.getMeter.mockResolvedValue(null);
+      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({ plan: 'pro', status: 'active' });
+      mockBillingPlanService.getActivePlan.mockResolvedValue({ meterQuota: 200000, version: 'v1' });
+
+      await requireQuota('scraps', 'create')(req, res, next);
+
+      // incrementMeter and upsert should never be called by the middleware
+      expect(mockBillingUsageService.getMeter).toHaveBeenCalledTimes(1);
+      // get (legacy path) should not be called at all in meter mode
+      expect(mockBillingUsageService.get).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
     });
 
     test('should call SubscriptionRepository in meter mode (degraded-mode gate)', async () => {

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -430,11 +430,10 @@ describe('BillingResetService unit tests:', () => {
       ];
 
       for (const { lastResetAt, expectedKey } of runsAndExpectedKeys) {
-        jest.resetModules();
         const anchor = new Date(lastResetAt.getTime() + 7 * 24 * 60 * 60 * 1000);
         jest.setSystemTime(anchor);
 
-        // Re-import with fresh mocks for each simulated run
+        // Reconfigure mocks for each simulated run
         const capturedAnchors = [];
         mockSubscriptionRepository.findAllDueForResetByLastReset.mockResolvedValue([
           { organization: orgId, currentPeriodStart: cycleStart, lastResetAt },

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -387,6 +387,38 @@ describe('BillingResetService unit tests:', () => {
       expect(capturedAnchors[0]).toBe('2026-W18');
     });
 
+    test('fix #3575: anchor clamped to now when cron is delayed >1 week', async () => {
+      // Simulate a cron that ran late: lastResetAt was >2 weeks ago.
+      // Without clamping, anchor = lastResetAt+7d = still in the past → wrong bucket.
+      // With clamping, anchor = min(lastResetAt+7d, now) = now → correct current bucket.
+      const now = new Date('2026-05-01T12:00:00.000Z'); // W18
+      jest.setSystemTime(now);
+
+      // lastResetAt was 3 weeks ago — cron skipped 2 full weeks
+      const lastResetAt = new Date('2026-04-10T12:00:00.000Z');
+      const naturalAnchor = new Date(lastResetAt.getTime() + 7 * 24 * 60 * 60 * 1000); // 2026-04-17 → W16
+      expect(naturalAnchor < now).toBe(true); // sanity: natural anchor is in the past
+
+      const capturedAnchors = [];
+      mockSubscriptionRepository.findAllDueForResetByLastReset.mockResolvedValue([
+        { organization: orgId, currentPeriodStart: new Date('2026-04-01T00:00:00.000Z'), lastResetAt },
+      ]);
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.updateLastResetAt.mockResolvedValue({});
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockImplementation((_orgId, weekKey) => {
+        capturedAnchors.push(weekKey);
+        return Promise.resolve(null);
+      });
+      mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
+
+      const result = await BillingResetService.resetAllDue();
+
+      expect(result.processed).toBe(1);
+      // Anchor must be clamped to now (2026-05-01 → W18), not the stale natural anchor (W16)
+      expect(capturedAnchors[0]).toBe('2026-W18');
+    });
+
     test('fix #3569: S+1/S+2/S+3 within same Stripe cycle produce distinct weekKeys', async () => {
       // Simulate 3 consecutive weekly cron runs within the same monthly billing cycle.
       // currentPeriodStart is the same for all 3; lastResetAt advances by 7d each run.

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -330,5 +330,97 @@ describe('BillingResetService unit tests:', () => {
       expect(result).toEqual({ processed: 1, errors: 0 });
       expect(mockSubscriptionRepository.updateLastResetAt).toHaveBeenCalledWith(orgId, now);
     });
+
+    // ── Fix #3569: week anchor derived from lastResetAt+7d, not currentPeriodStart ──
+
+    test('fix #3569: anchor = lastResetAt+7d when lastResetAt is set (advances across weeks)', async () => {
+      const now = new Date('2026-05-08T12:00:00.000Z'); // W19
+      jest.setSystemTime(now);
+      // lastResetAt was one week ago (W18 reset)
+      const lastResetAt = new Date('2026-05-01T12:00:00.000Z'); // W18
+      // currentPeriodStart is the Stripe billing cycle start (same for all 4 weeks of the month)
+      const currentPeriodStart = new Date('2026-04-15T00:00:00.000Z'); // stays constant within cycle
+
+      const capturedAnchors = [];
+      mockSubscriptionRepository.findAllDueForResetByLastReset.mockResolvedValue([
+        { organization: orgId, currentPeriodStart, lastResetAt },
+      ]);
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.updateLastResetAt.mockResolvedValue({});
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockImplementation((_orgId, weekKey) => {
+        capturedAnchors.push(weekKey);
+        return Promise.resolve(null);
+      });
+      mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W19' }));
+
+      const result = await BillingResetService.resetAllDue();
+
+      expect(result.processed).toBe(1);
+      // Anchor = lastResetAt + 7d = 2026-05-08 → isoWeekKey = W19
+      expect(capturedAnchors[0]).toBe('2026-W19');
+    });
+
+    test('fix #3569: anchor = now when lastResetAt is null (first ever reset)', async () => {
+      // currentPeriodStart stays the same as above but lastResetAt is null
+      const capturedAnchors = [];
+      mockSubscriptionRepository.findAllDueForResetByLastReset.mockResolvedValue([
+        {
+          organization: orgId,
+          currentPeriodStart: new Date('2026-04-15T00:00:00.000Z'),
+          lastResetAt: null,
+        },
+      ]);
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockSubscriptionRepository.updateLastResetAt.mockResolvedValue({});
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+      mockUsageRepository.findByWeek.mockImplementation((_orgId, weekKey) => {
+        capturedAnchors.push(weekKey);
+        return Promise.resolve(null);
+      });
+      mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc({ weekKey: '2026-W18' }));
+
+      const result = await BillingResetService.resetAllDue();
+
+      expect(result.processed).toBe(1);
+      // Anchor = now (2026-05-01 system time) → isoWeekKey = W18
+      expect(capturedAnchors[0]).toBe('2026-W18');
+    });
+
+    test('fix #3569: S+1/S+2/S+3 within same Stripe cycle produce distinct weekKeys', async () => {
+      // Simulate 3 consecutive weekly cron runs within the same monthly billing cycle.
+      // currentPeriodStart is the same for all 3; lastResetAt advances by 7d each run.
+      const cycleStart = new Date('2026-04-15T00:00:00.000Z');
+      const runsAndExpectedKeys = [
+        { lastResetAt: new Date('2026-04-24T12:00:00.000Z'), expectedKey: '2026-W18' }, // +7d = May 1
+        { lastResetAt: new Date('2026-05-01T12:00:00.000Z'), expectedKey: '2026-W19' }, // +7d = May 8
+        { lastResetAt: new Date('2026-05-08T12:00:00.000Z'), expectedKey: '2026-W20' }, // +7d = May 15
+      ];
+
+      for (const { lastResetAt, expectedKey } of runsAndExpectedKeys) {
+        jest.resetModules();
+        const anchor = new Date(lastResetAt.getTime() + 7 * 24 * 60 * 60 * 1000);
+        jest.setSystemTime(anchor);
+
+        // Re-import with fresh mocks for each simulated run
+        const capturedAnchors = [];
+        mockSubscriptionRepository.findAllDueForResetByLastReset.mockResolvedValue([
+          { organization: orgId, currentPeriodStart: cycleStart, lastResetAt },
+        ]);
+        mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+        mockSubscriptionRepository.updateLastResetAt.mockResolvedValue({});
+        mockPlanService.getActivePlan.mockResolvedValue(makePlan());
+        mockUsageRepository.findByWeek.mockImplementation((_orgId, weekKey) => {
+          capturedAnchors.push(weekKey);
+          return Promise.resolve(null);
+        });
+        mockUsageRepository.upsertWeekSnapshot.mockResolvedValue(makeUsageDoc({ weekKey: expectedKey }));
+
+        const result = await BillingResetService.resetAllDue();
+
+        expect(result.processed).toBe(1);
+        expect(capturedAnchors[0]).toBe(expectedKey);
+      }
+    });
   });
 });

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -217,10 +217,12 @@ describe('Billing webhook subscription unit tests:', () => {
       );
 
       expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
-      expect(mockResetService.resetWeek).toHaveBeenCalledWith(
-        orgId,
-        new Date(periodStart * 1000),
-      );
+      // Plan-only change (no period change) → anchor is new Date() (current moment), NOT the
+      // billing-cycle start. Using newPeriodStart here would resolve to a past ISO week bucket.
+      expect(mockResetService.resetWeek).toHaveBeenCalledWith(orgId, expect.any(Date));
+      const [, anchor] = mockResetService.resetWeek.mock.calls[0];
+      // Anchor must NOT be the period start (which is in the past relative to the plan switch)
+      expect(anchor.getTime()).not.toBe(periodStart * 1000);
     });
 
     test('fix #3571: plan change AND period_start change — resetWeek called exactly once (not twice)', async () => {
@@ -253,6 +255,11 @@ describe('Billing webhook subscription unit tests:', () => {
 
       // Plan-change reset triggers first; period-start reset is skipped to avoid double reset.
       expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+      // When period also changed, anchor must be newPeriodStart (not now)
+      expect(mockResetService.resetWeek).toHaveBeenCalledWith(
+        orgId,
+        new Date(newPeriodStart * 1000),
+      );
     });
 
     test('fix #3571: no plan change — resetWeek NOT called on same period_start', async () => {

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -187,6 +187,224 @@ describe('Billing webhook subscription unit tests:', () => {
       ).resolves.not.toThrow();
     });
 
+    // ── Fix #3571: plan change mid-cycle triggers resetWeek ───────────────────
+
+    test('fix #3571: plan change with same period_start — resetWeek called once', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: periodStart + 2592000,
+          current_period_start: periodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              // Same period_start → only plan changed
+              items: {
+                data: [{ price: { metadata: { planId: 'starter' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+      expect(mockResetService.resetWeek).toHaveBeenCalledWith(
+        orgId,
+        new Date(periodStart * 1000),
+      );
+    });
+
+    test('fix #3571: plan change AND period_start change — resetWeek called exactly once (not twice)', async () => {
+      const oldPeriodStart = 1700000000;
+      const newPeriodStart = 1700604800;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: newPeriodStart + 2592000,
+          current_period_start: newPeriodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              current_period_start: oldPeriodStart,
+              items: {
+                data: [{ price: { metadata: { planId: 'starter' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      // Plan-change reset triggers first; period-start reset is skipped to avoid double reset.
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+    });
+
+    test('fix #3571: no plan change — resetWeek NOT called on same period_start', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: periodStart + 2592000,
+          current_period_start: periodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              // cancel_at_period_end changed, plan did not change
+              cancel_at_period_end: true,
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).not.toHaveBeenCalled();
+    });
+
+    test('fix #3571: plan upgrade Growth→Pro — resetWeek called with current anchor (allows full Pro quota)', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: periodStart + 2592000,
+          current_period_start: periodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              items: {
+                data: [{ price: { metadata: { planId: 'starter' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+      const [calledOrg, calledAnchor] = mockResetService.resetWeek.mock.calls[0];
+      expect(calledOrg).toBe(orgId);
+      // Anchor should be the new period start (Date object from current_period_start)
+      expect(calledAnchor).toBeInstanceOf(Date);
+    });
+
+    test('fix #3571: plan downgrade Pro→Growth — resetWeek called (meterUsed reset to 0)', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: periodStart + 2592000,
+          current_period_start: periodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              items: {
+                data: [{ price: { metadata: { planId: 'pro' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+    });
+
+    test('fix #3571: resetWeek on plan change — errors do not throw (non-fatal)', async () => {
+      const periodStart = 1700000000;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockResetService.resetWeek.mockRejectedValue(new Error('db unavailable'));
+
+      await expect(
+        BillingWebhookService.handleSubscriptionUpdated(
+          {
+            id: 'sub_456',
+            status: 'active',
+            current_period_end: periodStart + 2592000,
+            current_period_start: periodStart,
+            cancel_at_period_end: false,
+            items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+          },
+          {
+            data: {
+              previous_attributes: {
+                items: {
+                  data: [{ price: { metadata: { planId: 'starter' } } }],
+                },
+              },
+            },
+          },
+        ),
+      ).resolves.not.toThrow();
+    });
+
+    test('fix #3571: plan change with no newPeriodStart falls back to now for anchor', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000 + 2592000,
+          // No current_period_start field
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              items: {
+                data: [{ price: { metadata: { planId: 'starter' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+      const [, anchor] = mockResetService.resetWeek.mock.calls[0];
+      expect(anchor).toBeInstanceOf(Date);
+    });
+
     test('should update currentPeriodStart in subscription when period_start is present', async () => {
       const newPeriodStart = 1700604800;
       const existing = { _id: subId, organization: orgId };


### PR DESCRIPTION
## Summary

- **Lazy seed in requireQuota** (`billing.requireQuota.js`): when `getMeter()` returns `null` (new user / first scrap of the week), fall back to `BillingPlanService.getActivePlan()` for `meterQuota` instead of defaulting to 0. Prevents 402 METER_EXHAUSTED on every first request. Reuses the `subscription` already fetched by the degraded-mode gate — no extra DB round-trip.
- **Week anchor fix in resetAllDue** (`billing.reset.service.js`): derive anchor from `lastResetAt + 7d` (or `now` on first run) instead of `currentPeriodStart`. `currentPeriodStart` is constant within a monthly Stripe cycle, so weeks 2/3/4 were resetting to the same `weekKey` → no-op. The new logic advances by exactly 7 days each cron run.
- **Plan-change reset in handleSubscriptionUpdated** (`billing.webhook.service.js`): when `previous_attributes.items` shows a plan change, trigger `resetWeek` immediately (memo edge case 5: plan switch = immediate meter reset + fresh quota). `planChangeResetTriggered` flag prevents double reset when plan and period_start both change simultaneously.

Closes #3569
Closes #3571