### PR TITLE
feat(billing): per-step idempotency keys + automatic_tax config flag

### DIFF
--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -1,6 +1,6 @@
 # Billing Module
 
-Stripe-based billing with per-plan quota management.
+Stripe-based billing with per-plan quota management and meter-based compute pricing.
 
 ## Quota System
 
@@ -61,3 +61,47 @@ billingEvents.on('plan.changed', ({ organizationId, previousPlan, newPlan, isDow
   }
 });
 ```
+
+## Meter Attribution — `BillingMeterService.attribute`
+
+Charges compute units for a completed history run. Idempotent per `(history._id, stepKey)` pair.
+
+```js
+import BillingMeterService from '../billing/services/billing.meter.service.js';
+
+// Initial charge — default stepKey='initial'
+await BillingMeterService.attribute(history, organizationId);
+
+// Delta charge after setDigest (pass ONLY the digest cost delta, not cumulative)
+await BillingMeterService.attribute(historyWithDigestDelta, organizationId, { stepKey: 'digest' });
+
+// Delta charge per fix attempt
+await BillingMeterService.attribute(historyWithFixDelta, organizationId, { stepKey: 'fix:1' });
+await BillingMeterService.attribute(historyWithFixDelta, organizationId, { stepKey: 'fix:2' });
+```
+
+**Per-step semantics**: each `stepKey` is independently idempotent. Replaying the same
+`(history._id, stepKey)` is a safe no-op. Passing a new `stepKey` charges the delta once.
+
+**Cost composition rule**: always pass ONLY the incremental cost delta in `history.costs` for each
+step. Passing the cumulative total will double-charge costs already attributed in prior steps.
+
+**Backward compat**: callers that only ever attribute once (no multi-step) continue to work
+unchanged — the default `stepKey='initial'` makes the idempotency key `${history._id}:initial`.
+
+## Stripe — `automatic_tax` flag
+
+```js
+// config/defaults/development.config.js (downstream project override)
+stripe: {
+  automaticTax: true, // set true once Stripe Tax product is enabled in Dashboard
+}
+```
+
+Default is `false` (devkit default). When `false`, checkout sessions are created without
+`automatic_tax` or `customer_update` fields, which is safe for merchants not using Stripe Tax
+(e.g. auto-entrepreneur FR, franchise TVA art. 293 B).
+
+**V1 note**: do NOT set `automaticTax: true` in production until the Stripe Tax product is
+activated in the Stripe Dashboard. In LIVE mode without Tax setup Stripe returns:
+`invalid_request_error — The 'automatic_tax' parameter requires the Stripe Tax product`.

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -87,6 +87,16 @@ const config = {
   stripe: {
     secretKey: process.env.DEVKIT_NODE_stripe_secretKey ?? '',
     webhookSecret: process.env.DEVKIT_NODE_stripe_webhookSecret ?? '',
+    /**
+     * Feature flag — default OFF.
+     * Set to true in downstream project config once Stripe Tax product is enabled
+     * in the Stripe Dashboard. In LIVE mode, Stripe rejects automatic_tax: enabled
+     * if the Tax product is not activated → checkout sessions will fail.
+     * See: https://stripe.com/docs/tax/set-up
+     *
+     * V1 intent: disabled (auto-entrepreneur FR, franchise TVA art. 293 B).
+     */
+    automaticTax: false,
     prices: {
       starter: {
         monthly: process.env.DEVKIT_NODE_stripe_prices_starter_monthly ?? '',

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -106,15 +106,29 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  *              to BillingExtraService.debit (best-effort — does not throw when extras
  *              are exhausted; extrasConsumed=0 is returned instead).
  *
- *              Idempotent on history._id — a second call with the same history object
- *              is a no-op (replay protection via consumedHistoryIds).
+ *              Per-step idempotency: the idempotency key is `${history._id}:${stepKey}`.
+ *              This allows multiple attributions on the same history at different processing
+ *              steps (e.g. 'initial', 'digest', 'fix:1') without silently blocking the
+ *              cost delta for subsequent steps.
+ *
+ *              Each stepKey call is independently idempotent — replaying the same
+ *              `(history._id, stepKey)` pair is a no-op (replay protection via consumedHistoryIds).
+ *
+ *              IMPORTANT: each call must pass ONLY the cost delta for that step (not the
+ *              cumulative total), otherwise earlier steps will be double-charged.
  *
  * @param {Object} history - History-like object with _id, costs, planId, planVersion fields.
  * @param {string} organizationId - The organization ObjectId (string).
+ * @param {Object} [options={}] - Optional per-step configuration.
+ * @param {string} [options.stepKey='initial'] - Logical step name scoping this attribution.
+ *   Use 'initial' for the first (and often only) charge per history.
+ *   Use a distinct value (e.g. 'digest', 'fix:1', 'fix:2') for subsequent attributions on
+ *   the same history after cost-impacting mutations (setDigest, setFixCost).
+ *   Downstream callers must pass ONLY the incremental cost delta in history.costs for each step.
  * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number}>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const attribute = async (history, organizationId) => {
+const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) => {
   if (!config?.billing?.meterMode) {
     return { applied: false, meterUsed: 0, extrasConsumed: 0 };
   }
@@ -143,7 +157,7 @@ const attribute = async (history, organizationId) => {
     );
   }
 
-  const idempotencyKey = history._id?.toString?.() ?? String(history._id);
+  const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${stepKey}`;
 
   const result = await BillingUsageService.incrementMeter(
     organizationId,

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -125,10 +125,17 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  *   Use a distinct value (e.g. 'digest', 'fix:1', 'fix:2') for subsequent attributions on
  *   the same history after cost-impacting mutations (setDigest, setFixCost).
  *   Downstream callers must pass ONLY the incremental cost delta in history.costs for each step.
- * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number}>}
+ * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number, reason?: string}>}
+ *   `reason` is present only when `applied` is true but extras were exhausted:
+ *   `{ applied: true, meterUsed, extrasConsumed: 0, reason: 'extras_exhausted' }`.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) => {
+  // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string
+  // to prevent arbitrary data from polluting consumedHistoryIds
+  const validatedStepKey = (typeof stepKey === 'string' && /^[a-zA-Z0-9:_-]{1,64}$/.test(stepKey))
+    ? stepKey
+    : 'initial';
   if (!config?.billing?.meterMode) {
     return { applied: false, meterUsed: 0, extrasConsumed: 0 };
   }
@@ -157,7 +164,7 @@ const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) 
     );
   }
 
-  const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${stepKey}`;
+  const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${validatedStepKey}`;
 
   const result = await BillingUsageService.incrementMeter(
     organizationId,

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -97,20 +97,23 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
     if (latest?.stripeCustomerId) subscription = latest;
   }
 
-  const session = await stripe.checkout.sessions.create(
-    {
-      customer: subscription.stripeCustomerId,
-      mode: 'subscription',
-      line_items: [{ price: priceId, quantity: 1 }],
-      success_url: successUrl,
-      cancel_url: cancelUrl,
-      automatic_tax: { enabled: true },
-      customer_update: { address: 'auto', name: 'auto' },
-      metadata: {
-        organizationId: String(organization._id),
-        plan: matchedPlan.planId,
-      },
+  const checkoutParams = {
+    customer: subscription.stripeCustomerId,
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      organizationId: String(organization._id),
+      plan: matchedPlan.planId,
     },
+  };
+  if (config?.stripe?.automaticTax) {
+    checkoutParams.automatic_tax = { enabled: true };
+    checkoutParams.customer_update = { address: 'auto', name: 'auto' };
+  }
+  const session = await stripe.checkout.sessions.create(
+    checkoutParams,
     { idempotencyKey: `sub_checkout_${String(organization._id)}_${priceId}` },
   );
 
@@ -214,30 +217,33 @@ const createExtrasCheckout = async (organization, packId, successUrl, cancelUrl)
   // Use a timestamped idempotency key (debounce double-click within ~1s granularity)
   const idempotencyKey = `extras_checkout_${String(organization._id)}_${packId}_${Date.now()}`;
 
-  const session = await stripe.checkout.sessions.create(
-    {
-      customer: subscription.stripeCustomerId,
-      mode: 'payment',
-      line_items: [{ price: priceId, quantity: 1 }],
-      success_url: successUrl,
-      cancel_url: cancelUrl,
-      automatic_tax: { enabled: true },
-      customer_update: { address: 'auto', name: 'auto' },
+  const extrasCheckoutParams = {
+    customer: subscription.stripeCustomerId,
+    mode: 'payment',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      organizationId: String(organization._id),
+      packId,
+      kind: 'extras',
+      stripeSessionId: '__pending__',
+    },
+    payment_intent_data: {
       metadata: {
         organizationId: String(organization._id),
         packId,
         kind: 'extras',
         stripeSessionId: '__pending__',
       },
-      payment_intent_data: {
-        metadata: {
-          organizationId: String(organization._id),
-          packId,
-          kind: 'extras',
-          stripeSessionId: '__pending__',
-        },
-      },
     },
+  };
+  if (config?.stripe?.automaticTax) {
+    extrasCheckoutParams.automatic_tax = { enabled: true };
+    extrasCheckoutParams.customer_update = { address: 'auto', name: 'auto' };
+  }
+  const session = await stripe.checkout.sessions.create(
+    extrasCheckoutParams,
     { idempotencyKey },
   );
 

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -108,7 +108,7 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
       plan: matchedPlan.planId,
     },
   };
-  if (config?.stripe?.automaticTax) {
+  if (config?.stripe?.automaticTax === true) {
     checkoutParams.automatic_tax = { enabled: true };
     checkoutParams.customer_update = { address: 'auto', name: 'auto' };
   }
@@ -238,7 +238,7 @@ const createExtrasCheckout = async (organization, packId, successUrl, cancelUrl)
       },
     },
   };
-  if (config?.stripe?.automaticTax) {
+  if (config?.stripe?.automaticTax === true) {
     extrasCheckoutParams.automatic_tax = { enabled: true };
     extrasCheckoutParams.customer_update = { address: 'auto', name: 'auto' };
   }

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -280,6 +280,25 @@ describe('Billing service unit tests:', () => {
       expect(callArgs.automatic_tax).toEqual({ enabled: true });
       expect(callArgs.customer_update).toEqual({ address: 'auto', name: 'auto' });
     });
+
+    test('should NOT include automatic_tax when config.stripe.automaticTax is truthy but not strict true (e.g. 1)', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_truthy_tax', automaticTax: 1 } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_truthy_tax',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
+
+      const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.automatic_tax).toBeUndefined();
+      expect(callArgs.customer_update).toBeUndefined();
+    });
   });
 
   describe('createPortalSession', () => {

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -211,7 +211,7 @@ describe('Billing service unit tests:', () => {
       });
     });
 
-    test('should use existing customer when subscription has stripeCustomerId', async () => {
+    test('should use existing customer when subscription has stripeCustomerId — automaticTax off by default', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: { stripe: { secretKey: 'sk_test_789' } },
       }));
@@ -234,8 +234,6 @@ describe('Billing service unit tests:', () => {
           line_items: [{ price: 'price_starter_m', quantity: 1 }],
           success_url: 'http://ok',
           cancel_url: 'http://cancel',
-          automatic_tax: { enabled: true },
-          customer_update: { address: 'auto', name: 'auto' },
           metadata: {
             organizationId: orgId,
             plan: 'starter',
@@ -245,13 +243,13 @@ describe('Billing service unit tests:', () => {
       );
     });
 
-    test('should include customer_update in checkout session params', async () => {
+    test('should NOT include automatic_tax when config.stripe.automaticTax is false', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { stripe: { secretKey: 'sk_test_cu' } },
+        default: { stripe: { secretKey: 'sk_test_no_tax', automaticTax: false } },
       }));
 
       mockSubscriptionRepository.findByOrganization.mockResolvedValue({
-        stripeCustomerId: 'cus_cu_test',
+        stripeCustomerId: 'cus_no_tax',
       });
 
       const mod = await import('../services/billing.service.js');
@@ -260,6 +258,26 @@ describe('Billing service unit tests:', () => {
       await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
 
       const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.automatic_tax).toBeUndefined();
+      expect(callArgs.customer_update).toBeUndefined();
+    });
+
+    test('should include automatic_tax and customer_update when config.stripe.automaticTax is true', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_with_tax', automaticTax: true } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_with_tax',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
+
+      const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.automatic_tax).toEqual({ enabled: true });
       expect(callArgs.customer_update).toEqual({ address: 'auto', name: 'auto' });
     });
   });
@@ -354,6 +372,64 @@ describe('Billing service unit tests:', () => {
       BillingService = mod.default;
 
       await expect(BillingService.createPortalSession(mockOrganization, 'not-a-url')).rejects.toThrow('Invalid return URL');
+    });
+  });
+
+  describe('createExtrasCheckout — automaticTax flag', () => {
+    test('should NOT include automatic_tax when config.stripe.automaticTax is false', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: {
+          stripe: {
+            secretKey: 'sk_test_ext_no_tax',
+            automaticTax: false,
+            prices: { packs: { pack_500k: 'price_pack500' } },
+          },
+          billing: {
+            packs: [{ packId: 'pack_500k', meterUnits: 500000 }],
+          },
+        },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_ext_no_tax',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await BillingService.createExtrasCheckout(mockOrganization, 'pack_500k', 'http://ok', 'http://cancel');
+
+      const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.automatic_tax).toBeUndefined();
+      expect(callArgs.customer_update).toBeUndefined();
+    });
+
+    test('should include automatic_tax and customer_update when config.stripe.automaticTax is true', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: {
+          stripe: {
+            secretKey: 'sk_test_ext_with_tax',
+            automaticTax: true,
+            prices: { packs: { pack_500k: 'price_pack500' } },
+          },
+          billing: {
+            packs: [{ packId: 'pack_500k', meterUnits: 500000 }],
+          },
+        },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_ext_with_tax',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await BillingService.createExtrasCheckout(mockOrganization, 'pack_500k', 'http://ok', 'http://cancel');
+
+      const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+      expect(callArgs.automatic_tax).toEqual({ enabled: true });
+      expect(callArgs.customer_update).toEqual({ address: 'auto', name: 'auto' });
     });
   });
 

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -356,6 +356,29 @@ describe('BillingMeterService unit tests:', () => {
       );
     });
 
+    test('invalid stepKey (special chars) falls back to "initial"', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 100,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439099',
+        costs: { scrap: 0.1 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      await BillingMeterService.attribute(history, orgId, { stepKey: 'bad key! @#$' });
+
+      // Invalid stepKey falls back to 'initial'
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439099:initial',
+      );
+    });
+
     test('replay of {stepKey:"digest"} is blocked (idempotent)', async () => {
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
       // First digest call: applied

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -197,7 +197,7 @@ describe('BillingMeterService unit tests:', () => {
         orgId,
         10000,
         { scrap: 10000 },
-        '507f1f77bcf86cd799439033',
+        '507f1f77bcf86cd799439033:initial',
       );
       expect(warnSpy).toHaveBeenCalledWith(
         '[billing.meter] units capped: requested 20000, cap 10000, applied 10000',
@@ -227,7 +227,7 @@ describe('BillingMeterService unit tests:', () => {
         orgId,
         5000,
         { scrap: 5000 },
-        '507f1f77bcf86cd799439034',
+        '507f1f77bcf86cd799439034:initial',
       );
       expect(warnSpy).not.toHaveBeenCalled();
     });
@@ -255,9 +255,139 @@ describe('BillingMeterService unit tests:', () => {
         orgId,
         20000,
         { scrap: 20000 },
-        '507f1f77bcf86cd799439035',
+        '507f1f77bcf86cd799439035:initial',
       );
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attribute — per-step idempotency keys', () => {
+    test('same history attributed twice with default stepKey: 2nd is no-op (regression)', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      // First call: applied
+      mockBillingUsageService.incrementMeter.mockResolvedValueOnce({
+        applied: true,
+        meterUsed: 1000,
+        extrasConsumed: 0,
+      });
+      // Second call: no-op (replay)
+      mockBillingUsageService.incrementMeter.mockResolvedValueOnce({
+        applied: false,
+        meterUsed: 1000,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439040',
+        costs: { scrap: 1 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const first = await BillingMeterService.attribute(history, orgId);
+      const second = await BillingMeterService.attribute(history, orgId);
+
+      expect(first.applied).toBe(true);
+      expect(second.applied).toBe(false);
+
+      // Both calls must use the same idempotency key (stepKey defaults to 'initial')
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        1, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439040:initial',
+      );
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        2, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439040:initial',
+      );
+    });
+
+    test('same history attributed with {stepKey:"initial"} then {stepKey:"digest"}: both charged', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 500,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439041',
+        costs: { scrap: 0.5 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const initial = await BillingMeterService.attribute(history, orgId, { stepKey: 'initial' });
+      const digest = await BillingMeterService.attribute(history, orgId, { stepKey: 'digest' });
+
+      expect(initial.applied).toBe(true);
+      expect(digest.applied).toBe(true);
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        1, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439041:initial',
+      );
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        2, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439041:digest',
+      );
+    });
+
+    test('same history attributed with {stepKey:"fix:1"} then {stepKey:"fix:2"}: both charged', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 200,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439042',
+        costs: { scrap: 0.2 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const fix1 = await BillingMeterService.attribute(history, orgId, { stepKey: 'fix:1' });
+      const fix2 = await BillingMeterService.attribute(history, orgId, { stepKey: 'fix:2' });
+
+      expect(fix1.applied).toBe(true);
+      expect(fix2.applied).toBe(true);
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        1, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439042:fix:1',
+      );
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        2, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439042:fix:2',
+      );
+    });
+
+    test('replay of {stepKey:"digest"} is blocked (idempotent)', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      // First digest call: applied
+      mockBillingUsageService.incrementMeter.mockResolvedValueOnce({
+        applied: true,
+        meterUsed: 300,
+        extrasConsumed: 0,
+      });
+      // Replay: no-op
+      mockBillingUsageService.incrementMeter.mockResolvedValueOnce({
+        applied: false,
+        meterUsed: 300,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439043',
+        costs: { scrap: 0.3 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const first = await BillingMeterService.attribute(history, orgId, { stepKey: 'digest' });
+      const replay = await BillingMeterService.attribute(history, orgId, { stepKey: 'digest' });
+
+      expect(first.applied).toBe(true);
+      expect(replay.applied).toBe(false);
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledTimes(2);
+      // Both calls use the same digest key
+      for (const call of mockBillingUsageService.incrementMeter.mock.calls) {
+        expect(call[3]).toBe('507f1f77bcf86cd799439043:digest');
+      }
     });
   });
 

--- a/modules/billing/tests/billing.service.extras.unit.tests.js
+++ b/modules/billing/tests/billing.service.extras.unit.tests.js
@@ -155,7 +155,6 @@ describe('BillingService.createExtrasCheckout unit tests:', () => {
         customer: 'cus_existing',
         mode: 'payment',
         line_items: [{ price: 'price_pack500k', quantity: 1 }],
-        automatic_tax: { enabled: true },
         metadata: expect.objectContaining({
           organizationId: orgId,
           packId: 'pack_500k',
@@ -235,7 +234,7 @@ describe('BillingService.createExtrasCheckout unit tests:', () => {
     expect(mockStripeInstance.checkout.sessions.create).toHaveBeenCalled();
   });
 
-  test('should include customer_update in extras checkout session params', async () => {
+  test('should NOT include customer_update when automaticTax flag is off (default)', async () => {
     jest.unstable_mockModule('../../../config/index.js', () => ({
       default: makeConfig(),
     }));
@@ -250,7 +249,33 @@ describe('BillingService.createExtrasCheckout unit tests:', () => {
     );
 
     const [params] = mockStripeInstance.checkout.sessions.create.mock.calls[0];
+    expect(params.customer_update).toBeUndefined();
+    expect(params.automatic_tax).toBeUndefined();
+  });
+
+  test('should include customer_update and automatic_tax when automaticTax flag is on', async () => {
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        ...makeConfig(),
+        stripe: {
+          ...makeConfig().stripe,
+          automaticTax: true,
+        },
+      },
+    }));
+
+    const mod = await import('../services/billing.service.js');
+    BillingService = mod.default;
+
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue({ stripeCustomerId: 'cus_existing' });
+
+    await BillingService.createExtrasCheckout(
+      mockOrganization, 'pack_500k', 'http://success', 'http://cancel',
+    );
+
+    const [params] = mockStripeInstance.checkout.sessions.create.mock.calls[0];
     expect(params.customer_update).toEqual({ address: 'auto', name: 'auto' });
+    expect(params.automatic_tax).toEqual({ enabled: true });
   });
 
   test('should handle 11000 duplicate key on subscription create gracefully', async () => {


### PR DESCRIPTION
## Summary

- **#3570 — per-step idempotency keys**: `BillingMeterService.attribute` now accepts an optional `{ stepKey = 'initial' }` third argument. The idempotency key is `${history._id}:${stepKey}` instead of bare `history._id`. This unblocks `setDigest` / `setFixCost` delta charges which were silently no-oped by the `consumedHistoryIds $ne` guard.
- **#3572 — automatic_tax config flag**: `automatic_tax: { enabled: true }` and `customer_update` are now conditionally injected into checkout sessions only when `config.stripe.automaticTax === true`. Default is `false` at devkit level (V1 intent: auto-entrepreneur FR, franchise TVA art. 293 B). Both subscription checkout and extras pack checkout follow the flag.

## Backward compatibility

- Existing callers of `attribute(history, organizationId)` without options continue to work — default `stepKey='initial'` makes the idempotency key `${history._id}:initial`. Note: this changes the stored key format from plain `history._id` to `history._id:initial`. **Any existing `consumedHistoryIds` entries in the DB will not match the new format** — meaning a first call after deploy will re-charge a history that was previously attributed. Downstreams should account for this during cutover (no-op in practice for trawl since it hasn't launched LIVE yet).
- Existing downstreams without `stripe.automaticTax` in config default to `false` — **automatic_tax will no longer be sent to Stripe**. This is intentionally different from the previous behavior (always-on). Downstreams must explicitly set `stripe.automaticTax: true` once Stripe Tax is enabled in Dashboard.

Closes #3570
Closes #3572