### PR TITLE
feat(billing): expose config.billing.equivalences via /api/auth/config

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -583,6 +583,7 @@ const getConfig = (req, res) => {
     data.billing = {
       enabled: !!config.billing?.enabled,
       meterMode: !!config.billing?.meterMode,
+      equivalences: config.billing?.equivalences ?? null,
     };
   }
 

--- a/modules/auth/tests/auth.config.controller.unit.tests.js
+++ b/modules/auth/tests/auth.config.controller.unit.tests.js
@@ -110,7 +110,7 @@ describe('auth.controller getConfig:', () => {
     expect(data.billing).toBeUndefined();
   });
 
-  test('data.billing defaults to false/false when config.billing is undefined (authenticated)', async () => {
+  test('data.billing defaults to false/false/null when config.billing is undefined (authenticated)', async () => {
     // config has no billing key
     const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
 
@@ -123,6 +123,7 @@ describe('auth.controller getConfig:', () => {
     expect(data.billing).toBeDefined();
     expect(data.billing.enabled).toBe(false);
     expect(data.billing.meterMode).toBe(false);
+    expect(data.billing.equivalences).toBeNull();
   });
 
   test('data.billing reflects config truthfully when both flags are enabled (authenticated)', async () => {
@@ -139,5 +140,26 @@ describe('auth.controller getConfig:', () => {
     expect(data.billing).toBeDefined();
     expect(data.billing.enabled).toBe(true);
     expect(data.billing.meterMode).toBe(true);
+    expect(data.billing.equivalences).toBeNull();
+  });
+
+  test('data.billing.equivalences is returned verbatim when set in config (authenticated)', async () => {
+    const equivalences = {
+      plans: {
+        growth: { scrapsPerMonth: 200, typicalScrapsPerMonth: 50, features: ['alerts', 'export'] },
+        pro: { scrapsPerMonth: 1000, typicalScrapsPerMonth: 200, features: ['alerts', 'export', 'api'] },
+      },
+    };
+    mockConfig.billing = { enabled: true, meterMode: true, equivalences };
+
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = { user: { id: '1' } };
+    const res = {};
+
+    AuthController.getConfig(req, res);
+
+    const [data] = mockResponses.successCb.mock.calls[0];
+    expect(data.billing.equivalences).toEqual(equivalences);
   });
 });

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1542,6 +1542,7 @@ describe('Auth integration tests:', () => {
       expect(result.body.data.billing).toBeDefined();
       expect(typeof result.body.data.billing.enabled).toBe('boolean');
       expect(typeof result.body.data.billing.meterMode).toBe('boolean');
+      expect(result.body.data.billing.equivalences).toBeNull();
     });
 
     test('should reflect billing.meterMode=true when enabled (authenticated)', async () => {
@@ -1552,6 +1553,22 @@ describe('Auth integration tests:', () => {
         expect(result.body.data.billing.meterMode).toBe(true);
       } finally {
         config.billing = { ...config.billing, meterMode: originalMeterMode };
+      }
+    });
+
+    test('should return equivalences verbatim when set in config (authenticated)', async () => {
+      const originalBilling = config.billing;
+      const equivalences = {
+        plans: {
+          growth: { scrapsPerMonth: 200, typicalScrapsPerMonth: 50, features: ['alerts', 'export'] },
+        },
+      };
+      config.billing = { ...config.billing, equivalences };
+      try {
+        const result = await authAgent.get('/api/auth/config').expect(200);
+        expect(result.body.data.billing.equivalences).toEqual(equivalences);
+      } finally {
+        config.billing = originalBilling;
       }
     });
   });


### PR DESCRIPTION
## Summary

- Adds `equivalences` field to the billing object returned by the authenticated `/api/auth/config` endpoint
- Value is passed through verbatim from `config.billing.equivalences` — no transformation
- Defaults to `null` when not set (backwards compatible: zero behaviour change for projects not using `meterMode`)

## Use case

The downstream Vue UI renders plan/pack chips showing "X easy scraps / Y typical scraps + features list". This data lives in the project config's `billing.equivalences` object and must be served by the API so the frontend has no knowledge of pricing math. Without this field the UI would need to hard-code or duplicate equivalence values.

Trawl will populate `equivalences` in its own `billing` config block; all other projects that don't set it continue to receive `null` and are unaffected.

## Contract (opt-in)

```js
// trawl config — downstream only
billing: {
  enabled: true,
  meterMode: true,
  equivalences: {
    plans: {
      growth: { scrapsPerMonth: 200, typicalScrapsPerMonth: 50, features: ['alerts', 'export'] },
      pro:    { scrapsPerMonth: 1000, typicalScrapsPerMonth: 200, features: ['alerts', 'export', 'api'] },
    },
  },
}
```

## Test plan

- [ ] Unit tests (`auth.config.controller.unit.tests.js`): 4 tests pass — absent for unauthenticated, null default, null when flags set, verbatim object when equivalences configured
- [ ] Integration tests (`auth.integration.tests.js`): null assertion on default response + new test verifying verbatim passthrough
- [ ] Lint clean