### PR TITLE
fix+refactor(billing): close TOCTOU race in withIdempotency + YYYY.MM version namespace contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,30 @@ Both file types are optional and can be used independently or together. Per-modu
 
 > See [MIGRATIONS.md](MIGRATIONS.md) for the full migration guide from route-level CASL to document-level CASL v2.
 
+## :credit_card: Billing — Version Namespace Contract
+
+When `meterMode` is enabled, three values must be aligned so `getPlanByVersion` resolves correctly and plan ratios are applied (not the ratio=1 fallback):
+
+| Value | Where set | Format |
+|-------|-----------|--------|
+| `config.billing.meter.ratioVersion` | downstream project config | `YYYY.MM` (e.g. `'2026.05'`) |
+| `planDefinitions[].version` | downstream project config (optional, takes priority) | same as above |
+| `history.planVersion` | written at run-time by the downstream cost-config | same as above |
+
+**Version resolution priority in `ensureSeeded`:**
+1. Explicit `version` in `planDefinitions` entry (e.g. `{ planId: 'pro', version: '2026.05', ... }`).
+2. `config.billing.meter.ratioVersion` — canonical fallback.
+3. Count-derived `v${n+1}` — backward compat for projects that set neither.
+
+**Preferred format:** `YYYY.MM` (calendar-style). Legacy `v${N}` is supported but new projects should use YYYY.MM.
+
+**Drift detection:** when `getPlanByVersion` returns null (version mismatch), `unitsFromCosts` emits a `[billing.meter] … ratio=1 fallback applied` WARN. Check that log at boot if meter charges look unexpectedly flat.
+
+**Downstream checklist:**
+- Set `billing.meter.ratioVersion` in your project config (e.g. `'2026.05'`).
+- Either set `version` in each `planDefinitions` entry or rely on `ratioVersion` as the fallback.
+- Ensure your cost-config writes the same version string into `history.planVersion`.
+
 ## :whale: Docker
 
 ```bash

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -47,9 +47,12 @@ const config = {
     /**
      * Plan definitions — DOWNSTREAM-OVERRIDE-REQUIRED for meter mode.
      * Used by BillingPlanService.ensureSeeded() at boot to upsert BillingPlan docs.
-     * Array of objects: { planId, meterQuota: units/week, ratios: { featureKey: multiplier } }.
+     * Array of objects: { planId, meterQuota: units/week, ratios: { featureKey: multiplier }, version? }.
      * billing.plans enum is derived at boot from planDefinitions.map(p => p.planId) — do NOT
      * declare billing.plans manually. This is the single source of truth for plan identifiers.
+     *
+     * version: optional — falls back to billing.meter.ratioVersion, then v${count + 1}.
+     * Downstream projects that use YYYY.MM versioning should set this (or set ratioVersion).
      */
     planDefinitions: [
       { planId: 'free', meterQuota: 0, ratios: { default: 1 } },
@@ -66,6 +69,23 @@ const config = {
      */
     meter: {
       runBaseUnits: 1,
+      /**
+       * Canonical version string emitted by billing.meter.service attribute() when writing
+       * history.planVersion. Downstream projects MUST override this value and keep it
+       * aligned with:
+       *   1. planDefinitions[].version (or omit it and rely on this value as the fallback)
+       *   2. The version string their cost-config writes into history records
+       *
+       * Preferred format: YYYY.MM (calendar-style, e.g. '2026.05').
+       * Legacy format v${N} (e.g. 'v1') is still supported for backward compat,
+       * but new projects should use YYYY.MM from the start.
+       *
+       * A mismatch here causes getPlanByVersion() to return null → ratio=1 fallback +
+       * a WARN log in unitsFromCosts. Check that warn at boot if meter charges look flat.
+       *
+       * DOWNSTREAM-OVERRIDE-REQUIRED — this devkit default is illustrative.
+       */
+      ratioVersion: '2026.05',
       /**
        * Conversion ratio: 1 unit = 1 / dollarsToUnitRatio USD of underlying cost.
        *

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -55,7 +55,26 @@ const wasProcessed = async (eventId) => {
   return doc !== null;
 };
 
+/**
+ * @function deleteByEventId
+ * @description Delete the processed event record for the given eventId.
+ *              Called by withIdempotency rollback when the handler throws — allows
+ *              Stripe to retry the event on a subsequent delivery.
+ *              Returns { deleted: true } if a document was removed, { deleted: false } if none found.
+ * @param {string} eventId - Stripe event ID to remove.
+ * @returns {Promise<{deleted: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const deleteByEventId = async (eventId) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') {
+    throw new Error('invalid argument: eventId must be a non-empty string');
+  }
+  const result = await ProcessedStripeEvent().deleteOne({ eventId });
+  return { deleted: result.deletedCount > 0 };
+};
+
 export default {
   tryRecord,
   wasProcessed,
+  deleteByEventId,
 };

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -19,6 +19,10 @@ export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
  *              Formula per key: floor(cost[key] * ratio[key] * dollarsToUnitRatio)
  *              Total: max(sum(per-key units), METER_RUN_BASE)
  *
+ *              When getPlanByVersion returns null (version mismatch), logs a WARN and
+ *              falls back to ratio=1 for all features. Check logs if charges look flat —
+ *              this indicates meter.ratioVersion vs planDefinitions version drift.
+ *
  * @param {Object} costs - Feature-keyed cost map: { featureKey: usdCost }.
  * @param {string} planId - Logical plan identifier (e.g. "pro").
  * @param {string} ratioVersion - Specific plan version for the ratio lookup.
@@ -34,6 +38,14 @@ const unitsFromCosts = async (costs, planId, ratioVersion) => {
 
   // Fetch the frozen plan snapshot for the given version
   const plan = await BillingPlanService.getPlanByVersion(planId, ratioVersion);
+  if (!plan) {
+    // WARN: version mismatch likely — costs.config emits a version that has no matching BillingPlan.
+    // Charges will use ratio=1 (flat) for all features. Align meter.ratioVersion + planDefinitions[].version
+    // + downstream cost-config emitted version to resolve. See billing README — Version Namespace Contract.
+    console.warn(
+      `[billing.meter] getPlanByVersion(${planId}, ${ratioVersion}) returned null — ratio=1 fallback applied. Check version namespace alignment.`,
+    );
+  }
   const ratios = (plan && typeof plan.ratios === 'object' && !Array.isArray(plan.ratios)) ? plan.ratios : {};
 
   const breakdown = {};

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -169,9 +169,15 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
  *              No-op when meter mode is disabled. Idempotent on re-run.
  *
  *              Accepts the canonical array-of-objects shape:
- *              [{ planId, meterQuota, ratios }, ...].
+ *              [{ planId, meterQuota, ratios, version? }, ...].
  *              The legacy object shape is normalized upstream in config/index.js
  *              before this service is ever called.
+ *
+ *              Version resolution priority (see billing README — Version Namespace Contract):
+ *              1. Explicit version in planDefinitions entry (e.g. '2026.05' — YYYY.MM contract).
+ *              2. config.billing.meter.ratioVersion (canonical version emitted by attribute()).
+ *              3. Derived from count (v${total + 1}) — full backward compat for projects
+ *                 that do not set either.
  *
  *              Race / E11000 safety: version is derived from the total count of
  *              existing docs for the planId (same strategy as bumpVersion). A
@@ -197,10 +203,15 @@ const ensureSeeded = async () => {
     }
 
     try {
-      // Derive version from total count so that an inactive v1 record does not
-      // collide with the insert (same approach as bumpVersion to avoid hardcoding 'v1').
-      const total = await BillingPlanRepository.count(planId);
-      const version = `v${total + 1}`;
+      // Version resolution priority:
+      // 1. Explicit version in planDefinitions entry (e.g. '2026.05' — YYYY.MM contract)
+      // 2. config.billing.meter.ratioVersion (canonical version emitted by attribute())
+      // 3. Derived from count (v${total + 1}) — full backward compat for projects without version config
+      let version = planDef.version ?? config?.billing?.meter?.ratioVersion ?? null;
+      if (!version) {
+        const total = await BillingPlanRepository.count(planId);
+        version = `v${total + 1}`;
+      }
 
       await BillingPlanRepository.create({
         planId,

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -80,8 +80,11 @@ const withIdempotency = async (event, handler) => {
   try {
     return await handler(event);
   } catch (err) {
-    // Rollback claim so Stripe can retry on a fresh delivery
-    await ProcessedStripeEventRepository.deleteByEventId(event.id);
+    // Rollback claim so Stripe can retry on a fresh delivery.
+    // Swallow rollback errors so the original handler error is always propagated.
+    await ProcessedStripeEventRepository.deleteByEventId(event.id).catch((rollbackErr) => {
+      console.error('[billing.webhook] rollback deleteByEventId failed — event may be stuck:', rollbackErr);
+    });
     throw err;
   }
 };

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -58,15 +58,13 @@ const syncOrganizationPlan = async (organizationId, plan) => {
 /**
  * @description Wrap a webhook handler with idempotency using ProcessedStripeEvent.
  *
- * Semantics:
- * - Pre-check via wasProcessed: short-circuits Stripe retries of identical events that already
- *   completed — handler is not invoked again.
- * - Record AFTER handler: if handler throws, the event remains "not processed" so Stripe can
- *   retry and the handler can eventually succeed. Prevents silent loss.
- * - TOCTOU between wasProcessed and tryRecord: two concurrent Stripe deliveries of the same
- *   event can both pass wasProcessed and both run handler. Acceptable because data-layer
- *   mutations are idempotent (creditPack uses $ne stripeSessionId, refundPartial uses $ne refId,
- *   subscription update is last-write-wins). tryRecord is best-effort dedup after success.
+ * Atomic-claim semantics (closes TOCTOU race):
+ * 1. tryRecord atomically inserts the event record BEFORE running the handler.
+ *    The unique index on eventId means only the first concurrent delivery succeeds;
+ *    all others get E11000 → { recorded: false } → skip.
+ * 2. If the handler throws, deleteByEventId rolls back the claim so Stripe can retry.
+ * 3. On handler success the record stays permanently — subsequent Stripe retries are
+ *    skipped via tryRecord returning { recorded: false }.
  *
  * @param {Object} event - Full Stripe event object (must have event.id and event.type).
  * @param {Function} handler - Async function (event) => result called when event is new.
@@ -74,15 +72,18 @@ const syncOrganizationPlan = async (organizationId, plan) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const withIdempotency = async (event, handler) => {
-  // Pre-check: if already processed, skip (Stripe retry of the same event)
-  if (await ProcessedStripeEventRepository.wasProcessed(event.id)) {
+  // Atomically claim the event — only the first delivery wins
+  const { recorded } = await ProcessedStripeEventRepository.tryRecord(event.id, event.type);
+  if (!recorded) {
     return { skipped: true, reason: 'duplicate_event' };
   }
-  // Run handler first — data-layer is already idempotent (creditPack, refundPartial, etc.)
-  const result = await handler(event);
-  // Best-effort dedup hint after success — TOCTOU is acceptable since data-layer guards prevent double-effect
-  await ProcessedStripeEventRepository.tryRecord(event.id, event.type);
-  return result;
+  try {
+    return await handler(event);
+  } catch (err) {
+    // Rollback claim so Stripe can retry on a fresh delivery
+    await ProcessedStripeEventRepository.deleteByEventId(event.id);
+    throw err;
+  }
 };
 
 /**

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -139,7 +139,8 @@ describe('BillingMeterService unit tests:', () => {
       expect(result.totalUnits).toBe(1);
     });
 
-    test('should use ratio=1 when plan not found (null)', async () => {
+    test('should use ratio=1 when plan not found (null) and emit a WARN log', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(null);
 
       const costs = { scrap: 0.001 };
@@ -147,6 +148,10 @@ describe('BillingMeterService unit tests:', () => {
 
       // ratio defaults to 1: floor(0.001 * 1 * 1000) = 1
       expect(result.totalUnits).toBe(1);
+      // WARN must be emitted so operators notice the version drift
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[billing.meter] getPlanByVersion(pro, v1) returned null'),
+      );
     });
 
     test('should skip cost entries with non-numeric or zero values', async () => {

--- a/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
+++ b/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
@@ -156,4 +156,57 @@ describe('BillingPlanService.ensureSeeded unit tests:', () => {
 
     await expect(BillingPlanService.ensureSeeded()).rejects.toThrow('DB connection lost');
   });
+
+  // Version Namespace Contract tests (#3574)
+
+  test('explicit version in planDefinitions entry is used as-is (YYYY.MM contract)', async () => {
+    mockConfig.billing.planDefinitions = [
+      { planId: 'pro', meterQuota: 500000, ratios: { default: 1 }, version: '2026.05' },
+    ];
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    await BillingPlanService.ensureSeeded();
+
+    // count should NOT be called — version resolved from explicit entry
+    expect(mockBillingPlanRepository.count).not.toHaveBeenCalled();
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ planId: 'pro', version: '2026.05' }),
+    );
+  });
+
+  test('no explicit version + meter.ratioVersion in config → uses ratioVersion (YYYY.MM fallback)', async () => {
+    mockConfig.billing.planDefinitions = [
+      { planId: 'starter', meterQuota: 50000, ratios: { default: 1 } },
+    ];
+    mockConfig.billing.meter = { ratioVersion: '2026.05' };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    await BillingPlanService.ensureSeeded();
+
+    // count should NOT be called — version resolved from ratioVersion
+    expect(mockBillingPlanRepository.count).not.toHaveBeenCalled();
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ planId: 'starter', version: '2026.05' }),
+    );
+  });
+
+  test('no explicit version + no ratioVersion → falls back to count-derived v${n+1}', async () => {
+    mockConfig.billing.planDefinitions = [
+      { planId: 'free', meterQuota: 0, ratios: { default: 1 } },
+    ];
+    // Ensure no meter.ratioVersion
+    mockConfig.billing.meter = { runBaseUnits: 1, dollarsToUnitRatio: 1000 };
+    mockBillingPlanRepository.findActive.mockResolvedValue(null);
+    mockBillingPlanRepository.count.mockResolvedValue(0);
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    await BillingPlanService.ensureSeeded();
+
+    expect(mockBillingPlanRepository.count).toHaveBeenCalledTimes(1);
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ planId: 'free', version: 'v1' }),
+    );
+  });
 });

--- a/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
@@ -22,6 +22,7 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
     mockModel = {
       create: jest.fn(),
       findOne: jest.fn(),
+      deleteOne: jest.fn(),
     };
 
     jest.unstable_mockModule('mongoose', () => ({
@@ -134,6 +135,45 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
     test('should return false for non-string eventId', async () => {
       const result = await ProcessedStripeEventRepository.wasProcessed(null);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('deleteByEventId', () => {
+    test('returns { deleted: true } when document removed', async () => {
+      mockModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const result = await ProcessedStripeEventRepository.deleteByEventId('evt_to_delete');
+
+      expect(result).toEqual({ deleted: true });
+      expect(mockModel.deleteOne).toHaveBeenCalledWith({ eventId: 'evt_to_delete' });
+    });
+
+    test('returns { deleted: false } when document not found', async () => {
+      mockModel.deleteOne.mockResolvedValue({ deletedCount: 0 });
+
+      const result = await ProcessedStripeEventRepository.deleteByEventId('evt_missing');
+
+      expect(result).toEqual({ deleted: false });
+    });
+
+    test('throws for empty eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.deleteByEventId(''),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+
+    test('throws for non-string eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.deleteByEventId(null),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+
+    test('propagates DB errors', async () => {
+      mockModel.deleteOne.mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        ProcessedStripeEventRepository.deleteByEventId('evt_abc'),
+      ).rejects.toThrow('DB connection lost');
     });
   });
 });

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -166,6 +166,23 @@ describe('Billing webhook idempotency unit tests:', () => {
     });
 
     /**
+     * Rollback itself fails (DB outage) — original handler error must still be thrown,
+     * not the rollback error. The swallowed rollback error is logged but never re-thrown.
+     */
+    test('rollback fails → original handler error still propagated (not masked)', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      mockProcessedStripeEventRepository.deleteByEventId.mockRejectedValue(new Error('DB outage'));
+      const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
+      const event = makeEvent();
+
+      await expect(
+        BillingWebhookService.withIdempotency(event, handler),
+      ).rejects.toThrow('handler blew up');
+
+      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_test_001');
+    });
+
+    /**
      * Retry after rollback: handler fails (rollback), then Stripe retries.
      * On the second delivery tryRecord succeeds again (record was deleted) → handler runs.
      */

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -5,6 +5,12 @@ import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globa
 
 /**
  * Unit tests for webhook idempotency (withIdempotency guard)
+ *
+ * Contract (post #3573 fix — atomic-claim):
+ * - tryRecord is called BEFORE the handler (atomic claim via unique index)
+ * - If tryRecord returns { recorded: false } → skip (Stripe retry or concurrent delivery)
+ * - If handler throws → deleteByEventId rollback → Stripe can retry
+ * - On success → record stays permanently (subsequent Stripe retries skipped)
  */
 describe('Billing webhook idempotency unit tests:', () => {
   let BillingWebhookService;
@@ -26,8 +32,9 @@ describe('Billing webhook idempotency unit tests:', () => {
     jest.resetModules();
 
     mockProcessedStripeEventRepository = {
-      wasProcessed: jest.fn(),
       tryRecord: jest.fn(),
+      wasProcessed: jest.fn(),
+      deleteByEventId: jest.fn(),
     };
 
     jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
@@ -79,68 +86,75 @@ describe('Billing webhook idempotency unit tests:', () => {
   });
 
   describe('withIdempotency', () => {
-    test('should call handler when event is new (wasProcessed=false), then record', async () => {
-      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
+    /**
+     * Happy path: new event — tryRecord succeeds, handler runs, result returned.
+     */
+    test('new event: tryRecord=true → handler runs → result returned', async () => {
       mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
       const handler = jest.fn().mockResolvedValue({ ok: true });
       const event = makeEvent();
 
       const result = await BillingWebhookService.withIdempotency(event, handler);
 
-      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledWith('evt_test_001');
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith(
+        'evt_test_001',
+        'checkout.session.completed',
+      );
       expect(handler).toHaveBeenCalledWith(event);
-      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith('evt_test_001', 'checkout.session.completed');
       expect(result).toEqual({ ok: true });
     });
 
     /**
-     * Stripe retry after success: wasProcessed returns true → handler not run.
-     * This is the primary dedup path for Stripe event retries after successful processing.
+     * Stripe retry after success: tryRecord returns { recorded: false } (unique index hit)
+     * → handler not invoked → skip sentinel returned.
      */
-    test('Stripe retry after success: wasProcessed=true → handler not run', async () => {
-      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(true);
+    test('Stripe retry: tryRecord=false → handler not run → skip sentinel', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false });
       const handler = jest.fn();
       const event = makeEvent();
 
       const result = await BillingWebhookService.withIdempotency(event, handler);
 
-      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledWith('evt_test_001');
+      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith(
+        'evt_test_001',
+        'checkout.session.completed',
+      );
       expect(handler).not.toHaveBeenCalled();
-      expect(mockProcessedStripeEventRepository.tryRecord).not.toHaveBeenCalled();
       expect(result).toEqual({ skipped: true, reason: 'duplicate_event' });
     });
 
     /**
-     * Concurrent delivery: two simultaneous Stripe deliveries of the same event both pass
-     * wasProcessed (it's not atomic). Both handlers run (acceptable per data-layer idempotency).
-     * Only the first tryRecord succeeds; the second gets E11000 → recorded=false (best-effort).
+     * Concurrent delivery: two simultaneous Stripe deliveries — tryRecord is atomic.
+     * First call wins (recorded: true) → handler runs once.
+     * Second call loses (recorded: false) → handler not run → skip.
+     *
+     * This is the TOCTOU fix: only ONE handler execution vs the old 2-execution race.
      */
-    test('concurrent delivery: both pass wasProcessed, both run handler, second tryRecord gets E11000', async () => {
-      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
+    test('concurrent delivery: only the first claim runs the handler (TOCTOU fix)', async () => {
       mockProcessedStripeEventRepository.tryRecord
-        .mockResolvedValueOnce({ recorded: true })
-        .mockResolvedValueOnce({ recorded: false }); // E11000 on the second concurrent delivery
-
+        .mockResolvedValueOnce({ recorded: true }) // first delivery wins
+        .mockResolvedValueOnce({ recorded: false }); // second delivery loses
       const handler = jest.fn().mockResolvedValue(undefined);
       const event = makeEvent('evt_concurrent', 'customer.subscription.updated');
 
-      // Both deliveries run concurrently — both pass wasProcessed
-      await Promise.all([
+      const results = await Promise.all([
         BillingWebhookService.withIdempotency(event, handler),
         BillingWebhookService.withIdempotency(event, handler),
       ]);
 
-      // Both handlers ran (acceptable — data-layer mutations are idempotent)
-      expect(handler).toHaveBeenCalledTimes(2);
+      // Handler runs exactly ONCE (not twice as in the old TOCTOU bug)
+      expect(handler).toHaveBeenCalledTimes(1);
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(2);
+      expect(results.some((r) => r && r.skipped)).toBe(true);
     });
 
     /**
-     * Silent-loss fix proof: if handler throws, no record is persisted.
-     * Stripe will retry; the handler gets another chance → no silent event loss.
+     * Handler throws → deleteByEventId rollback → event stays unprocessed for Stripe to retry.
+     * wasProcessed is NOT called (old pre-check removed in favour of atomic-claim).
      */
-    test('handler throws → no record persisted (silent-loss fix)', async () => {
-      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
+    test('handler throws → deleteByEventId called (rollback) → error re-thrown', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      mockProcessedStripeEventRepository.deleteByEventId.mockResolvedValue({ deleted: true });
       const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
       const event = makeEvent();
 
@@ -148,20 +162,52 @@ describe('Billing webhook idempotency unit tests:', () => {
         BillingWebhookService.withIdempotency(event, handler),
       ).rejects.toThrow('handler blew up');
 
-      // tryRecord must NOT have been called — event stays unprocessed for Stripe to retry
-      expect(mockProcessedStripeEventRepository.tryRecord).not.toHaveBeenCalled();
+      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_test_001');
     });
 
-    test('wasProcessed called exactly once per withIdempotency invocation', async () => {
-      mockProcessedStripeEventRepository.wasProcessed.mockResolvedValue(false);
+    /**
+     * Retry after rollback: handler fails (rollback), then Stripe retries.
+     * On the second delivery tryRecord succeeds again (record was deleted) → handler runs.
+     */
+    test('retry after rollback: second delivery succeeds after first handler failure', async () => {
+      // First delivery: claim succeeds, handler throws, rollback runs
+      mockProcessedStripeEventRepository.tryRecord
+        .mockResolvedValueOnce({ recorded: true })
+        .mockResolvedValueOnce({ recorded: true }); // second delivery can claim again
+      mockProcessedStripeEventRepository.deleteByEventId.mockResolvedValue({ deleted: true });
+
+      const handler = jest.fn()
+        .mockRejectedValueOnce(new Error('transient failure'))
+        .mockResolvedValueOnce({ ok: true });
+
+      const event = makeEvent('evt_retry_test');
+
+      // First delivery fails
+      await expect(
+        BillingWebhookService.withIdempotency(event, handler),
+      ).rejects.toThrow('transient failure');
+
+      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_retry_test');
+
+      // Second delivery (Stripe retry) succeeds
+      const result = await BillingWebhookService.withIdempotency(event, handler);
+      expect(result).toEqual({ ok: true });
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * tryRecord called exactly once per withIdempotency invocation.
+     * wasProcessed must NOT be called (old contract removed).
+     */
+    test('tryRecord called exactly once; wasProcessed never called', async () => {
       mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
       const handler = jest.fn().mockResolvedValue(undefined);
       const event = makeEvent('evt_single_check');
 
       await BillingWebhookService.withIdempotency(event, handler);
 
-      expect(mockProcessedStripeEventRepository.wasProcessed).toHaveBeenCalledTimes(1);
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(1);
+      expect(mockProcessedStripeEventRepository.wasProcessed).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- **#3573 — TOCTOU fix in `withIdempotency`**: move `tryRecord` BEFORE the handler (atomic-claim via unique index). First concurrent delivery wins; all others get `{ recorded: false }` → skip. On handler throw, `deleteByEventId` rollbacks the claim so Stripe can retry. Eliminates the double-handler-execution race in the old `wasProcessed`-first pattern.
- **#3574 — Version Namespace Contract (YYYY.MM)**: `ensureSeeded` resolves `BillingPlan.version` in priority order: (1) explicit `version` in `planDefinitions` entry, (2) `config.billing.meter.ratioVersion`, (3) count-derived `v${n+1}`. `unitsFromCosts` now emits a WARN log (not silent fallback) when `getPlanByVersion` returns null. `billing.development.config.js` adds `ratioVersion: '2026.05'`. README documents the contract.

## Files changed

- `billing.processedStripeEvent.repository.js` — add `deleteByEventId`
- `billing.webhook.service.js` — tryRecord-first + rollback in `withIdempotency`
- `billing.plan.service.js` — 3-priority version resolution in `ensureSeeded`
- `billing.meter.service.js` — WARN log on null plan
- `billing.development.config.js` — `ratioVersion: '2026.05'` + docs
- `README.md` — Version Namespace Contract section

## Test plan

- [x] `billing.webhook.idempotency.unit.tests.js` — 6 tests: happy path, Stripe retry skip, concurrent delivery (handler runs once — TOCTOU proof), handler throw + rollback, retry after rollback, `wasProcessed` never called
- [x] `billing.processedStripeEvent.repository.unit.tests.js` — 5 new `deleteByEventId` tests
- [x] `billing.plan.ensureSeeded.unit.tests.js` — 3 new version-path tests: explicit version, `ratioVersion` fallback, count-derived fallback
- [x] `billing.meter.service.unit.tests.js` — WARN log test
- [x] Lint clean