### PR TITLE
docs(billing/crons): jitter & sharding guidance

### DIFF
--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -53,6 +53,34 @@ spec:
 
 Repeat the manifest for `billing.extrasExpiration.js` and `billing.dunningSweep.js`, adjusting `name` and `schedule`.
 
+## Jitter & sharding
+
+Devkit-shipped crons run on identical UTC schedules across all consumer deployments. To avoid thundering-herd against a shared DB or external API:
+
+### Recommended pattern — startup jitter
+
+Wrap the cron handler in a `setTimeout` of 0–N seconds (N = jitter window) computed at process start, persisted across restarts:
+
+```js
+// illustrative — replace cron.schedule with your scheduler API
+const jitterMs = Math.floor(Math.random() * 60_000); // 0–60s window
+cron.schedule('0 2 * * 1', async () => {
+  await new Promise(r => setTimeout(r, jitterMs));
+  await BillingResetService.resetAllDue();
+});
+```
+
+### When to shard
+
+If your tenant count > 10k OR the operation touches a single table that doesn't tolerate concurrent writes well:
+- Shard by `organizationId` modulo N (e.g. 8 shards, each at a different hour offset: `0 2-9 * * 1`)
+- Or use a per-tenant queue with worker pool
+
+### Constraints
+
+- Don't jitter more than the operation's idempotency window — if reset is idempotent within 1h, jitter ≤ 30min. Beyond that, late-running jobs miss their window.
+- Don't jitter critical SLA-bound jobs (alerts, notifications) — jitter undermines time-sensitivity.
+
 ## Dependency: meterMode flag
 
 All scripts check `config.billing.meterMode` at startup. Downstream projects must set this flag to `true` in their project config to activate billing crons. The devkit default is `false` — all crons are no-ops until explicitly enabled.

--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -93,13 +93,18 @@ env:
     value: "8"
 ```
 
-Then filter in the script:
+Then filter in the script by hashing a stable field (e.g. the string representation of `_id`) against the shard count:
 
 ```js
 const shardIndex = parseInt(process.env.SHARD_INDEX ?? '0', 10);
 const shardTotal = parseInt(process.env.SHARD_TOTAL ?? '1', 10);
-// Only process orgs whose ID hashes to this shard
-const orgs = await Org.find({ $where: `this._id % ${shardTotal} === ${shardIndex}` });
+// Only process orgs assigned to this shard (stable hash on _id string)
+const allOrgs = await Org.find({}, '_id').lean();
+const orgs = allOrgs.filter(o => {
+  const id = o._id.toString();
+  const hash = [...id].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
+  return Math.abs(hash) % shardTotal === shardIndex;
+});
 ```
 
 ### Constraints

--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -62,19 +62,21 @@ Devkit-shipped crons run on identical UTC schedules across all consumer deployme
 These scripts are invoked once per CronJob execution and exit immediately after. Add a random delay at the top of your entrypoint to spread load across deployments:
 
 ```js
-// Add at the top of your cron entrypoint (before the main logic)
+// Wrap in an async IIFE — cron entrypoints are CommonJS, so top-level await is not available.
 // Jitter is re-randomized on each CronJob invocation — this is intentional for K8s CronJobs.
 // For a stable per-pod offset, derive from process.env.HOSTNAME instead (see note below).
-const jitterMs = Math.floor(Math.random() * 60_000); // 0–60s window
-await new Promise(r => setTimeout(r, jitterMs));
-await BillingResetService.resetAllDue();
+(async () => {
+  const jitterMs = Math.floor(Math.random() * 60_000); // 0–60s window
+  await new Promise(r => setTimeout(r, jitterMs));
+  await BillingResetService.resetAllDue();
+})();
 ```
 
-> **Stable per-pod jitter (optional):** If you want the same pod to always fire at the same offset within the window, derive jitter from the pod hostname instead of `Math.random()`:
+> **Stable per-pod jitter (optional):** If you want the same pod to always fire at the same offset within the window, derive jitter from the pod hostname instead of `Math.random()`. Use a distinct variable name to avoid shadowing if both snippets appear in the same file:
 > ```js
 > const seed = process.env.HOSTNAME ?? 'default';
-> const hash = [...seed].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
-> const jitterMs = Math.abs(hash) % 60_000;
+> const hostHash = [...seed].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
+> const stableJitterMs = Math.abs(hostHash) % 60_000;
 > ```
 
 ### When to shard
@@ -98,12 +100,14 @@ Then filter in the script by hashing a stable field (e.g. the string representat
 ```js
 const shardIndex = parseInt(process.env.SHARD_INDEX ?? '0', 10);
 const shardTotal = parseInt(process.env.SHARD_TOTAL ?? '1', 10);
-// Only process orgs assigned to this shard (stable hash on _id string)
+// Only process orgs assigned to this shard (stable hash on _id string).
+// Note: this loads all _id values into memory. For very large tenant counts,
+// prefer a server-side filter (e.g. MongoDB $expr + $mod on a numeric shard key).
 const allOrgs = await Org.find({}, '_id').lean();
 const orgs = allOrgs.filter(o => {
   const id = o._id.toString();
-  const hash = [...id].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
-  return Math.abs(hash) % shardTotal === shardIndex;
+  const h = [...id].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
+  return Math.abs(h) % shardTotal === shardIndex;
 });
 ```
 

--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -59,22 +59,48 @@ Devkit-shipped crons run on identical UTC schedules across all consumer deployme
 
 ### Recommended pattern — startup jitter
 
-Wrap the cron handler in a `setTimeout` of 0–N seconds (N = jitter window) computed at process start, persisted across restarts:
+These scripts are invoked once per CronJob execution and exit immediately after. Add a random delay at the top of your entrypoint to spread load across deployments:
 
 ```js
-// illustrative — replace cron.schedule with your scheduler API
+// Add at the top of your cron entrypoint (before the main logic)
+// Jitter is re-randomized on each CronJob invocation — this is intentional for K8s CronJobs.
+// For a stable per-pod offset, derive from process.env.HOSTNAME instead (see note below).
 const jitterMs = Math.floor(Math.random() * 60_000); // 0–60s window
-cron.schedule('0 2 * * 1', async () => {
-  await new Promise(r => setTimeout(r, jitterMs));
-  await BillingResetService.resetAllDue();
-});
+await new Promise(r => setTimeout(r, jitterMs));
+await BillingResetService.resetAllDue();
 ```
+
+> **Stable per-pod jitter (optional):** If you want the same pod to always fire at the same offset within the window, derive jitter from the pod hostname instead of `Math.random()`:
+> ```js
+> const seed = process.env.HOSTNAME ?? 'default';
+> const hash = [...seed].reduce((a, c) => ((a << 5) - a + c.charCodeAt(0)) | 0, 0);
+> const jitterMs = Math.abs(hash) % 60_000;
+> ```
 
 ### When to shard
 
 If your tenant count > 10k OR the operation touches a single table that doesn't tolerate concurrent writes well:
 - Shard by `organizationId` modulo N (e.g. 8 shards, each at a different hour offset: `0 2-9 * * 1`)
 - Or use a per-tenant queue with worker pool
+
+To implement shard-based filtering, pass a `SHARD_INDEX` and `SHARD_TOTAL` env vars in the CronJob manifest:
+
+```yaml
+env:
+  - name: SHARD_INDEX
+    value: "0"       # 0..N-1
+  - name: SHARD_TOTAL
+    value: "8"
+```
+
+Then filter in the script:
+
+```js
+const shardIndex = parseInt(process.env.SHARD_INDEX ?? '0', 10);
+const shardTotal = parseInt(process.env.SHARD_TOTAL ?? '1', 10);
+// Only process orgs whose ID hashes to this shard
+const orgs = await Org.find({ $where: `this._id % ${shardTotal} === ${shardIndex}` });
+```
 
 ### Constraints
 


### PR DESCRIPTION
## Summary

- Adds a **Jitter & sharding** section to `modules/billing/crons/README.md`, inserted after the Kubernetes CronJob example and before the `meterMode` dependency section.
- Documents the recommended startup-jitter pattern, when-to-shard heuristic (>10k tenants or single-table contention), and constraints around idempotency window vs jitter window.
- Clarifies that the `cron.schedule` snippet is illustrative (no `node-cron` dep in devkit).

Devkit-shipped crons run identical UTC schedules across all consumer deployments — without jitter, N consumers fan-in to one DB burst. This is documentation-only guidance; no code changes.

## Test plan

- [ ] CI green
- [ ] Markdown renders correctly on GitHub preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated billing infrastructure documentation with guidance on performance optimization and system reliability for scheduled operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->