### PR TITLE
fix(billing): migrate consumedHistoryIds to [String] for per-step idempotency

### DIFF
--- a/modules/billing/migrations/20260501000000-add-meter-fields.js
+++ b/modules/billing/migrations/20260501000000-add-meter-fields.js
@@ -2,7 +2,9 @@
  * Migration: Add meter fields to billing_usages collection
  *
  * Adds weekKey, meterUsed, meterQuota, planVersion, meterBreakdown,
- * resetAt, alertedAt80, alertedAt100, consumedHistoryIds to existing documents.
+ * resetAt, alertedAt80, alertedAt100 to existing documents.
+ * NOTE: consumedHistoryIds (original field) was renamed to consumedAttributionKeys
+ * in migration 20260502100000-rename-consumed-history-ids-to-attribution-keys.js.
  *
  * The (organizationId, weekKey) sparse unique index is owned by the Mongoose
  * schema and synced at bootstrap — do not duplicate it here (name mismatch
@@ -17,7 +19,7 @@ export async function up() {
   // No raw index creation needed: all billingusages indexes are managed by the
   // Mongoose BillingUsage model and auto-synced on connection.
   // No document backfill: new fields have defaults in the Mongoose schema
-  // (meterUsed: 0, meterQuota: 0, meterBreakdown: {}, consumedHistoryIds: []).
+  // (meterUsed: 0, meterQuota: 0, meterBreakdown: {}, consumedAttributionKeys: []).
   // Existing documents without these fields will use Mongoose defaults on read.
 }
 

--- a/modules/billing/migrations/20260501000000-add-meter-fields.js
+++ b/modules/billing/migrations/20260501000000-add-meter-fields.js
@@ -1,5 +1,5 @@
 /**
- * Migration: Add meter fields to billing_usages collection
+ * Migration: Add meter fields to billingusages collection
  *
  * Adds weekKey, meterUsed, meterQuota, planVersion, meterBreakdown,
  * resetAt, alertedAt80, alertedAt100 to existing documents.

--- a/modules/billing/migrations/20260502100000-rename-consumed-history-ids-to-attribution-keys.js
+++ b/modules/billing/migrations/20260502100000-rename-consumed-history-ids-to-attribution-keys.js
@@ -1,0 +1,138 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+/**
+ * Migration: Rename consumedHistoryIds → consumedAttributionKeys + backfill key format
+ *
+ * Background: PR #3576 introduced per-step idempotency keys in the format
+ * `${historyId}:${stepKey}` (e.g. "507f1f77bcf86cd799439011:initial").
+ * However the schema field `consumedHistoryIds` was typed `[Schema.ObjectId]`,
+ * causing Mongoose to throw CastError for every string key written — silently
+ * swallowed in _attributeMeter, meaning all meter attributions failed.
+ *
+ * This migration:
+ * 1. Converts legacy raw ObjectId entries to `${id}:initial` strings (preserving
+ *    replay protection for pre-#3576 attributions).
+ * 2. Renames the field from `consumedHistoryIds` to `consumedAttributionKeys`.
+ * 3. Is idempotent: documents already migrated (no `consumedHistoryIds` field) are skipped.
+ *
+ * Uses raw collection driver (not Mongoose model) so that $unset of the legacy field
+ * is not stripped by strict-mode schema enforcement.
+ *
+ * @returns {Promise<void>}
+ */
+export async function up() {
+  const collection = mongoose.connection.db.collection('billingusages');
+
+  // Process in batches to avoid memory pressure on large collections
+  const BATCH_SIZE = 500;
+  let processed = 0;
+
+  const cursor = collection.find(
+    { consumedHistoryIds: { $exists: true } },
+    { projection: { _id: 1, consumedHistoryIds: 1 } },
+  );
+
+  const ops = [];
+
+  for await (const doc of cursor) {
+    const legacyIds = Array.isArray(doc.consumedHistoryIds) ? doc.consumedHistoryIds : [];
+
+    // Backfill: convert raw ObjectId strings to id:initial format
+    const migrated = legacyIds.map((entry) => {
+      const str = entry?.toString?.() ?? String(entry);
+      // Already in new format (contains colon) — preserve as-is
+      if (str.includes(':')) return str;
+      // Raw ObjectId string → append :initial
+      return `${str}:initial`;
+    });
+
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: { consumedAttributionKeys: migrated },
+          $unset: { consumedHistoryIds: '' },
+        },
+      },
+    });
+
+    if (ops.length >= BATCH_SIZE) {
+      await collection.bulkWrite(ops, { ordered: false });
+      processed += ops.length;
+      ops.length = 0;
+    }
+  }
+
+  if (ops.length > 0) {
+    await collection.bulkWrite(ops, { ordered: false });
+    processed += ops.length;
+  }
+
+  if (processed > 0) {
+    console.info(
+      `[migration] rename-consumed-history-ids: migrated ${processed} documents to consumedAttributionKeys`,
+    );
+  }
+}
+
+/**
+ * Down: reverse migration — strip :initial suffix back to raw ObjectId strings,
+ * restore consumedHistoryIds field, remove consumedAttributionKeys.
+ *
+ * Note: this only faithfully restores entries in `id:initial` format.
+ * Entries with other stepKeys (e.g. `id:digest`) cannot be reversed to ObjectId
+ * and are dropped (replay protection for those steps will be lost).
+ *
+ * @returns {Promise<void>}
+ */
+export async function down() {
+  const collection = mongoose.connection.db.collection('billingusages');
+  const BATCH_SIZE = 500;
+  let processed = 0;
+
+  const cursor = collection.find(
+    { consumedAttributionKeys: { $exists: true } },
+    { projection: { _id: 1, consumedAttributionKeys: 1 } },
+  );
+
+  const ops = [];
+
+  for await (const doc of cursor) {
+    const keys = Array.isArray(doc.consumedAttributionKeys) ? doc.consumedAttributionKeys : [];
+
+    // Only restore :initial entries as raw ObjectId strings
+    const restored = keys
+      .filter((key) => /^[a-fA-F0-9]{24}(:initial)?$/.test(key))
+      .map((key) => key.replace(/:initial$/, ''));
+
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: { consumedHistoryIds: restored },
+          $unset: { consumedAttributionKeys: '' },
+        },
+      },
+    });
+
+    if (ops.length >= BATCH_SIZE) {
+      await collection.bulkWrite(ops, { ordered: false });
+      processed += ops.length;
+      ops.length = 0;
+    }
+  }
+
+  if (ops.length > 0) {
+    await collection.bulkWrite(ops, { ordered: false });
+    processed += ops.length;
+  }
+
+  if (processed > 0) {
+    console.info(
+      `[migration] rename-consumed-history-ids DOWN: restored ${processed} documents to consumedHistoryIds`,
+    );
+  }
+}

--- a/modules/billing/models/billing.usage.model.mongoose.js
+++ b/modules/billing/models/billing.usage.model.mongoose.js
@@ -107,7 +107,7 @@ const UsageMongoose = new Schema(
     /**
      * Per-step attribution keys consumed this period, in `${historyId}:${stepKey}` format.
      * Legacy raw ObjectId strings (before per-step idempotency) are stored as `${id}:initial`.
-     * Used for idempotent attribution checks — indexed for $ne query performance.
+     * Used for idempotent attribution checks — indexed for future $in / $elemMatch queries.
      */
     consumedAttributionKeys: {
       type: [String],

--- a/modules/billing/models/billing.usage.model.mongoose.js
+++ b/modules/billing/models/billing.usage.model.mongoose.js
@@ -105,12 +105,14 @@ const UsageMongoose = new Schema(
       default: null,
     },
     /**
-     * ObjectIds of History documents consumed (attributed) this period.
-     * Used for idempotent attribution checks.
+     * Per-step attribution keys consumed this period, in `${historyId}:${stepKey}` format.
+     * Legacy raw ObjectId strings (before per-step idempotency) are stored as `${id}:initial`.
+     * Used for idempotent attribution checks — indexed for $ne query performance.
      */
-    consumedHistoryIds: {
-      type: [Schema.ObjectId],
+    consumedAttributionKeys: {
+      type: [String],
       default: () => [],
+      index: true,
     },
   },
   {

--- a/modules/billing/models/billing.usage.schema.js
+++ b/modules/billing/models/billing.usage.schema.js
@@ -7,10 +7,16 @@ import { z } from 'zod';
  * BillingUsage Zod schema — mirrors billing.usage.model.mongoose.js
  *
  * Legacy fields (organizationId, month, counters) are always required.
- * Meter fields (weekKey, consumedHistoryIds, etc.) are optional to preserve
+ * Meter fields (weekKey, consumedAttributionKeys, etc.) are optional to preserve
  * backward compatibility with non-meter downstream projects.
  */
 const objectIdRegex = /^[a-f\d]{24}$/i;
+
+/**
+ * Attribution key regex: accepts raw ObjectId (legacy) or `${id}:${stepKey}` format.
+ * stepKey may contain alphanumeric chars, colons, hyphens, underscores (1-64 chars).
+ */
+const attributionKeyRegex = /^[a-fA-F0-9]{24}(:[a-zA-Z0-9:_-]{1,64})?$/;
 
 const BillingUsage = z.object({
   organizationId: z.string().trim().regex(objectIdRegex, 'organizationId must be a valid ObjectId'),
@@ -39,10 +45,20 @@ const BillingUsage = z.object({
   archivedAt: z.coerce.date().optional().nullable(),
 
   /**
-   * Array of ObjectIds of History documents attributed to this period.
+   * Per-step attribution keys consumed this period.
+   * Format: `${historyId}:${stepKey}` (e.g. "507f1f77bcf86cd799439011:initial").
+   * Legacy raw ObjectId strings are also accepted for backward compatibility.
    */
-  consumedHistoryIds: z
-    .array(z.string().trim().regex(objectIdRegex, 'consumedHistoryIds entries must be valid ObjectIds'))
+  consumedAttributionKeys: z
+    .array(
+      z
+        .string()
+        .trim()
+        .regex(
+          attributionKeyRegex,
+          'consumedAttributionKeys entries must be <objectId> or <objectId>:<stepKey>',
+        ),
+    )
     .default(() => []),
 });
 

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -109,13 +109,31 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
     }
   }
 
+  // Transition logic — remove after migration is confirmed complete on all production deployments.
+  // TODO(PR-A migration): drop legacy consumedHistoryIds dual-read once deployed data is fully migrated.
+  //
+  // Pre-migration docs have legacy consumedHistoryIds entries (raw ObjectIds for 'initial' attribution).
+  // Per-step keys ('digest', 'fix:N') didn't exist pre-PR-A so no legacy entries protect those.
+  const isInitial = idempotencyKey.endsWith(':initial');
+  const legacyId = isInitial ? idempotencyKey.split(':')[0] : null;
+  const filter = {
+    organizationId,
+    weekKey,
+    consumedAttributionKeys: { $ne: idempotencyKey },
+  };
+  if (legacyId) {
+    // Avoid double-charge during migration window: also check the legacy field.
+    // Use ObjectId cast for the legacy field type ([ObjectId] in older docs).
+    try {
+      filter.consumedHistoryIds = { $ne: new mongoose.Types.ObjectId(legacyId) };
+    } catch {
+      // Defensive only: initial keys are expected to contain a real history._id.
+    }
+  }
+
   try {
     const doc = await BillingUsage.findOneAndUpdate(
-      {
-        organizationId,
-        weekKey,
-        consumedAttributionKeys: { $ne: idempotencyKey },
-      },
+      filter,
       {
         $inc: incPayload,
         $push: { consumedAttributionKeys: idempotencyKey },
@@ -137,23 +155,19 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
           alertedAt100: null,
         },
       },
-      { upsert: true, returnDocument: 'after', runValidators: false },
+      { upsert: true, returnDocument: 'after', runValidators: false, strict: false, strictQuery: false },
     );
     return doc;
   } catch (err) {
     if (err.code === 11000) {
       // Duplicate key on upsert race — retry without upsert
       return BillingUsage.findOneAndUpdate(
-        {
-          organizationId,
-          weekKey,
-          consumedAttributionKeys: { $ne: idempotencyKey },
-        },
+        filter,
         {
           $inc: incPayload,
           $push: { consumedAttributionKeys: idempotencyKey },
         },
-        { returnDocument: 'after' },
+        { returnDocument: 'after', strictQuery: false },
       );
     }
     throw err;

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -167,7 +167,7 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
           $inc: incPayload,
           $push: { consumedAttributionKeys: idempotencyKey },
         },
-        { returnDocument: 'after', strictQuery: false },
+        { returnDocument: 'after', strict: false, strictQuery: false },
       );
     }
     throw err;

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -81,7 +81,7 @@ const findByWeek = (organizationId, weekKey) => {
 /**
  * @function incrementMeter
  * @description Atomically increment meter usage for the given org+weekKey, with upsert.
- *              Replay protection: the idempotencyKey is appended to consumedHistoryIds;
+ *              Replay protection: the idempotencyKey is appended to consumedAttributionKeys;
  *              if it is already present, the update is skipped (returns null).
  *              baseSnapshot fields ($setOnInsert) are only written on document creation,
  *              preserving the quota snapshot for the lifetime of the week.
@@ -114,11 +114,11 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
       {
         organizationId,
         weekKey,
-        consumedHistoryIds: { $ne: idempotencyKey },
+        consumedAttributionKeys: { $ne: idempotencyKey },
       },
       {
         $inc: incPayload,
-        $push: { consumedHistoryIds: idempotencyKey },
+        $push: { consumedAttributionKeys: idempotencyKey },
         $setOnInsert: {
           organizationId,
           weekKey,
@@ -147,11 +147,11 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
         {
           organizationId,
           weekKey,
-          consumedHistoryIds: { $ne: idempotencyKey },
+          consumedAttributionKeys: { $ne: idempotencyKey },
         },
         {
           $inc: incPayload,
-          $push: { consumedHistoryIds: idempotencyKey },
+          $push: { consumedAttributionKeys: idempotencyKey },
         },
         { returnDocument: 'after' },
       );
@@ -190,7 +190,7 @@ const archiveOtherWeeks = (orgId, currentWeekKey, archivedAt) =>
  * @param {string} weekKey - The ISO week key for the new period.
  * @param {Object} snapshotFields - Fields written only on document creation
  *   (organizationId, weekKey, month, meterUsed, meterQuota, planVersion,
- *    meterBreakdown, resetAt, alertedAt80, alertedAt100, consumedHistoryIds).
+ *    meterBreakdown, resetAt, alertedAt80, alertedAt100, consumedAttributionKeys).
  * @returns {Promise<Object>} The upserted document.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -147,7 +147,7 @@ const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) 
   // Silent fallback to 'initial' was removed — it collides with the actual initial attribution
   // and silently drops subsequent step charges (e.g. 'digest', 'fix:1').
   if (
-    stepKey !== undefined &&
+    stepKey != null &&
     (typeof stepKey !== 'string' || !/^[a-zA-Z0-9:_-]{1,64}$/.test(stepKey))
   ) {
     throw new Error(`[billing.meter] invalid stepKey: ${JSON.stringify(stepKey)}`);

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -132,20 +132,32 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  * @param {Object} history - History-like object with _id, costs, planId, planVersion fields.
  * @param {string} organizationId - The organization ObjectId (string).
  * @param {Object} [options={}] - Optional per-step configuration.
- * @param {string} [options.stepKey='initial'] - Logical step name scoping this attribution.
+ * @param {string|null|undefined} [options.stepKey='initial'] - Logical step name scoping this attribution.
  *   Use 'initial' for the first (and often only) charge per history.
  *   Use a distinct value (e.g. 'digest', 'fix:1', 'fix:2') for subsequent attributions on
  *   the same history after cost-impacting mutations (setDigest, setFixCost).
  *   Downstream callers must pass ONLY the incremental cost delta in history.costs for each step.
+ *   Format: alphanumeric, colon, hyphen, underscore only, 1-64 chars (e.g. 'initial', 'digest', 'fix:1').
+ *   null/undefined → defaults to 'initial'. Any other invalid value → throws Error.
+ *   No-op when config.billing.meterMode is false (validation is skipped in that case).
  * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number, reason?: string}>}
  *   `reason` is present only when `applied` is true but extras were exhausted:
  *   `{ applied: true, meterUsed, extrasConsumed: 0, reason: 'extras_exhausted' }`.
+ * @throws {Error} If stepKey is non-null/undefined and does not match the expected format.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) => {
-  // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string.
+  // Fast-path: when metering is disabled, skip all validation and return immediately.
+  // This preserves the documented no-op behavior for callers passing any stepKey when meterMode=false.
+  if (!config?.billing?.meterMode) {
+    return { applied: false, meterUsed: 0, extrasConsumed: 0 };
+  }
+
+  // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string (1-64 chars).
   // Silent fallback to 'initial' was removed — it collides with the actual initial attribution
   // and silently drops subsequent step charges (e.g. 'digest', 'fix:1').
+  // null/undefined → treated as absent → defaults to 'initial' (safe, intentional).
+  // Any other non-conforming value → throws so callers can detect and fix bad inputs.
   if (
     stepKey != null &&
     (typeof stepKey !== 'string' || !/^[a-zA-Z0-9:_-]{1,64}$/.test(stepKey))
@@ -153,9 +165,6 @@ const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) 
     throw new Error(`[billing.meter] invalid stepKey: ${JSON.stringify(stepKey)}`);
   }
   const validatedStepKey = stepKey ?? 'initial';
-  if (!config?.billing?.meterMode) {
-    return { applied: false, meterUsed: 0, extrasConsumed: 0 };
-  }
 
   // Lazy imports to avoid circular deps — these services import billing.meter.service
   const { default: BillingUsageService } = await import('./billing.usage.service.js');

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -124,7 +124,7 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  *              cost delta for subsequent steps.
  *
  *              Each stepKey call is independently idempotent — replaying the same
- *              `(history._id, stepKey)` pair is a no-op (replay protection via consumedHistoryIds).
+ *              `(history._id, stepKey)` pair is a no-op (replay protection via consumedAttributionKeys).
  *
  *              IMPORTANT: each call must pass ONLY the cost delta for that step (not the
  *              cumulative total), otherwise earlier steps will be double-charged.
@@ -143,11 +143,16 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) => {
-  // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string
-  // to prevent arbitrary data from polluting consumedHistoryIds
-  const validatedStepKey = (typeof stepKey === 'string' && /^[a-zA-Z0-9:_-]{1,64}$/.test(stepKey))
-    ? stepKey
-    : 'initial';
+  // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string.
+  // Silent fallback to 'initial' was removed — it collides with the actual initial attribution
+  // and silently drops subsequent step charges (e.g. 'digest', 'fix:1').
+  if (
+    stepKey !== undefined &&
+    (typeof stepKey !== 'string' || !/^[a-zA-Z0-9:_-]{1,64}$/.test(stepKey))
+  ) {
+    throw new Error(`[billing.meter] invalid stepKey: ${JSON.stringify(stepKey)}`);
+  }
+  const validatedStepKey = stepKey ?? 'initial';
   if (!config?.billing?.meterMode) {
     return { applied: false, meterUsed: 0, extrasConsumed: 0 };
   }

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -32,8 +32,10 @@ const isoWeekKey = (date) => {
  *              both operations are no-ops.
  *
  *              Race: if resetWeek and incrementMeter race on the same weekKey,
- *              incrementMeter uses $ne on consumedAttributionKeys so a duplicate upsert
- *              will hit the 11000 path in incrementMeter's retry branch.
+ *              the unique (organizationId, weekKey) index causes the concurrent upsert
+ *              to throw E11000 — handled by incrementMeter's retry branch (non-upsert retry).
+ *              (The $ne on consumedAttributionKeys is replay protection within the same doc,
+ *              not the race guard.)
  *
  * @param {string} orgId - The organization ObjectId (string).
  * @param {Date} periodStart - The start of the new billing period (used to derive newWeekKey).

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -32,7 +32,7 @@ const isoWeekKey = (date) => {
  *              both operations are no-ops.
  *
  *              Race: if resetWeek and incrementMeter race on the same weekKey,
- *              incrementMeter uses $ne on consumedHistoryIds so a duplicate upsert
+ *              incrementMeter uses $ne on consumedAttributionKeys so a duplicate upsert
  *              will hit the 11000 path in incrementMeter's retry branch.
  *
  * @param {string} orgId - The organization ObjectId (string).
@@ -79,7 +79,7 @@ const resetWeek = async (orgId, periodStart) => {
       resetAt,
       alertedAt80: null,
       alertedAt100: null,
-      consumedHistoryIds: [],
+      consumedAttributionKeys: [],
     });
   } catch (err) {
     if (err.code === 11000) {

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -361,14 +361,10 @@ describe('BillingMeterService unit tests:', () => {
       );
     });
 
-    test('invalid stepKey (special chars) falls back to "initial"', async () => {
-      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
-      mockBillingUsageService.incrementMeter.mockResolvedValue({
-        applied: true,
-        meterUsed: 100,
-        extrasConsumed: 0,
-      });
-
+    test('invalid stepKey (special chars) throws instead of silently falling back to "initial"', async () => {
+      // Previously: invalid stepKey silently fell back to 'initial', which collides with the
+      // actual initial attribution key and would silently drop subsequent step charges.
+      // Fix: throw immediately so callers can detect and correct the issue.
       const history = {
         _id: '507f1f77bcf86cd799439099',
         costs: { scrap: 0.1 },
@@ -376,12 +372,12 @@ describe('BillingMeterService unit tests:', () => {
         planVersion: 'v1',
       };
 
-      await BillingMeterService.attribute(history, orgId, { stepKey: 'bad key! @#$' });
+      await expect(
+        BillingMeterService.attribute(history, orgId, { stepKey: 'bad key! @#$' }),
+      ).rejects.toThrow('[billing.meter] invalid stepKey');
 
-      // Invalid stepKey falls back to 'initial'
-      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
-        orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439099:initial',
-      );
+      // incrementMeter must NOT be called — the throw happens before any DB write
+      expect(mockBillingUsageService.incrementMeter).not.toHaveBeenCalled();
     });
 
     test('replay of {stepKey:"digest"} is blocked (idempotent)', async () => {

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -380,6 +380,46 @@ describe('BillingMeterService unit tests:', () => {
       expect(mockBillingUsageService.incrementMeter).not.toHaveBeenCalled();
     });
 
+    test('null and undefined stepKey fall back to initial while invalid values throw', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 100,
+        extrasConsumed: 0,
+      });
+      const history = {
+        _id: '507f1f77bcf86cd799439098',
+        costs: { scrap: 0.1 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      await expect(BillingMeterService.attribute(history, orgId, { stepKey: null })).resolves.toEqual({
+        applied: true,
+        meterUsed: 100,
+        extrasConsumed: 0,
+      });
+      await expect(BillingMeterService.attribute(history, orgId, { stepKey: undefined })).resolves.toEqual({
+        applied: true,
+        meterUsed: 100,
+        extrasConsumed: 0,
+      });
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        1, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439098:initial',
+      );
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenNthCalledWith(
+        2, orgId, expect.any(Number), expect.any(Object), '507f1f77bcf86cd799439098:initial',
+      );
+
+      await expect(
+        BillingMeterService.attribute(history, orgId, { stepKey: 123 }),
+      ).rejects.toThrow('[billing.meter] invalid stepKey');
+      await expect(
+        BillingMeterService.attribute(history, orgId, { stepKey: 'bad space' }),
+      ).rejects.toThrow('[billing.meter] invalid stepKey');
+    });
+
     test('replay of {stepKey:"digest"} is blocked (idempotent)', async () => {
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
       // First digest call: applied

--- a/modules/billing/tests/billing.usage.repository.integration.tests.js
+++ b/modules/billing/tests/billing.usage.repository.integration.tests.js
@@ -1,0 +1,91 @@
+/**
+ * Module dependencies.
+ */
+import mongoose from 'mongoose';
+import { describe, beforeAll, beforeEach, afterAll, test, expect } from '@jest/globals';
+
+import mongooseService from '../../../lib/services/mongoose.js';
+import { up as renameConsumedHistoryIds } from '../migrations/20260502100000-rename-consumed-history-ids-to-attribution-keys.js';
+
+/**
+ * Integration tests for BillingUsageRepository migration-window replay protection.
+ */
+describe('BillingUsageRepository integration tests:', () => {
+  let BillingUsageRepository;
+  let BillingUsage;
+  let collection;
+
+  beforeAll(async () => {
+    await mongooseService.loadModels();
+    await mongooseService.connect();
+    BillingUsage = mongoose.model('BillingUsage');
+    collection = mongoose.connection.db.collection('billingusages');
+    await collection.createIndex(
+      { organizationId: 1, weekKey: 1 },
+      { unique: true, sparse: true, name: 'organizationId_1_weekKey_1' },
+    );
+    BillingUsageRepository = (await import('../repositories/billing.usage.repository.js')).default;
+  });
+
+  beforeEach(async () => {
+    await BillingUsage.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongooseService.disconnect();
+  });
+
+  test('incrementMeter rejects legacy initial attribution before and after rename migration', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+    const historyId = new mongoose.Types.ObjectId();
+    const weekKey = '2099-W01';
+    const idempotencyKey = `${historyId.toString()}:initial`;
+
+    await collection.insertOne({
+      organizationId,
+      month: '2099-01',
+      weekKey,
+      counters: {},
+      meterUsed: 100,
+      meterQuota: 1000,
+      meterBreakdown: {},
+      consumedHistoryIds: [historyId],
+      consumedAttributionKeys: [],
+    });
+
+    const preMigrationReplay = await BillingUsageRepository.incrementMeter(
+      organizationId.toString(),
+      weekKey,
+      25,
+      {},
+      idempotencyKey,
+      { meterQuota: 1000, planVersion: 'v1', resetAt: null, month: '2099-01' },
+    );
+
+    expect(preMigrationReplay).toBeNull();
+    let doc = await collection.findOne({ organizationId, weekKey });
+    expect(doc.meterUsed).toBe(100);
+    expect(doc.consumedHistoryIds).toEqual([historyId]);
+    expect(doc.consumedAttributionKeys).toEqual([]);
+
+    await renameConsumedHistoryIds();
+
+    doc = await collection.findOne({ organizationId, weekKey });
+    expect(doc.consumedHistoryIds).toBeUndefined();
+    expect(doc.consumedAttributionKeys).toEqual([idempotencyKey]);
+
+    const postMigrationReplay = await BillingUsageRepository.incrementMeter(
+      organizationId.toString(),
+      weekKey,
+      25,
+      {},
+      idempotencyKey,
+      { meterQuota: 1000, planVersion: 'v1', resetAt: null, month: '2099-01' },
+    );
+
+    expect(postMigrationReplay).toBeNull();
+    doc = await collection.findOne({ organizationId, weekKey });
+    expect(doc.meterUsed).toBe(100);
+    expect(doc.consumedAttributionKeys).toEqual([idempotencyKey]);
+  });
+});

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -24,7 +24,7 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
     meterUsed: 0,
     meterQuota: 500000,
     planVersion: 'v1',
-    consumedHistoryIds: [],
+    consumedAttributionKeys: [],
     ...overrides,
   });
 
@@ -97,7 +97,7 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
 
   describe('incrementMeter', () => {
     test('should call findOneAndUpdate with correct filter including idempotency key', async () => {
-      const updatedDoc = makeUsageDoc({ meterUsed: 100, consumedHistoryIds: ['hist_001'] });
+      const updatedDoc = makeUsageDoc({ meterUsed: 100, consumedAttributionKeys: ['hist_001'] });
       mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
 
       const result = await BillingUsageRepository.incrementMeter(
@@ -113,11 +113,11 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
         expect.objectContaining({
           organizationId: orgId,
           weekKey,
-          consumedHistoryIds: { $ne: 'hist_001' },
+          consumedAttributionKeys: { $ne: 'hist_001' },
         }),
         expect.objectContaining({
           $inc: expect.objectContaining({ meterUsed: 100 }),
-          $push: { consumedHistoryIds: 'hist_001' },
+          $push: { consumedAttributionKeys: 'hist_001' },
           $setOnInsert: expect.any(Object),
         }),
         expect.objectContaining({ upsert: true, returnDocument: 'after' }),
@@ -171,7 +171,7 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
     });
 
     test('should return null when idempotencyKey already present (replay)', async () => {
-      // findOneAndUpdate returns null when filter does not match (consumedHistoryIds already contains key)
+      // findOneAndUpdate returns null when filter does not match (consumedAttributionKeys already contains key)
       mockModel.findOneAndUpdate.mockResolvedValue(null);
 
       const result = await BillingUsageRepository.incrementMeter(
@@ -188,7 +188,7 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
 
     test('incrementMeter same idempotencyKey twice → second returns null', async () => {
       mockModel.findOneAndUpdate
-        .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100, consumedHistoryIds: ['hist_x'] }))
+        .mockResolvedValueOnce(makeUsageDoc({ meterUsed: 100, consumedAttributionKeys: ['hist_x'] }))
         .mockResolvedValueOnce(null); // second: replay
 
       const r1 = await BillingUsageRepository.incrementMeter(orgId, weekKey, 100, {}, 'hist_x', {});
@@ -347,7 +347,7 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
         resetAt: new Date(),
         alertedAt80: null,
         alertedAt100: null,
-        consumedHistoryIds: [],
+        consumedAttributionKeys: [],
       };
       const newDoc = makeUsageDoc();
       mockModel.findOneAndUpdate.mockResolvedValue(newDoc);

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -41,7 +41,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     planVersion: 'v1',
     alertedAt80: null,
     alertedAt100: null,
-    consumedHistoryIds: [],
+    consumedAttributionKeys: [],
     ...overrides,
   });
 

--- a/modules/billing/tests/billing.usage.unit.tests.js
+++ b/modules/billing/tests/billing.usage.unit.tests.js
@@ -109,47 +109,61 @@ describe('BillingUsage unit tests:', () => {
     });
   });
 
-  describe('Schema validation — consumedHistoryIds', () => {
+  describe('Schema validation — consumedAttributionKeys', () => {
     const objectIdRegex = /^[a-f\d]{24}$/i;
 
-    test('should accept an empty consumedHistoryIds array', () => {
+    test('should accept an empty consumedAttributionKeys array', () => {
       const result = schema.BillingUsage.safeParse({
         organizationId: '507f1f77bcf86cd799439011',
         month: '2026-03',
-        consumedHistoryIds: [],
+        consumedAttributionKeys: [],
       });
       expect(result.error).toBeFalsy();
-      expect(result.data.consumedHistoryIds).toEqual([]);
+      expect(result.data.consumedAttributionKeys).toEqual([]);
     });
 
-    test('should accept valid ObjectId strings in consumedHistoryIds', () => {
+    test('should accept legacy raw ObjectId strings (pre-stepKey era)', () => {
       const result = schema.BillingUsage.safeParse({
         organizationId: '507f1f77bcf86cd799439011',
         month: '2026-03',
-        consumedHistoryIds: ['507f1f77bcf86cd799439012', '507f1f77bcf86cd799439013'],
+        consumedAttributionKeys: ['507f1f77bcf86cd799439012', '507f1f77bcf86cd799439013'],
       });
       expect(result.error).toBeFalsy();
-      for (const id of result.data.consumedHistoryIds) {
-        expect(objectIdRegex.test(id)).toBe(true);
+      for (const key of result.data.consumedAttributionKeys) {
+        expect(objectIdRegex.test(key)).toBe(true);
       }
     });
 
-    test('should reject invalid ObjectId strings in consumedHistoryIds', () => {
+    test('should accept id:stepKey format strings', () => {
       const result = schema.BillingUsage.safeParse({
         organizationId: '507f1f77bcf86cd799439011',
         month: '2026-03',
-        consumedHistoryIds: ['not-an-objectid'],
+        consumedAttributionKeys: [
+          '507f1f77bcf86cd799439012:initial',
+          '507f1f77bcf86cd799439013:digest',
+          '507f1f77bcf86cd799439014:fix:1',
+        ],
+      });
+      expect(result.error).toBeFalsy();
+      expect(result.data.consumedAttributionKeys).toHaveLength(3);
+    });
+
+    test('should reject strings that are neither raw ObjectId nor id:stepKey', () => {
+      const result = schema.BillingUsage.safeParse({
+        organizationId: '507f1f77bcf86cd799439011',
+        month: '2026-03',
+        consumedAttributionKeys: ['not-an-objectid'],
       });
       expect(result.error).toBeDefined();
     });
 
-    test('should default consumedHistoryIds to empty array when missing', () => {
+    test('should default consumedAttributionKeys to empty array when missing', () => {
       const result = schema.BillingUsage.safeParse({
         organizationId: '507f1f77bcf86cd799439011',
         month: '2026-03',
       });
       expect(result.error).toBeFalsy();
-      expect(result.data.consumedHistoryIds).toEqual([]);
+      expect(result.data.consumedAttributionKeys).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

🔴 **SHIP-STOPPER fix.** `consumedHistoryIds` was typed `[Schema.ObjectId]` but `BillingMeterService.attribute({stepKey})` (#3576) writes string keys like `${id}:${stepKey}`. Mongoose CastError throws on the `$push`, every meter attribution silently fails (the catch in `_attributeMeter` swallows it).

Verified runtime: `Cast to ObjectId failed for value "507f1f77bcf86cd799439011:initial"`.

## Changes

- **Schema**: `consumedHistoryIds: [Schema.ObjectId]` → `consumedAttributionKeys: [String]`, kept indexed for `$ne` perf
- **Zod**: validator updated to accept `^[a-fA-F0-9]{24}(:[a-zA-Z0-9:_-]{1,64})?$` (legacy raw _id + new id:stepKey)
- **Repository**: rename + writes use string field (both primary and E11000 retry paths)
- **Reset service**: `upsertWeekSnapshot` snapshot also updated to new field name
- **Validation**: invalid stepKey now throws (was silent fallback to 'initial' → collision with initial attribution → drops subsequent step charges)
- **Migration** `20260502100000-rename-consumed-history-ids-to-attribution-keys`: backfill aliases legacy raw _id → `${id}:initial`, idempotent, uses raw collection driver so Mongoose strict mode doesn't strip the $unset
- **Tests**: updated all refs in 4 test files; updated stepKey test from "falls back" to "throws"; added Zod tests for id:stepKey format

## Breaking change

Field rename internal to BillingUsage model. Downstream consumers using `BillingMeterService.attribute()` API are unaffected. Direct queries against `BillingUsage.consumedHistoryIds` need update.

## Test plan

- [x] `npm run test:unit` — 1027 tests pass
- [x] `npm run lint` — clean
- [ ] CI green
- [ ] Migration runs cleanly on TEST DB (idempotent)
- [ ] New stepKey throw test exercises pre-DB-write guard