### PR TITLE
fix(billing): meter hardening — version safety + zero-cost + API ergonomics

### DIFF
--- a/modules/billing/migrations/20260502110000-backfill-plan-version-snapshots.js
+++ b/modules/billing/migrations/20260502110000-backfill-plan-version-snapshots.js
@@ -1,0 +1,139 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+import config from '../../../config/index.js';
+
+const isPlainObject = (value) =>
+  value != null && typeof value === 'object' && !Array.isArray(value);
+
+const isNonEmptyRatios = (value) => isPlainObject(value) && Object.keys(value).length > 0;
+
+const configuredPlans = () => {
+  const byPlanId = new Map();
+
+  const definitions = config?.billing?.planDefinitions;
+  if (Array.isArray(definitions)) {
+    for (const def of definitions) {
+      if (def?.planId) byPlanId.set(def.planId, def);
+    }
+  }
+
+  const legacyPlans = config?.billing?.plans;
+  if (isPlainObject(legacyPlans)) {
+    for (const [planId, def] of Object.entries(legacyPlans)) {
+      byPlanId.set(planId, { ...(def ?? {}), planId });
+    }
+  }
+
+  return byPlanId;
+};
+
+const canonicalSnapshot = (planId, plansById) => {
+  const plan = plansById.get(planId);
+  if (!plan) return null;
+
+  const version = plan.version ?? config?.billing?.meter?.ratioVersion ?? null;
+  if (!version || !isNonEmptyRatios(plan.ratios) || typeof plan.meterQuota !== 'number') {
+    return null;
+  }
+
+  return {
+    version,
+    ratios: plan.ratios,
+    meterQuota: plan.meterQuota,
+  };
+};
+
+/**
+ * Migration: Backfill BillingPlan version snapshots from billing config.
+ *
+ * Repairs legacy BillingPlan docs missing a version or frozen ratios by applying
+ * the canonical configured snapshot for the same planId. Idempotent: documents
+ * already at the canonical version with non-empty ratios are skipped.
+ *
+ * @returns {Promise<void>}
+ */
+export async function up() {
+  const collection = mongoose.connection.db.collection('billingplans');
+  const plansById = configuredPlans();
+  const BATCH_SIZE = 500;
+  let processed = 0;
+  let skipped = 0;
+
+  const cursor = collection.find(
+    {
+      $or: [
+        { version: { $exists: false } },
+        { version: null },
+        { ratios: { $exists: false } },
+        { ratios: null },
+        { ratios: {} },
+      ],
+    },
+    { projection: { _id: 1, planId: 1, version: 1, ratios: 1 } },
+  );
+
+  const ops = [];
+
+  for await (const doc of cursor) {
+    const canonical = canonicalSnapshot(doc.planId, plansById);
+    if (!canonical) {
+      console.warn(
+        `[migration] backfill-plan-version-snapshots: missing canonical config for ${doc.planId}; skipping`,
+      );
+      skipped += 1;
+      continue;
+    }
+
+    if (doc.version === canonical.version && isNonEmptyRatios(doc.ratios)) {
+      skipped += 1;
+      continue;
+    }
+
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: {
+            version: canonical.version,
+            ratios: canonical.ratios,
+            meterQuota: canonical.meterQuota,
+          },
+        },
+      },
+    });
+
+    if (ops.length >= BATCH_SIZE) {
+      await collection.bulkWrite(ops, { ordered: false });
+      processed += ops.length;
+      ops.length = 0;
+    }
+  }
+
+  if (ops.length > 0) {
+    await collection.bulkWrite(ops, { ordered: false });
+    processed += ops.length;
+  }
+
+  if (processed > 0 || skipped > 0) {
+    console.info(
+      `[migration] backfill-plan-version-snapshots: backfilled ${processed} documents, skipped ${skipped}`,
+    );
+  }
+}
+
+/**
+ * Down: intentionally no-op.
+ *
+ * Reverting version snapshots can corrupt historical attribution because meter
+ * calculations depend on immutable (planId, version) ratios. Keep consistency
+ * and require manual intervention for any rollback.
+ *
+ * @returns {void}
+ */
+export function down() {
+  console.warn(
+    '[migration] backfill-plan-version-snapshots DOWN: no-op; preserving BillingPlan snapshots',
+  );
+}

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -6,7 +6,7 @@ import BillingPlanService from './billing.plan.service.js';
 
 /**
  * Floor charge per run — configurable via config.billing.meter.runBaseUnits.
- * Guarantees every attributed event costs at least 1 unit regardless of costs.
+ * Applies only when no cost data is available at all.
  */
 export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
 
@@ -17,11 +17,12 @@ export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
  *              dollar for each feature key.
  *
  *              Formula per key: floor(cost[key] * ratio[key] * dollarsToUnitRatio)
- *              Total: max(sum(per-key units), METER_RUN_BASE)
+ *              Total: sum(per-key units). Empty or zero-only cost maps return 0.
+ *              METER_RUN_BASE applies only when costs is null/undefined.
  *
- *              When getPlanByVersion returns null (version mismatch), logs a WARN and
- *              falls back to ratio=1 for all features. Check logs if charges look flat —
- *              this indicates meter.ratioVersion vs planDefinitions version drift.
+ *              When meterMode is enabled and getPlanByVersion returns null
+ *              (version mismatch), throws so attribution cannot silently bill with
+ *              ratio=1. When meterMode is disabled, keeps the legacy ratio=1 fallback.
  *
  * @param {Object} costs - Feature-keyed cost map: { featureKey: usdCost }.
  * @param {string} planId - Logical plan identifier (e.g. "pro").
@@ -30,15 +31,26 @@ export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const unitsFromCosts = async (costs, planId, ratioVersion) => {
-  if (!costs || typeof costs !== 'object') {
+  if (costs == null || typeof costs !== 'object') {
     return { totalUnits: METER_RUN_BASE, breakdown: {} };
   }
 
   const dollarsToUnitRatio = config?.billing?.meter?.dollarsToUnitRatio ?? 1000;
 
+  const hasBillableCost = Object.values(costs).some(
+    (cost) => typeof cost === 'number' && Number.isFinite(cost) && cost > 0,
+  );
+  if (!hasBillableCost) {
+    return { totalUnits: 0, breakdown: {} };
+  }
+
   // Fetch the frozen plan snapshot for the given version
   const plan = await BillingPlanService.getPlanByVersion(planId, ratioVersion);
   if (!plan) {
+    if (config?.billing?.meterMode) {
+      throw new Error(`[billing.meter] missing plan version snapshot for (${planId}, ${ratioVersion})`);
+    }
+
     // WARN: version mismatch likely — costs.config emits a version that has no matching BillingPlan.
     // Charges will use ratio=1 (flat) for all features. Align meter.ratioVersion + planDefinitions[].version
     // + downstream cost-config emitted version to resolve. See billing README — Version Namespace Contract.
@@ -63,9 +75,7 @@ const unitsFromCosts = async (costs, planId, ratioVersion) => {
     }
   }
 
-  const totalUnits = Math.max(rawTotal, METER_RUN_BASE);
-
-  return { totalUnits, breakdown };
+  return { totalUnits: rawTotal, breakdown };
 };
 
 /**
@@ -136,22 +146,44 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  *   Use 'initial' for the first (and often only) charge per history.
  *   Use a distinct value (e.g. 'digest', 'fix:1', 'fix:2') for subsequent attributions on
  *   the same history after cost-impacting mutations (setDigest, setFixCost).
- *   Downstream callers must pass ONLY the incremental cost delta in history.costs for each step.
+ *   Downstream callers must pass ONLY the incremental cost delta in history.costs for each step,
+ *   or use options.costsOverride to pass the delta directly.
  *   Format: alphanumeric, colon, hyphen, underscore only, 1-64 chars (e.g. 'initial', 'digest', 'fix:1').
  *   null/undefined → defaults to 'initial'. Any other invalid value → throws Error.
  *   No-op when config.billing.meterMode is false (validation is skipped in that case).
+ * @param {Object|null|undefined} [options.costsOverride=null] - Optional cost map to charge
+ *   instead of history.costs. Use for delta charging:
+ *   `attribute(history, orgId, { stepKey: 'digest', costsOverride: { digest: 0.5 } })`.
+ *   Empty or zero-only overrides return `{ applied: false, reason: 'zero_cost_skipped' }`
+ *   before writing the idempotency key.
+ * @param {Object|null|undefined} [options.costs=null] - Alias cost map used when
+ *   options.costsOverride is not provided. Prefer costsOverride for new delta-charge callers.
+ * @param {string|null|undefined} [options.planId=null] - Optional planId override for paths
+ *   where the history plan should not be used:
+ *   `attribute(history, orgId, { planId: 'override', ratioVersion: '2026.05' })`.
+ * @param {string|null|undefined} [options.ratioVersion=null] - Optional ratio snapshot override
+ *   paired with options.planId. Falls back to history.planVersion when omitted.
  * @returns {Promise<{applied: boolean, meterUsed: number, extrasConsumed: number, reason?: string}>}
- *   `reason` is present only when `applied` is true but extras were exhausted:
- *   `{ applied: true, meterUsed, extrasConsumed: 0, reason: 'extras_exhausted' }`.
+ *   `reason` is present for zero-cost skips and exhausted extras:
+ *   `{ applied: false, meterUsed: 0, extrasConsumed: 0, reason: 'zero_cost_skipped' }`
+ *   or `{ applied: true, meterUsed, extrasConsumed: 0, reason: 'extras_exhausted' }`.
  * @throws {Error} If stepKey is non-null/undefined and does not match the expected format.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) => {
+const attribute = async (history, organizationId, options = {}) => {
   // Fast-path: when metering is disabled, skip all validation and return immediately.
   // This preserves the documented no-op behavior for callers passing any stepKey when meterMode=false.
   if (!config?.billing?.meterMode) {
     return { applied: false, meterUsed: 0, extrasConsumed: 0 };
   }
+
+  const {
+    stepKey = 'initial',
+    costs: explicitCosts = null,
+    costsOverride = null,
+    planId: explicitPlanId = null,
+    ratioVersion: explicitRatioVersion = null,
+  } = options ?? {};
 
   // Validate stepKey: must be a non-empty alphanumeric+colon+hyphen+underscore string (1-64 chars).
   // Silent fallback to 'initial' was removed — it collides with the actual initial attribution
@@ -170,14 +202,15 @@ const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) 
   const { default: BillingUsageService } = await import('./billing.usage.service.js');
   const { default: BillingExtraService } = await import('./billing.extra.service.js');
 
-  const planId = history.planId ?? config?.billing?.plans?.[0] ?? 'pro';
-  const ratioVersion = history.planVersion ?? null;
+  const planId = explicitPlanId ?? history.planId ?? config?.billing?.plans?.[0] ?? 'pro';
+  const ratioVersion = explicitRatioVersion ?? history.planVersion ?? null;
+  const costs = costsOverride ?? explicitCosts ?? history.costs;
 
   let totalUnits = METER_RUN_BASE;
   let breakdown = {};
 
-  if (history.costs && ratioVersion) {
-    ({ totalUnits, breakdown } = await unitsFromCosts(history.costs, planId, ratioVersion));
+  if (costs && ratioVersion) {
+    ({ totalUnits, breakdown } = await unitsFromCosts(costs, planId, ratioVersion));
   }
 
   const maxUnits = config?.billing?.meter?.maxUnitsPerOperation ?? Infinity;
@@ -188,6 +221,10 @@ const attribute = async (history, organizationId, { stepKey = 'initial' } = {}) 
     console.warn(
       `[billing.meter] units capped: requested ${totalUnits}, cap ${maxUnits}, applied ${cappedUnits}`,
     );
+  }
+
+  if (cappedUnits === 0) {
+    return { applied: false, meterUsed: 0, extrasConsumed: 0, reason: 'zero_cost_skipped' };
   }
 
   const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${validatedStepKey}`;

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -162,6 +162,44 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
   throw lastErr;
 };
 
+const isDuplicateKeyError = (err) =>
+  err.code === 11000 || (err.message && err.message.includes('E11000'));
+
+/**
+ * @desc Resolve the configured immutable version for a plan definition.
+ *       Returns null when config does not pin a version and count-derived
+ *       backward-compat behavior should be used for first-time seeding.
+ * @param {Object} planDef - Configured plan definition without planId.
+ * @returns {string|null} Configured version, or null.
+ */
+const configuredVersion = (planDef) => planDef.version ?? config?.billing?.meter?.ratioVersion ?? null;
+
+/**
+ * @desc Create a configured plan snapshot, deriving a legacy vN version only
+ *       when config did not specify one.
+ * @param {string} planId - Logical plan identifier.
+ * @param {Object} planDef - Configured plan definition without planId.
+ * @param {string|null} [version=null] - Pre-resolved version to use.
+ * @returns {Promise<Object>} The created BillingPlan document.
+ */
+const createConfiguredPlan = async (planId, planDef, version = null) => {
+  let resolvedVersion = version;
+  if (!resolvedVersion) {
+    const total = await BillingPlanRepository.count(planId);
+    resolvedVersion = `v${total + 1}`;
+  }
+
+  return BillingPlanRepository.create({
+    planId,
+    version: resolvedVersion,
+    meterQuota: planDef.meterQuota ?? 0,
+    ratios: planDef.ratios ?? { default: 1 },
+    effectiveFrom: new Date(),
+    effectiveUntil: null,
+    active: true,
+  });
+};
+
 /**
  * @function ensureSeeded
  * @description Upsert BillingPlan docs from config.billing.planDefinitions.
@@ -196,38 +234,39 @@ const ensureSeeded = async () => {
 
   for (const def of definitions) {
     const { planId, ...planDef } = def;
+    const targetVersion = configuredVersion(planDef);
     const existing = await BillingPlanRepository.findActive(planId);
     if (existing) {
-      skipped += 1;
+      if (!targetVersion || existing.version === targetVersion) {
+        skipped += 1;
+        continue;
+      }
+
+      console.info(
+        `[billing.plan] version drift detected for ${planId}: active=${existing.version}, config=${targetVersion}; re-seeding`,
+      );
+      try {
+        await BillingPlanRepository.deactivateAll(planId, new Date());
+        await createConfiguredPlan(planId, planDef, targetVersion);
+        cache.delete(planId);
+        seeded += 1;
+      } catch (err) {
+        if (isDuplicateKeyError(err)) {
+          skipped += 1;
+          continue;
+        }
+        throw err;
+      }
       continue;
     }
 
     try {
-      // Version resolution priority:
-      // 1. Explicit version in planDefinitions entry (e.g. '2026.05' — YYYY.MM contract)
-      // 2. config.billing.meter.ratioVersion (canonical version emitted by attribute())
-      // 3. Derived from count (v${total + 1}) — full backward compat for projects without version config
-      let version = planDef.version ?? config?.billing?.meter?.ratioVersion ?? null;
-      if (!version) {
-        const total = await BillingPlanRepository.count(planId);
-        version = `v${total + 1}`;
-      }
-
-      await BillingPlanRepository.create({
-        planId,
-        version,
-        meterQuota: planDef.meterQuota ?? 0,
-        ratios: planDef.ratios ?? { default: 1 },
-        effectiveFrom: new Date(),
-        effectiveUntil: null,
-        active: true,
-      });
+      await createConfiguredPlan(planId, planDef, targetVersion);
       cache.delete(planId);
       seeded += 1;
     } catch (err) {
       // E11000: concurrent pod beat us to the insert — treat as skip, not fatal.
-      const isE11000 = err.code === 11000 || (err.message && err.message.includes('E11000'));
-      if (isE11000) {
+      if (isDuplicateKeyError(err)) {
         skipped += 1;
         continue;
       }

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -116,22 +116,37 @@ describe('BillingMeterService unit tests:', () => {
       expect(result.breakdown.unknown_feature).toBe(1);
     });
 
-    test('should enforce METER_RUN_BASE floor when costs are tiny', async () => {
+    test('should return zero when positive costs floor to zero units', async () => {
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
 
-      // 0.000001 * 1 * 1000 = 0.001 → floor = 0 → total = 0, floor to METER_RUN_BASE
+      // 0.000001 * 1 * 1000 = 0.001 → floor = 0
       const costs = { scrap: 0.000001 };
       const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
 
-      expect(result.totalUnits).toBe(1); // METER_RUN_BASE
+      expect(result.totalUnits).toBe(0);
+      expect(result.breakdown).toEqual({});
     });
 
-    test('should return METER_RUN_BASE when costs is empty object', async () => {
-      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan());
-
+    test('should return zero when costs is empty object', async () => {
       const result = await BillingMeterService.unitsFromCosts({}, 'pro', 'v1');
-      expect(result.totalUnits).toBe(1);
+      expect(result).toEqual({ totalUnits: 0, breakdown: {} });
+      expect(mockBillingPlanService.getPlanByVersion).not.toHaveBeenCalled();
+    });
+
+    test('should return zero when costs contains only zero values', async () => {
+      const result = await BillingMeterService.unitsFromCosts({ digest: 0 }, 'pro', 'v1');
+      expect(result.totalUnits).toBe(0);
       expect(result.breakdown).toEqual({});
+      expect(mockBillingPlanService.getPlanByVersion).not.toHaveBeenCalled();
+    });
+
+    test('should apply versioned ratio for non-zero digest costs', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { digest: 2 } }));
+
+      const result = await BillingMeterService.unitsFromCosts({ digest: 0.5 }, 'pro', 'v1');
+
+      expect(mockBillingPlanService.getPlanByVersion).toHaveBeenCalledWith('pro', 'v1');
+      expect(result).toEqual({ totalUnits: 1000, breakdown: { digest: 1000 } });
     });
 
     test('should return METER_RUN_BASE when costs is null', async () => {
@@ -139,18 +154,26 @@ describe('BillingMeterService unit tests:', () => {
       expect(result.totalUnits).toBe(1);
     });
 
-    test('should use ratio=1 when plan not found (null) and emit a WARN log', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    test('should throw when plan version is missing and meterMode is enabled', async () => {
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(null);
 
       const costs = { scrap: 0.001 };
-      const result = await BillingMeterService.unitsFromCosts(costs, 'pro', 'v1');
 
-      // ratio defaults to 1: floor(0.001 * 1 * 1000) = 1
-      expect(result.totalUnits).toBe(1);
-      // WARN must be emitted so operators notice the version drift
+      await expect(BillingMeterService.unitsFromCosts(costs, 'pro', 'nonexistent-version')).rejects.toThrow(
+        '[billing.meter] missing plan version snapshot for (pro, nonexistent-version)',
+      );
+    });
+
+    test('should use ratio=1 when plan not found and meterMode is disabled', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockConfig.billing.meterMode = false;
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(null);
+
+      const result = await BillingMeterService.unitsFromCosts({ scrap: 0.002 }, 'pro', 'nonexistent-version');
+
+      expect(result).toEqual({ totalUnits: 2, breakdown: { scrap: 2 } });
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[billing.meter] getPlanByVersion(pro, v1) returned null'),
+        expect.stringContaining('[billing.meter] getPlanByVersion(pro, nonexistent-version) returned null'),
       );
     });
 
@@ -267,6 +290,118 @@ describe('BillingMeterService unit tests:', () => {
   });
 
   describe('attribute — per-step idempotency keys', () => {
+    test('costsOverride empty object skips without writing idempotency key', async () => {
+      const history = {
+        _id: '507f1f77bcf86cd799439044',
+        costs: { scrap: 1 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const result = await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        costsOverride: {},
+      });
+
+      expect(result).toEqual({
+        applied: false,
+        meterUsed: 0,
+        extrasConsumed: 0,
+        reason: 'zero_cost_skipped',
+      });
+      expect(mockBillingUsageService.incrementMeter).not.toHaveBeenCalled();
+      expect(mockBillingExtraService.debit).not.toHaveBeenCalled();
+    });
+
+    test('costsOverride charges only the override delta', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1, digest: 2 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 1000,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439045',
+        costs: { scrap: 10 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const result = await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        costsOverride: { digest: 0.5 },
+      });
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        1000,
+        { digest: 1000 },
+        '507f1f77bcf86cd799439045:digest',
+      );
+      expect(result).toEqual({ applied: true, meterUsed: 1000, extrasConsumed: 0 });
+    });
+
+    test('options.costs is accepted as an alias when costsOverride is absent', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { digest: 2 } }));
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 1000,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439047',
+        costs: { scrap: 10 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        costs: { digest: 0.5 },
+      });
+
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        1000,
+        { digest: 1000 },
+        '507f1f77bcf86cd799439047:digest',
+      );
+    });
+
+    test('explicit planId and ratioVersion override history fields', async () => {
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(
+        makePlan({ planId: 'override', version: '2026.05', ratios: { digest: 3 } }),
+      );
+      mockBillingUsageService.incrementMeter.mockResolvedValue({
+        applied: true,
+        meterUsed: 1500,
+        extrasConsumed: 0,
+      });
+
+      const history = {
+        _id: '507f1f77bcf86cd799439046',
+        costs: { digest: 0.5 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        planId: 'override',
+        ratioVersion: '2026.05',
+      });
+
+      expect(mockBillingPlanService.getPlanByVersion).toHaveBeenCalledWith('override', '2026.05');
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        1500,
+        { digest: 1500 },
+        '507f1f77bcf86cd799439046:digest',
+      );
+    });
+
     test('same history attributed twice with default stepKey: 2nd is no-op (regression)', async () => {
       mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { scrap: 1 } }));
       // First call: applied

--- a/modules/billing/tests/billing.plan.backfill.integration.tests.js
+++ b/modules/billing/tests/billing.plan.backfill.integration.tests.js
@@ -1,0 +1,75 @@
+/**
+ * Module dependencies.
+ */
+import mongoose from 'mongoose';
+import { describe, beforeAll, beforeEach, afterAll, afterEach, test, expect, jest } from '@jest/globals';
+
+import mongooseService from '../../../lib/services/mongoose.js';
+import { up as backfillPlanVersionSnapshots } from '../migrations/20260502110000-backfill-plan-version-snapshots.js';
+
+/**
+ * Integration tests for BillingPlan snapshot backfill migration.
+ */
+describe('BillingPlan backfill migration integration tests:', () => {
+  let collection;
+
+  beforeAll(async () => {
+    await mongooseService.loadModels();
+    await mongooseService.connect();
+    collection = mongoose.connection.db.collection('billingplans');
+  });
+
+  beforeEach(async () => {
+    await collection.deleteMany({});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await mongooseService.disconnect();
+  });
+
+  test('backfills canonical version, ratios, and meterQuota when version is null', async () => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    await collection.insertOne({
+      planId: 'pro',
+      version: null,
+      meterQuota: 1,
+      ratios: {},
+      active: true,
+      effectiveFrom: new Date('2026-05-01T00:00:00.000Z'),
+      effectiveUntil: null,
+    });
+
+    await backfillPlanVersionSnapshots();
+
+    const doc = await collection.findOne({ planId: 'pro' });
+    expect(doc.version).toBe('2026.05');
+    expect(doc.ratios).toEqual({ default: 1 });
+    expect(doc.meterQuota).toBe(500000);
+  });
+
+  test('is idempotent when re-run after canonical snapshot is applied', async () => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    await collection.insertOne({
+      planId: 'starter',
+      version: null,
+      meterQuota: 1,
+      ratios: {},
+      active: true,
+      effectiveFrom: new Date('2026-05-01T00:00:00.000Z'),
+      effectiveUntil: null,
+    });
+
+    await backfillPlanVersionSnapshots();
+    const first = await collection.findOne({ planId: 'starter' });
+
+    await backfillPlanVersionSnapshots();
+    const second = await collection.findOne({ planId: 'starter' });
+
+    expect(second).toEqual(first);
+    expect(await collection.countDocuments({ planId: 'starter' })).toBe(1);
+  });
+});

--- a/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
+++ b/modules/billing/tests/billing.plan.ensureSeeded.unit.tests.js
@@ -175,6 +175,33 @@ describe('BillingPlanService.ensureSeeded unit tests:', () => {
     );
   });
 
+  test('active plan with different configured version is re-seeded', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    mockConfig.billing.planDefinitions = [
+      { planId: 'pro', meterQuota: 500000, ratios: { default: 2 }, version: '2026.05' },
+    ];
+    mockBillingPlanRepository.findActive.mockResolvedValue({ planId: 'pro', version: '2026.04' });
+    mockBillingPlanRepository.deactivateAll.mockResolvedValue({ modifiedCount: 1 });
+    mockBillingPlanRepository.create.mockResolvedValue({});
+
+    const result = await BillingPlanService.ensureSeeded();
+
+    expect(result).toEqual({ seeded: 1, skipped: 0 });
+    expect(mockBillingPlanRepository.deactivateAll).toHaveBeenCalledWith('pro', expect.any(Date));
+    expect(mockBillingPlanRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planId: 'pro',
+        version: '2026.05',
+        meterQuota: 500000,
+        ratios: { default: 2 },
+        active: true,
+      }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[billing.plan] version drift detected for pro: active=2026.04, config=2026.05; re-seeding',
+    );
+  });
+
   test('no explicit version + meter.ratioVersion in config → uses ratioVersion (YYYY.MM fallback)', async () => {
     mockConfig.billing.planDefinitions = [
       { planId: 'starter', meterQuota: 50000, ratios: { default: 1 } },


### PR DESCRIPTION
## Summary

Bundles 3 findings from the post-recalibration billing audit on the same `meter.service.js` surface:

- 🟠 **D**: Hard-fail on missing `(planId, ratioVersion)` snapshot in `meterMode` (was silent ratio=1 fallback → undercharge for non-1 ratios)
- 🟠 **E**: Zero-cost attribution returns 0, skips idempotency key write (was charging 1 unit METER_RUN_BASE for legitimate zero-cost steps)
- 🟡 **E**: `attribute()` accepts `{costs, planId, ratioVersion, stepKey, costsOverride}` options for explicit per-call overrides

## Changes

### meter.service.js
- `unitsFromCosts({})` and `unitsFromCosts({key: 0})` → `{ totalUnits: 0, breakdown: {} }`
- `unitsFromCosts(costs, planId, version)` throws on null `getPlanByVersion` when meterMode=true
- `attribute()` signature accepts options object (backward compat preserved)
- Skip `incrementMeter` and idempotency key write when `cappedUnits === 0`, return `{applied: false, reason: 'zero_cost_skipped'}`

### plan.service.js
- `ensureSeeded(planId)` detects version drift on existing active plans → re-seeds with INFO log

### Migration
- `20260502110000-backfill-plan-version-snapshots.js` — idempotent backfill of canonical `version` + `ratios` + `meterQuota` for plans missing them

### Tests
- Unit tests cover all new throw/skip paths + backward compat
- Integration tests cover backfill migration idempotency + ensureSeeded re-seeding

## Test plan

- [ ] CI green (unit + integration + e2e + lint)
- [ ] Migration runs cleanly on TEST DB
- [ ] No silent ratio=1 fallback in meterMode
- [ ] Zero-cost attribution preserves idempotency key for future delta charges