### PR TITLE
fix(billing): mega hardening v3 — atomicity + DRY + config

### DIFF
--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -125,7 +125,7 @@ billing: {
     preserveUsageDefault: true,
   },
   alerts: {
-    thresholdPercents: [80, 100],
+    thresholdPercents: [80, 100],  // only 80 and 100 are supported schema fields; other values warn and are skipped
   },
   events: {
     extrasExhausted: 'billing.extras_debit.exhausted',
@@ -155,7 +155,7 @@ export default {
       preserveUsageDefault: false,
     },
     alerts: {
-      thresholdPercents: [90, 100],
+      thresholdPercents: [80, 100],
     },
     events: {
       extrasExhausted: 'billing.extras_debit.exhausted',

--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -99,9 +99,72 @@ Consumers wanting clean-break behavior on downgrade should pass `{ preserveUsage
 
 ## Extras debit reliability
 
-`attribute()` returns optimistically after usage increment + outbox row insert. Extras debit happens out of band; if it fails, cron `retry-pending-extras-debit` reconciles within 5min. After 5 failed attempts, the outbox row is marked `failed` and event `billing.extras_debit.exhausted` is emitted for alerting.
+`attribute()` returns optimistically after usage increment + outbox row insert. Extras debit happens out of band; if it fails, cron `retry-pending-extras-debit` reconciles on the configured retry interval. After the configured failed-attempt limit, the outbox row is marked `failed` and the configured exhausted event is emitted for alerting.
 
 Consumers should NOT retry on `applied: true` — the outbox handles eventual consistency.
+
+## Meter hardening configuration
+
+Defaults live in `modules/billing/config/billing.development.config.js` and can be overridden by downstream project config:
+
+```js
+billing: {
+  meter: {
+    runBase: 1,
+    maxUnitsPerOperation: 10000,
+    fallbackPlanId: null,
+  },
+  outbox: {
+    maxRetryAttempts: 5,
+    retryIntervalSec: 300,
+  },
+  crons: {
+    jitterMaxMs: 60_000,
+  },
+  planChange: {
+    preserveUsageDefault: true,
+  },
+  alerts: {
+    thresholdPercents: [80, 100],
+  },
+  events: {
+    extrasExhausted: 'billing.extras_debit.exhausted',
+  },
+}
+```
+
+Example override:
+
+```js
+// config/defaults/production.config.js
+export default {
+  billing: {
+    meter: {
+      runBase: 2,
+      maxUnitsPerOperation: 25000,
+      fallbackPlanId: 'starter',
+    },
+    outbox: {
+      maxRetryAttempts: 8,
+      retryIntervalSec: 120,
+    },
+    crons: {
+      jitterMaxMs: 30_000,
+    },
+    planChange: {
+      preserveUsageDefault: false,
+    },
+    alerts: {
+      thresholdPercents: [90, 100],
+    },
+    events: {
+      extrasExhausted: 'billing.extras_debit.exhausted',
+    },
+  },
+};
+```
+
+`meter.runBaseUnits` is still accepted as a backward-compatible alias for `meter.runBase`.
 
 ## Stripe — `automatic_tax` flag
 

--- a/modules/billing/billing.init.js
+++ b/modules/billing/billing.init.js
@@ -6,6 +6,7 @@ import config from '../../config/index.js';
 import AnalyticsService from '../../lib/services/analytics.js';
 import billingEvents from './lib/events.js';
 import BillingPlanService from './services/billing.plan.service.js';
+import BillingUsageRepository from './repositories/billing.usage.repository.js';
 
 /**
  * Billing module initialisation.
@@ -29,7 +30,9 @@ export default async (app) => {
   billingEvents.on('plan.changed', ({ organizationId, newPlan }) => {
     try {
       AnalyticsService.groupIdentify('company', String(organizationId), { plan: newPlan });
-    } catch (_) { /* analytics must not break billing flow */ }
+    } catch (err) {
+      console.warn('[billing] analytics groupIdentify failed (non-fatal):', err?.message ?? err);
+    }
   });
 
   try {
@@ -49,6 +52,13 @@ export default async (app) => {
   // Runs after ensureSeeded so the plan catalog is up to date.
   // Never crashes boot — wrapped in try/catch.
   if (config?.billing?.meterMode) {
+    const legacyUsageCount = await BillingUsageRepository.countLegacyConsumedHistoryIds();
+    if (legacyUsageCount > 0) {
+      throw new Error(
+        `[billing] legacy consumedHistoryIds field still present on ${legacyUsageCount} usage document(s); run migration 20260502100000-rename-consumed-history-ids-to-attribution-keys before enabling meterMode`,
+      );
+    }
+
     try {
       const Subscription = mongoose.model('Subscription');
       const knownPlans = new Set(config.billing.plans ?? []);
@@ -58,8 +68,8 @@ export default async (app) => {
           console.warn(`[billing] Subscription.plan value "${plan}" not in planDefinitions — orphaned plan, may resolve quota=0`);
         }
       }
-    } catch (_err) {
-      // Validator failure must NOT crash boot (e.g. model not yet registered at early init)
+    } catch (err) {
+      console.warn('[billing] Subscription.plan boot validator failed (non-fatal):', err?.message ?? err);
     }
   }
 };

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -64,11 +64,14 @@ const config = {
      * Meter unit parameters — downstream projects must override with their
      * actual unit economics before enabling meterMode in production.
      *
-     * runBaseUnits: flat units charged per run (before per-feature ratios).
+     * runBase: flat units charged per run when no cost data is available.
+     * runBaseUnits: deprecated alias kept for downstream backward compatibility.
      * maxUnitsPerOperation: safety cap per single operation run.
      */
     meter: {
+      runBase: 1,
       runBaseUnits: 1,
+      fallbackPlanId: null,
       /**
        * Canonical version string emitted by billing.meter.service attribute() when writing
        * history.planVersion. Downstream projects MUST override this value and keep it
@@ -97,6 +100,22 @@ const config = {
        */
       dollarsToUnitRatio: 1000,
       maxUnitsPerOperation: 10000,
+    },
+    outbox: {
+      maxRetryAttempts: 5,
+      retryIntervalSec: 300,
+    },
+    crons: {
+      jitterMaxMs: 60_000,
+    },
+    planChange: {
+      preserveUsageDefault: true,
+    },
+    alerts: {
+      thresholdPercents: [80, 100],
+    },
+    events: {
+      extrasExhausted: 'billing.extras_debit.exhausted',
     },
     /**
      * Extra meter packs — downstream projects override with actual packs.

--- a/modules/billing/controllers/billing.controller.js
+++ b/modules/billing/controllers/billing.controller.js
@@ -7,10 +7,6 @@ import responses from '../../../lib/helpers/responses.js';
 import BillingService from '../services/billing.service.js';
 import BillingUsageService from '../services/billing.usage.service.js';
 import BillingExtraService from '../services/billing.extra.service.js';
-import BillingExtraBalanceRepository from '../repositories/billing.extraBalance.repository.js';
-
-// NOTE: BillingExtraBalance uses field name 'organization', BillingUsage uses 'organizationId' — both are Schema.ObjectId refs to Organization.
-// Only the field name differs (historical reasons) — keep queries consistent with each model's own convention.
 
 /**
  * @desc Endpoint to create a Stripe Checkout session
@@ -81,7 +77,7 @@ const getUsage = async (req, res) => {
     if (config.billing?.meterMode) {
       // Meter mode — return compute fields
       const meter = await BillingUsageService.getMeter(req.organization._id.toString());
-      const extrasRemaining = await BillingExtraBalanceRepository.getBalance(req.organization._id.toString());
+      const extrasRemaining = await BillingExtraService.getOrgBalanceContext(req.organization._id.toString());
       const packsAvailable = config.billing?.packs ?? [];
 
       return responses.success(res, 'billing usage')({
@@ -153,7 +149,7 @@ const extrasCheckout = async (req, res) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
 const extrasBalance = async (req, res) => {
   try {
-    const balance = await BillingExtraBalanceRepository.getBalance(req.organization._id.toString());
+    const balance = await BillingExtraService.getOrgBalanceContext(req.organization._id.toString());
     const packsAvailable = config.billing?.packs ?? [];
     responses.success(res, 'extras balance')({ balance, packsAvailable });
   } catch (err) {

--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -3,6 +3,7 @@
  */
 import config from '../../../config/index.js';
 import logger from '../../../lib/services/logger.js';
+import responses from '../../../lib/helpers/responses.js';
 import getStripe from '../lib/stripe.js';
 import BillingWebhookService from '../services/billing.webhook.service.js';
 
@@ -15,7 +16,9 @@ import BillingWebhookService from '../services/billing.webhook.service.js';
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
 const handleWebhook = async (req, res) => {
   const stripe = getStripe();
-  if (!stripe) return res.status(400).json({ error: 'Stripe is not configured' });
+  if (!stripe) {
+    return responses.error(res, 400, 'Bad Request', 'Stripe is not configured')(new Error('Stripe is not configured'));
+  }
 
   const sig = req.headers['stripe-signature'];
   const { webhookSecret } = config.stripe;
@@ -24,7 +27,7 @@ const handleWebhook = async (req, res) => {
   try {
     event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
   } catch (err) {
-    return res.status(400).json({ error: 'Webhook signature verification failed' });
+    return responses.error(res, 400, 'Bad Request', 'Webhook signature verification failed')(err);
   }
 
   try {
@@ -65,7 +68,7 @@ const handleWebhook = async (req, res) => {
     return res.status(200).json({ received: true });
   } catch (err) {
     logger.error('Stripe webhook handler error:', err);
-    return res.status(500).json({ error: 'Webhook handler failed' });
+    return responses.error(res, 500, 'Internal Server Error', 'Webhook handler failed')(err);
   }
 };
 

--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -59,19 +59,21 @@ Repeat the manifest for `billing.extrasExpiration.js` and `billing.dunningSweep.
 
 Devkit-shipped crons run on identical UTC schedules across all consumer deployments. To avoid thundering-herd against a shared DB or external API:
 
-### Recommended pattern — startup jitter
+### Built-in startup jitter
 
-These scripts are invoked once per CronJob execution and exit immediately after. Add a random delay at the top of your entrypoint to spread load across deployments:
+`billing.extrasExpiration.js`, `billing.dunningSweep.js`, and `retry-pending-extras-debit.cron.js` call `applyJitter(config.billing.crons.jitterMaxMs ?? 60000)` before doing work. Override the window per project:
 
 ```js
-// Wrap in an async IIFE — cron entrypoints are CommonJS, so top-level await is not available.
-// Jitter is re-randomized on each CronJob invocation — this is intentional for K8s CronJobs.
-// For a stable per-pod offset, derive from process.env.HOSTNAME instead (see note below).
-(async () => {
-  const jitterMs = Math.floor(Math.random() * 60_000); // 0–60s window
-  await new Promise(r => setTimeout(r, jitterMs));
-  await BillingResetService.resetAllDue();
-})();
+export default {
+  billing: {
+    crons: {
+      jitterMaxMs: 30_000,
+    },
+    outbox: {
+      retryIntervalSec: 120,
+    },
+  },
+};
 ```
 
 > **Stable per-pod jitter (optional):** If you want the same pod to always fire at the same offset within the window, derive jitter from the pod hostname instead of `Math.random()`. Use a distinct variable name to avoid shadowing if both snippets appear in the same file:

--- a/modules/billing/crons/billing.dunningSweep.js
+++ b/modules/billing/crons/billing.dunningSweep.js
@@ -17,9 +17,16 @@
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const [{ default: config }, { default: mongooseService }] = await Promise.all([
+const [
+  { default: config },
+  { default: mongooseService },
+  { applyJitter },
+  { getCronJitterMaxMs },
+] = await Promise.all([
   import('../../../config/index.js'),
   import('../../../lib/services/mongoose.js'),
+  import('../lib/billing.cron-utils.js'),
+  import('../lib/billing.constants.js'),
 ]);
 
 if (!config?.billing?.meterMode) {
@@ -28,6 +35,7 @@ if (!config?.billing?.meterMode) {
 }
 
 try {
+  await applyJitter(getCronJitterMaxMs());
   await mongooseService.connect();
 
   const [{ default: BillingSubscriptionRepository }, { default: OrganizationRepository }] = await Promise.all([

--- a/modules/billing/crons/billing.extrasExpiration.js
+++ b/modules/billing/crons/billing.extrasExpiration.js
@@ -14,9 +14,16 @@
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const [{ default: config }, { default: mongooseService }] = await Promise.all([
+const [
+  { default: config },
+  { default: mongooseService },
+  { applyJitter },
+  { getCronJitterMaxMs },
+] = await Promise.all([
   import('../../../config/index.js'),
   import('../../../lib/services/mongoose.js'),
+  import('../lib/billing.cron-utils.js'),
+  import('../lib/billing.constants.js'),
 ]);
 
 if (!config?.billing?.meterMode) {
@@ -25,6 +32,7 @@ if (!config?.billing?.meterMode) {
 }
 
 try {
+  await applyJitter(getCronJitterMaxMs());
   await mongooseService.connect();
 
   const [{ default: BillingExtraService }, { default: BillingExtraBalanceRepository }] =

--- a/modules/billing/crons/retry-pending-extras-debit.cron.js
+++ b/modules/billing/crons/retry-pending-extras-debit.cron.js
@@ -10,9 +10,16 @@
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const [{ default: config }, { default: mongooseService }] = await Promise.all([
+const [
+  { default: config },
+  { default: mongooseService },
+  { applyJitter },
+  { getCronJitterMaxMs, getOutboxRetryIntervalMs },
+] = await Promise.all([
   import('../../../config/index.js'),
   import('../../../lib/services/mongoose.js'),
+  import('../lib/billing.cron-utils.js'),
+  import('../lib/billing.constants.js'),
 ]);
 
 if (!config?.billing?.meterMode) {
@@ -20,16 +27,14 @@ if (!config?.billing?.meterMode) {
   process.exit(0);
 }
 
-const { randomInt } = await import('node:crypto');
-const jitterMs = randomInt(0, 60_000);
-await new Promise((resolve) => setTimeout(resolve, jitterMs));
+await applyJitter(getCronJitterMaxMs());
 
 try {
   await mongooseService.loadModels();
   await mongooseService.connect();
 
   const { default: BillingMeterOutboxService } = await import('../services/billing.meter.outbox.service.js');
-  const result = await BillingMeterOutboxService.retryPendingExtrasDebits(5 * 60 * 1000, 100);
+  const result = await BillingMeterOutboxService.retryPendingExtrasDebits(getOutboxRetryIntervalMs(), 100);
 
   console.log(
     `[billing.retryPendingExtrasDebit] done — scanned: ${result.scanned}, committed: ${result.committed}, failedAttempts: ${result.failedAttempts}, exhausted: ${result.exhausted}`,

--- a/modules/billing/lib/billing.constants.js
+++ b/modules/billing/lib/billing.constants.js
@@ -1,0 +1,93 @@
+/**
+ * Module dependencies
+ */
+import config from '../../../config/index.js';
+
+export const DEFAULT_METER_RUN_BASE = 1;
+export const DEFAULT_OUTBOX_MAX_RETRY_ATTEMPTS = 5;
+export const DEFAULT_OUTBOX_RETRY_INTERVAL_SEC = 300;
+export const DEFAULT_CRON_JITTER_MAX_MS = 60_000;
+export const DEFAULT_PLAN_CHANGE_PRESERVE_USAGE = true;
+export const DEFAULT_ALERT_THRESHOLD_PERCENTS = [80, 100];
+export const DEFAULT_EXTRAS_EXHAUSTED_EVENT = 'billing.extras_debit.exhausted';
+
+/**
+ * Floor charge per run. `runBaseUnits` is kept as a backward-compatible alias
+ * for downstream projects that already adopted the earlier config name.
+ */
+export const METER_RUN_BASE =
+  config?.billing?.meter?.runBase
+  ?? config?.billing?.meter?.runBaseUnits
+  ?? DEFAULT_METER_RUN_BASE;
+
+/**
+ * @function getMeterRunBase
+ * @description Resolve the configured base units charged when no costs are present.
+ * @returns {number} Meter run base units.
+ */
+export const getMeterRunBase = () =>
+  config?.billing?.meter?.runBase
+  ?? config?.billing?.meter?.runBaseUnits
+  ?? DEFAULT_METER_RUN_BASE;
+
+/**
+ * @function getMeterFallbackPlanId
+ * @description Resolve the configured fallback plan used by meter attribution.
+ * @returns {string|null} Fallback plan id, or null when no explicit fallback exists.
+ */
+export const getMeterFallbackPlanId = () =>
+  config?.billing?.meter?.fallbackPlanId
+  ?? config?.billing?.plans?.[0]
+  ?? 'pro';
+
+/**
+ * @function getOutboxMaxRetryAttempts
+ * @description Resolve the maximum number of retry attempts before an outbox row fails.
+ * @returns {number} Maximum retry attempts.
+ */
+export const getOutboxMaxRetryAttempts = () =>
+  config?.billing?.outbox?.maxRetryAttempts ?? DEFAULT_OUTBOX_MAX_RETRY_ATTEMPTS;
+
+/**
+ * @function getOutboxRetryIntervalMs
+ * @description Resolve the outbox retry interval in milliseconds.
+ * @returns {number} Retry interval in milliseconds.
+ */
+export const getOutboxRetryIntervalMs = () =>
+  (config?.billing?.outbox?.retryIntervalSec ?? DEFAULT_OUTBOX_RETRY_INTERVAL_SEC) * 1000;
+
+/**
+ * @function getCronJitterMaxMs
+ * @description Resolve the maximum startup jitter for billing cron scripts.
+ * @returns {number} Jitter maximum in milliseconds.
+ */
+export const getCronJitterMaxMs = () =>
+  config?.billing?.crons?.jitterMaxMs ?? DEFAULT_CRON_JITTER_MAX_MS;
+
+/**
+ * @function getPlanChangePreserveUsageDefault
+ * @description Resolve the default preserveUsage behavior for plan-change rotations.
+ * @returns {boolean} Whether plan-change rotation preserves usage by default.
+ */
+export const getPlanChangePreserveUsageDefault = () =>
+  config?.billing?.planChange?.preserveUsageDefault ?? DEFAULT_PLAN_CHANGE_PRESERVE_USAGE;
+
+/**
+ * @function getAlertThresholdPercents
+ * @description Resolve configured meter alert threshold percentages.
+ * @returns {number[]} Sorted threshold percentages.
+ */
+export const getAlertThresholdPercents = () => {
+  const thresholds = config?.billing?.alerts?.thresholdPercents ?? DEFAULT_ALERT_THRESHOLD_PERCENTS;
+  return thresholds
+    .filter((threshold) => Number.isFinite(threshold) && threshold > 0)
+    .sort((a, b) => b - a);
+};
+
+/**
+ * @function getExtrasExhaustedEventName
+ * @description Resolve the event name emitted when extras debit retries are exhausted.
+ * @returns {string} Billing extras exhausted event name.
+ */
+export const getExtrasExhaustedEventName = () =>
+  config?.billing?.events?.extrasExhausted ?? DEFAULT_EXTRAS_EXHAUSTED_EVENT;

--- a/modules/billing/lib/billing.cron-utils.js
+++ b/modules/billing/lib/billing.cron-utils.js
@@ -1,0 +1,23 @@
+/**
+ * Module dependencies
+ */
+import { randomInt } from 'node:crypto';
+
+/**
+ * @function applyJitter
+ * @description Sleep for a random number of milliseconds from 0 to maxMs.
+ * @param {number} maxMs - Exclusive upper bound for jitter in milliseconds.
+ * @returns {Promise<number>} The number of milliseconds slept.
+ */
+export const applyJitter = async (maxMs) => {
+  if (!Number.isFinite(maxMs) || maxMs <= 0) return 0;
+  const jitterMaxMs = Math.floor(maxMs);
+  if (jitterMaxMs <= 0) return 0;
+  const delayMs = randomInt(0, jitterMaxMs);
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+  return delayMs;
+};
+
+export default {
+  applyJitter,
+};

--- a/modules/billing/lib/billing.errors.js
+++ b/modules/billing/lib/billing.errors.js
@@ -1,0 +1,12 @@
+/**
+ * @function isDuplicateKeyError
+ * @description Identify Mongo duplicate-key errors across driver and string-only shapes.
+ * @param {Error|Object} err - Error object to inspect.
+ * @returns {boolean} True when the error represents E11000 duplicate key.
+ */
+export const isDuplicateKeyError = (err) =>
+  err?.code === 11000 || (typeof err?.message === 'string' && err.message.includes('E11000'));
+
+export default {
+  isDuplicateKeyError,
+};

--- a/modules/billing/lib/billing.isoWeek.js
+++ b/modules/billing/lib/billing.isoWeek.js
@@ -4,11 +4,13 @@
  * @param {Date} date - Date to compute.
  * @returns {string} ISO week key.
  */
+const MS_PER_DAY = 86_400_000;
+
 export const isoWeekKey = (date) => {
   const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  const weekNum = Math.ceil(((d - yearStart) / MS_PER_DAY + 1) / 7);
   return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
 };
 

--- a/modules/billing/lib/billing.isoWeek.js
+++ b/modules/billing/lib/billing.isoWeek.js
@@ -1,0 +1,25 @@
+/**
+ * @function isoWeekKey
+ * @description Compute the ISO 8601 week key in YYYY-Www format.
+ * @param {Date} date - Date to compute.
+ * @returns {string} ISO week key.
+ */
+export const isoWeekKey = (date) => {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+};
+
+/**
+ * @function currentWeekKey
+ * @description Compute the current ISO 8601 week key in YYYY-Www format.
+ * @returns {string} Current ISO week key.
+ */
+export const currentWeekKey = () => isoWeekKey(new Date());
+
+export default {
+  currentWeekKey,
+  isoWeekKey,
+};

--- a/modules/billing/lib/events.js
+++ b/modules/billing/lib/events.js
@@ -11,7 +11,7 @@ import { EventEmitter } from 'events';
  *     Payload: { organizationId, previousPlan, newPlan, subscription, isDowngrade }
  *   - `billing.plan_change.rotated` — emitted after current-week meter snapshot refresh
  *     Payload: { organizationId, oldQuota, newQuota, oldVersion, newVersion, preserveUsage }
- *   - `billing.extras_debit.exhausted` — emitted when outbox extras debit retries fail 5 times
+ *   - `billing.extras_debit.exhausted` — emitted when outbox extras debit retries exhaust
  *     Payload: { organizationId, idempotencyKey, extrasUnits, attempts, lastError }
  *   - `payment.failed`  — emitted when an invoice payment fails (pastDueSince set on first failure)
  *     Payload: { organizationId }

--- a/modules/billing/models/billing.meter.outbox.model.mongoose.js
+++ b/modules/billing/models/billing.meter.outbox.model.mongoose.js
@@ -11,16 +11,18 @@ const Schema = mongoose.Schema;
  * Stores deferred extras debits created after meter usage crosses plan quota.
  * Pending rows are retried by the billing retry-pending-extras-debit cron.
  */
-const BillingMeterOutboxMongoose = new Schema({
-  organizationId: { type: Schema.ObjectId, required: true, index: true },
-  idempotencyKey: { type: String, required: true, unique: true },
-  extrasUnits: { type: Number, required: true },
-  status: { type: String, enum: ['pending', 'committed', 'failed'], default: 'pending', index: true },
-  attempts: { type: Number, default: 0 },
-  lastError: { type: String, default: null },
-  lastAttemptedAt: { type: Date, default: null },
-  createdAt: { type: Date, default: () => new Date() },
-});
+const BillingMeterOutboxMongoose = new Schema(
+  {
+    organizationId: { type: Schema.ObjectId, required: true, index: true },
+    idempotencyKey: { type: String, required: true, unique: true },
+    extrasUnits: { type: Number, required: true },
+    status: { type: String, enum: ['pending', 'committed', 'failed'], default: 'pending', index: true },
+    attempts: { type: Number, default: 0 },
+    lastError: { type: String, default: null },
+    lastAttemptedAt: { type: Date, default: null },
+  },
+  { timestamps: true },
+);
 
 BillingMeterOutboxMongoose.index({ status: 1, lastAttemptedAt: 1 });
 

--- a/modules/billing/models/billing.meter.outbox.schema.js
+++ b/modules/billing/models/billing.meter.outbox.schema.js
@@ -20,6 +20,7 @@ const BillingMeterOutbox = z.object({
   lastError: z.string().nullable().default(null),
   lastAttemptedAt: z.coerce.date().nullable().default(null),
   createdAt: z.coerce.date().optional(),
+  updatedAt: z.coerce.date().optional(),
 });
 
 const BillingMeterOutboxCreate = z.object({

--- a/modules/billing/models/billing.processedStripeEvent.schema.js
+++ b/modules/billing/models/billing.processedStripeEvent.schema.js
@@ -1,0 +1,24 @@
+/**
+ * Module dependencies
+ */
+import { z } from 'zod';
+
+/**
+ * ProcessedStripeEvent Zod schema — mirrors billing.processedStripeEvent.model.mongoose.js
+ */
+
+const ProcessedStripeEvent = z.object({
+  eventId: z.string().trim().min(1, 'eventId is required'),
+  type: z.string().trim().min(1, 'type is required'),
+  processedAt: z.coerce.date().default(() => new Date()),
+});
+
+const ProcessedStripeEventCreate = z.object({
+  eventId: z.string().trim().min(1, 'eventId is required'),
+  type: z.string().trim().min(1, 'type is required'),
+});
+
+export default {
+  ProcessedStripeEvent,
+  ProcessedStripeEventCreate,
+};

--- a/modules/billing/policies/billing.policy.js
+++ b/modules/billing/policies/billing.policy.js
@@ -33,11 +33,9 @@ export function billingSubjectRegistration({ registerPathSubject }) {
  * @param {Object|null} membership - Optional organization membership
  * @param {Object} builder - CASL AbilityBuilder helpers
  * @param {Function} builder.can - Grant an ability
- * @param {Function} builder.cannot - Deny an ability
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
-export function billingAbilities(user, membership, { can, cannot }) {
+export function billingAbilities(user, membership, { can }) {
   if (Array.isArray(user?.roles) && user.roles.includes('admin')) {
     can('manage', 'all');
     return;

--- a/modules/billing/repositories/billing.meter.outbox.repository.js
+++ b/modules/billing/repositories/billing.meter.outbox.repository.js
@@ -2,6 +2,7 @@
  * Module dependencies
  */
 import mongoose from 'mongoose';
+import { getOutboxMaxRetryAttempts } from '../lib/billing.constants.js';
 
 /**
  * @function BillingMeterOutbox
@@ -62,6 +63,16 @@ const findPendingDue = (thresholdMs = 5 * 60 * 1000, limit = 100) => {
 };
 
 /**
+ * @function findByIdempotencyKey
+ * @description Fetch an outbox row by its idempotency key.
+ * @param {string} idempotencyKey - Usage attribution idempotency key.
+ * @returns {Promise<Object|null>} Matching outbox row or null.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const findByIdempotencyKey = (idempotencyKey) =>
+  BillingMeterOutbox().findOne({ idempotencyKey }).lean();
+
+/**
  * @function markCommitted
  * @description Mark an outbox row as committed after a successful extras debit.
  *              The `status:'pending'` filter makes this idempotent: committed or
@@ -90,34 +101,37 @@ const markCommitted = (id) =>
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const markFailedAttempt = async (id, error) => {
   const message = error?.message ?? String(error);
-  const doc = await BillingMeterOutbox().findOneAndUpdate(
-    { _id: id, status: 'pending' },
-    {
-      $inc: { attempts: 1 },
-      $set: {
-        lastError: message,
-        lastAttemptedAt: new Date(),
-      },
-    },
-    { returnDocument: 'after' },
-  ).lean();
+  const attemptedAt = new Date();
+  const maxRetryAttempts = getOutboxMaxRetryAttempts();
 
-  if (!doc) return null;
-  if (doc.attempts >= 5) {
-    // Atomic exhaustion transition: filter on status:'pending' ensures only
-    // the first concurrent caller wins the status flip and owns the event emit.
-    return BillingMeterOutbox().findOneAndUpdate(
-      { _id: id, status: 'pending' },
-      { $set: { status: 'failed' } },
-      { returnDocument: 'after' },
-    ).lean();
-  }
-  return doc;
+  const nextAttempts = { $add: [{ $ifNull: ['$attempts', 0] }, 1] };
+
+  return BillingMeterOutbox().findOneAndUpdate(
+    { _id: id, status: 'pending' },
+    [
+      {
+        $set: {
+          attempts: nextAttempts,
+          lastError: message,
+          lastAttemptedAt: attemptedAt,
+          status: {
+            $cond: [
+              { $gte: [nextAttempts, maxRetryAttempts] },
+              'failed',
+              '$status',
+            ],
+          },
+        },
+      },
+    ],
+    { returnDocument: 'after', updatePipeline: true },
+  ).lean();
 };
 
 export default {
   create,
   findPendingDue,
+  findByIdempotencyKey,
   markCommitted,
   markFailedAttempt,
 };

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -2,6 +2,7 @@
  * Module dependencies
  */
 import mongoose from 'mongoose';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 /**
  * Lazily resolves the ProcessedStripeEvent Mongoose model.
@@ -34,7 +35,7 @@ const tryRecord = async (eventId, type) => {
     await ProcessedStripeEvent().create({ eventId, type, processedAt: new Date() });
     return { recorded: true };
   } catch (err) {
-    if (err.code === 11000) {
+    if (isDuplicateKeyError(err)) {
       return { recorded: false };
     }
     throw err;

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -124,26 +124,6 @@ const findPlan = (organizationId) => {
 };
 
 /**
- * @function findAllDueForReset
- * @description Fetch active/trialing subscriptions whose currentPeriodStart falls
- *              within the provided time window. Used by the weekly meter reset sweep.
- *              Returns lean plain objects (no population) for performance.
- * @deprecated Prefer findAllDueForResetByLastReset() for scheduler-delay resilience.
- * @param {Date} from - The start of the window (inclusive).
- * @param {Date} to - The end of the window (inclusive).
- * @returns {Promise<Array<{organization: string, currentPeriodStart: Date}>>}
- */
-// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
-const findAllDueForReset = (from, to) =>
-  Subscription.find(
-    {
-      status: { $in: ['active', 'trialing'] },
-      currentPeriodStart: { $gte: from, $lte: to },
-    },
-    { organization: 1, currentPeriodStart: 1 },
-  ).lean();
-
-/**
  * @function findAllDueForResetByLastReset
  * @description Fetch active/trialing subscriptions whose last successful reset is missing
  *              or older than 7 days. Filters out subscriptions without currentPeriodStart
@@ -237,7 +217,6 @@ export default {
   findPlan,
   findByStripeCustomerId,
   findByStripeSubscriptionId,
-  findAllDueForReset,
   findAllDueForResetByLastReset,
   updateLastResetAt,
   findStaleDunning,

--- a/modules/billing/repositories/billing.usage.repository.js
+++ b/modules/billing/repositories/billing.usage.repository.js
@@ -2,6 +2,7 @@
  * Module dependencies
  */
 import mongoose from 'mongoose';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 const BillingUsage = mongoose.model('BillingUsage');
 
@@ -38,7 +39,7 @@ const increment = async (organizationId, month, key, amount) => {
       { upsert: true, returnDocument: 'after', runValidators: true },
     ).exec();
   } catch (err) {
-    if (err.code === 11000) {
+    if (isDuplicateKeyError(err)) {
       return BillingUsage.findOneAndUpdate(
         { organizationId, month },
         { $inc: { [`counters.${key}`]: amount } },
@@ -112,27 +113,11 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
   }
   const hasBreakdownIncrements = Object.keys(incPayload).some((key) => key.startsWith('meterBreakdown.'));
 
-  // Transition logic — remove after migration is confirmed complete on all production deployments.
-  // TODO(PR-A migration): drop legacy consumedHistoryIds dual-read once deployed data is fully migrated.
-  //
-  // Pre-migration docs have legacy consumedHistoryIds entries (raw ObjectIds for 'initial' attribution).
-  // Per-step keys ('digest', 'fix:N') didn't exist pre-PR-A so no legacy entries protect those.
-  const isInitial = idempotencyKey.endsWith(':initial');
-  const legacyId = isInitial ? idempotencyKey.split(':')[0] : null;
   const filter = {
     organizationId,
     weekKey,
     consumedAttributionKeys: { $ne: idempotencyKey },
   };
-  if (legacyId) {
-    // Avoid double-charge during migration window: also check the legacy field.
-    // Use ObjectId cast for the legacy field type ([ObjectId] in older docs).
-    try {
-      filter.consumedHistoryIds = { $ne: new mongoose.Types.ObjectId(legacyId) };
-    } catch {
-      // Defensive only: initial keys are expected to contain a real history._id.
-    }
-  }
 
   try {
     const doc = await BillingUsage.findOneAndUpdate(
@@ -169,7 +154,7 @@ const incrementMeter = async (organizationId, weekKey, units, breakdown, idempot
     );
     return doc;
   } catch (err) {
-    if (err.code === 11000) {
+    if (isDuplicateKeyError(err)) {
       // Duplicate key on upsert race — retry without upsert
       return BillingUsage.findOneAndUpdate(
         filter,
@@ -279,6 +264,15 @@ const markThreshold = (docId, field) =>
     { $set: { [field]: new Date() } },
   );
 
+/**
+ * @function countLegacyConsumedHistoryIds
+ * @description Count usage documents that still carry the removed legacy migration field.
+ * @returns {Promise<number>} Number of documents with consumedHistoryIds present.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const countLegacyConsumedHistoryIds = () =>
+  BillingUsage.countDocuments({ consumedHistoryIds: { $exists: true } });
+
 export default {
   get,
   increment,
@@ -289,4 +283,5 @@ export default {
   upsertWeekSnapshot,
   rotateWeekSnapshotForPlanChange,
   markThreshold,
+  countLegacyConsumedHistoryIds,
 };

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -48,6 +48,16 @@ const debit = (orgId, units, refId) =>
   BillingExtraBalanceRepository.debit(orgId, units, refId);
 
 /**
+ * @function getOrgBalanceContext
+ * @description Return the current extra balance for an organization.
+ * @param {string} orgId - The organization ObjectId (string).
+ * @returns {Promise<number>} Current cached extras balance.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const getOrgBalanceContext = (orgId) =>
+  BillingExtraBalanceRepository.getBalance(orgId);
+
+/**
  * @function expireOldEntries
  * @description Sweep expired topup entries for an organization and push
  *              corresponding expiration ledger entries to reduce the balance.
@@ -172,6 +182,7 @@ const listLedger = async (orgId, { page = 1, limit = 20 } = {}) => {
 export default {
   creditPack,
   debit,
+  getOrgBalanceContext,
   expireOldEntries,
   refundPartial,
   listLedger,

--- a/modules/billing/services/billing.meter.outbox.service.js
+++ b/modules/billing/services/billing.meter.outbox.service.js
@@ -4,6 +4,7 @@
 import BillingMeterOutboxRepository from '../repositories/billing.meter.outbox.repository.js';
 import BillingExtraService from './billing.extra.service.js';
 import billingEvents from '../lib/events.js';
+import { getExtrasExhaustedEventName, getOutboxMaxRetryAttempts } from '../lib/billing.constants.js';
 
 /**
  * @function emitExhausted
@@ -16,8 +17,9 @@ import billingEvents from '../lib/events.js';
  * @returns {void}
  */
 const emitExhausted = (row, updated) => {
+  const eventName = getExtrasExhaustedEventName();
   try {
-    billingEvents.emit('billing.extras_debit.exhausted', {
+    billingEvents.emit(eventName, {
       organizationId: String(row.organizationId),
       idempotencyKey: row.idempotencyKey,
       extrasUnits: row.extrasUnits,
@@ -26,9 +28,18 @@ const emitExhausted = (row, updated) => {
     });
   } catch (evtErr) {
     // Listener errors must not disrupt outbox retry accounting — log for traceability
-    console.error('[billing.outbox] billing.extras_debit.exhausted listener error (non-fatal):', evtErr?.message ?? evtErr);
+    console.error(`[billing.outbox] ${eventName} listener error (non-fatal):`, evtErr?.message ?? evtErr);
   }
 };
+
+/**
+ * @function shouldEmitExhausted
+ * @description Check whether a failed row is exactly on the transition attempt.
+ * @param {Object|null} updated - Updated outbox row returned by markFailedAttempt.
+ * @returns {boolean} True when the caller owns the exhausted transition.
+ */
+const shouldEmitExhausted = (updated) =>
+  updated?.status === 'failed' && updated.attempts === getOutboxMaxRetryAttempts();
 
 /**
  * @function retryPendingExtrasDebits
@@ -62,14 +73,14 @@ const retryPendingExtrasDebits = async (thresholdMs = 5 * 60 * 1000, limit = 100
 
       const updated = await BillingMeterOutboxRepository.markFailedAttempt(row._id, 'extras debit not applied');
       failedAttempts += 1;
-      if (updated?.status === 'failed') {
+      if (shouldEmitExhausted(updated)) {
         exhausted += 1;
         emitExhausted(row, updated);
       }
     } catch (err) {
       const updated = await BillingMeterOutboxRepository.markFailedAttempt(row._id, err);
       failedAttempts += 1;
-      if (updated?.status === 'failed') {
+      if (shouldEmitExhausted(updated)) {
         exhausted += 1;
         emitExhausted(row, updated);
       }

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -3,12 +3,12 @@
  */
 import config from '../../../config/index.js';
 import BillingPlanService from './billing.plan.service.js';
+import BillingUsageService from './billing.usage.service.js';
+import BillingExtraService from './billing.extra.service.js';
+import BillingMeterOutboxRepository from '../repositories/billing.meter.outbox.repository.js';
+import { getMeterFallbackPlanId, getMeterRunBase, METER_RUN_BASE } from '../lib/billing.constants.js';
 
-/**
- * Floor charge per run — configurable via config.billing.meter.runBaseUnits.
- * Applies only when no cost data is available at all.
- */
-export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
+export { METER_RUN_BASE };
 
 /**
  * @function unitsFromCosts
@@ -32,7 +32,7 @@ export const METER_RUN_BASE = config?.billing?.meter?.runBaseUnits ?? 1;
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const unitsFromCosts = async (costs, planId, ratioVersion) => {
   if (costs == null || typeof costs !== 'object') {
-    return { totalUnits: METER_RUN_BASE, breakdown: {} };
+    return { totalUnits: getMeterRunBase(), breakdown: {} };
   }
 
   const dollarsToUnitRatio = config?.billing?.meter?.dollarsToUnitRatio ?? 1000;
@@ -44,19 +44,29 @@ const unitsFromCosts = async (costs, planId, ratioVersion) => {
     return { totalUnits: 0, breakdown: {} };
   }
 
-  // Fetch the frozen plan snapshot for the given version
-  const plan = await BillingPlanService.getPlanByVersion(planId, ratioVersion);
-  if (!plan) {
+  if (!ratioVersion) {
+    const message = '[billing.meter] non-null costs without ratioVersion in meterMode';
     if (config?.billing?.meterMode) {
+      throw new Error(message);
+    }
+    console.warn(message);
+  }
+
+  // Fetch the frozen plan snapshot for the given version
+  const plan = ratioVersion ? await BillingPlanService.getPlanByVersion(planId, ratioVersion) : null;
+  if (!plan) {
+    if (config?.billing?.meterMode && ratioVersion) {
       throw new Error(`[billing.meter] missing plan version snapshot for (${planId}, ${ratioVersion})`);
     }
 
     // WARN: version mismatch likely — costs.config emits a version that has no matching BillingPlan.
-    // Charges will use ratio=1 (flat) for all features. Align meter.ratioVersion + planDefinitions[].version
-    // + downstream cost-config emitted version to resolve. See billing README — Version Namespace Contract.
-    console.warn(
-      `[billing.meter] getPlanByVersion(${planId}, ${ratioVersion}) returned null — ratio=1 fallback applied. Check version namespace alignment.`,
-    );
+    if (ratioVersion) {
+      // Charges will use ratio=1 (flat) for all features. Align meter.ratioVersion + planDefinitions[].version
+      // + downstream cost-config emitted version to resolve. See billing README — Version Namespace Contract.
+      console.warn(
+        `[billing.meter] getPlanByVersion(${planId}, ${ratioVersion}) returned null — ratio=1 fallback applied. Check version namespace alignment.`,
+      );
+    }
   }
   const ratios = (plan && typeof plan.ratios === 'object' && !Array.isArray(plan.ratios)) ? plan.ratios : {};
 
@@ -156,8 +166,8 @@ const capBreakdown = (breakdown, cappedUnits, originalTotal) => {
  * @param {Object|null|undefined} [options.costsOverride=null] - Optional cost map to charge
  *   instead of history.costs. Use for delta charging:
  *   `attribute(history, orgId, { stepKey: 'digest', costsOverride: { digest: 0.5 } })`.
- *   Empty or zero-only overrides return `{ applied: false, reason: 'zero_cost_skipped' }`
- *   before writing the idempotency key.
+ *   Empty or zero-only overrides write the idempotency key with a zero-unit attribution,
+ *   then return `{ applied: false, reason: 'zero_cost_skipped' }`.
  * @param {Object|null|undefined} [options.costs=null] - Alias cost map used when
  *   options.costsOverride is not provided. Prefer costsOverride for new delta-charge callers.
  * @param {string|null|undefined} [options.planId=null] - Optional planId override for paths
@@ -201,18 +211,15 @@ const attribute = async (history, organizationId, options = {}) => {
   }
   const validatedStepKey = stepKey ?? 'initial';
 
-  // Lazy imports to avoid circular deps — these services import billing.meter.service
-  const { default: BillingUsageService } = await import('./billing.usage.service.js');
-  const { default: BillingExtraService } = await import('./billing.extra.service.js');
-
-  const planId = explicitPlanId ?? history.planId ?? config?.billing?.plans?.[0] ?? 'pro';
+  const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${validatedStepKey}`;
+  const planId = explicitPlanId ?? history.planId ?? getMeterFallbackPlanId();
   const ratioVersion = explicitRatioVersion ?? history.planVersion ?? null;
   const costs = costsOverride ?? explicitCosts ?? history.costs;
 
-  let totalUnits = METER_RUN_BASE;
+  let totalUnits = getMeterRunBase();
   let breakdown = {};
 
-  if (costs && ratioVersion) {
+  if (costs != null) {
     ({ totalUnits, breakdown } = await unitsFromCosts(costs, planId, ratioVersion));
   }
 
@@ -227,10 +234,9 @@ const attribute = async (history, organizationId, options = {}) => {
   }
 
   if (cappedUnits === 0) {
+    await BillingUsageService.incrementMeter(organizationId, 0, {}, idempotencyKey);
     return { applied: false, meterUsed: 0, extrasConsumed: 0, reason: 'zero_cost_skipped' };
   }
-
-  const idempotencyKey = `${history._id?.toString?.() ?? String(history._id)}:${validatedStepKey}`;
 
   // incrementMeterWithOutbox atomically creates the outbox row before returning so there
   // is exactly one pending row per (idempotencyKey) when extras overflow. result.outbox is
@@ -255,8 +261,6 @@ const attribute = async (history, organizationId, options = {}) => {
     try {
       const debitResult = await BillingExtraService.debit(organizationId, extrasConsumed, idempotencyKey);
       if (debitResult.applied && outboxDoc) {
-        // Lazy import to avoid pulling in repository at module load time
-        const { default: BillingMeterOutboxRepository } = await import('../repositories/billing.meter.outbox.repository.js');
         await BillingMeterOutboxRepository.markCommitted(outboxDoc._id);
       }
     } catch (err) {

--- a/modules/billing/services/billing.plan.service.js
+++ b/modules/billing/services/billing.plan.service.js
@@ -3,6 +3,7 @@
  */
 import config from '../../../config/index.js';
 import BillingPlanRepository from '../repositories/billing.plan.repository.js';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 /**
  * In-memory cache: planId → { plan, fetchedAt }
@@ -151,8 +152,7 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
     try {
       return await bumpVersion(planId, fields);
     } catch (err) {
-      const isE11000 = err.code === 11000 || (err.message && err.message.includes('E11000'));
-      if (!isE11000 || attempt === maxAttempts - 1) throw err;
+      if (!isDuplicateKeyError(err) || attempt === maxAttempts - 1) throw err;
       lastErr = err;
       const delay = backoffMs[attempt] ?? 900;
       await new Promise((resolve) => setTimeout(resolve, delay));
@@ -161,9 +161,6 @@ const bumpVersionWithRetry = async (planId, fields, { maxAttempts = 3 } = {}) =>
 
   throw lastErr;
 };
-
-const isDuplicateKeyError = (err) =>
-  err.code === 11000 || (err.message && err.message.includes('E11000'));
 
 /**
  * @desc Resolve the configured immutable version for a plan definition.

--- a/modules/billing/services/billing.reset.service.js
+++ b/modules/billing/services/billing.reset.service.js
@@ -6,22 +6,9 @@ import BillingUsageRepository from '../repositories/billing.usage.repository.js'
 import BillingSubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import BillingPlanService from './billing.plan.service.js';
 import billingEvents from '../lib/events.js';
-
-/**
- * Compute the ISO week key (YYYY-Www) for a given date.
- * ISO 8601: week starts on Monday; week 1 contains the first Thursday.
- * @param {Date} date - The date to compute the week key for.
- * @returns {string} The week key in YYYY-Www format (e.g. "2026-W18").
- */
-// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const isoWeekKey = (date) => {
-  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-  // Move to the nearest Thursday (ISO week definition anchor)
-  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
-  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
-};
+import { isoWeekKey } from '../lib/billing.isoWeek.js';
+import { getPlanChangePreserveUsageDefault } from '../lib/billing.constants.js';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 /**
  * @function resetWeek
@@ -85,7 +72,7 @@ const resetWeek = async (orgId, periodStart) => {
       consumedAttributionKeys: [],
     });
   } catch (err) {
-    if (err.code === 11000) {
+    if (isDuplicateKeyError(err)) {
       // Race: another pod already created this week's doc
       return BillingUsageRepository.findByWeek(orgId, newWeekKey);
     }
@@ -101,14 +88,14 @@ const resetWeek = async (orgId, periodStart) => {
  *              the next attribution lazily creates it with the active plan.
  * @param {string} organizationId - The organization ObjectId (string).
  * @param {Object} [options={}] - Rotation options.
- * @param {boolean} [options.preserveUsage=true] - Keep meterUsed and breakdown when true; reset them when false.
+ * @param {boolean} [options.preserveUsage] - Keep meterUsed and breakdown when true; defaults to config billing.planChange.preserveUsageDefault.
  * @returns {Promise<Object|null>} The updated current week usage document, or null when no current doc exists.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const forceRotateForPlanChange = async (organizationId, options = {}) => {
   if (!config?.billing?.meterMode) return null;
 
-  const { preserveUsage = true } = options ?? {};
+  const { preserveUsage = getPlanChangePreserveUsageDefault() } = options ?? {};
   const now = new Date();
   const currentWeekKey = isoWeekKey(now);
   const existingDoc = await BillingUsageRepository.findByWeek(organizationId, currentWeekKey);

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -5,6 +5,7 @@ import config from '../../../config/index.js';
 import getStripe from '../lib/stripe.js';
 import BillingPlansService from './billing.plans.service.js';
 import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 /**
  * Validate that a redirect URL is safe for the current environment.
@@ -30,6 +31,52 @@ const isAllowedUrl = (url) => {
   } catch {
     return false;
   }
+};
+
+/**
+ * @function _ensureStripeCustomer
+ * @description Find or create the billing subscription shell that carries a Stripe customer id.
+ * @param {Object} stripe - Stripe client instance.
+ * @param {Object} organization - Organization document.
+ * @returns {Promise<Object>} Subscription document with stripeCustomerId.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const _ensureStripeCustomer = async (stripe, organization) => {
+  let subscription = await SubscriptionRepository.findByOrganization(organization._id);
+  if (subscription?.stripeCustomerId) return subscription;
+
+  const customer = await stripe.customers.create(
+    {
+      name: organization.name,
+      metadata: { organizationId: String(organization._id) },
+    },
+    { idempotencyKey: `cus_create_${String(organization._id)}` },
+  );
+
+  if (subscription) {
+    subscription = await SubscriptionRepository.update({
+      _id: subscription._id,
+      stripeCustomerId: customer.id,
+    });
+  } else {
+    try {
+      subscription = await SubscriptionRepository.create({
+        organization: organization._id,
+        stripeCustomerId: customer.id,
+      });
+    } catch (err) {
+      if (isDuplicateKeyError(err)) {
+        subscription = await SubscriptionRepository.findByOrganization(organization._id);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const latest = await SubscriptionRepository.findByOrganization(organization._id);
+  if (latest?.stripeCustomerId) return latest;
+  if (subscription?.stripeCustomerId) return subscription;
+  throw new Error('No Stripe customer found for this organization');
 };
 
 /**
@@ -61,41 +108,7 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
     throw new Error('Invalid priceId: must be an active published price');
   }
 
-  // Find or create subscription record with Stripe customer
-  let subscription = await SubscriptionRepository.findByOrganization(organization._id);
-
-  if (!subscription?.stripeCustomerId) {
-    const customer = await stripe.customers.create(
-      {
-        name: organization.name,
-        metadata: { organizationId: String(organization._id) },
-      },
-      { idempotencyKey: `cus_create_${String(organization._id)}` },
-    );
-
-    if (subscription) {
-      subscription = await SubscriptionRepository.update({
-        _id: subscription._id,
-        stripeCustomerId: customer.id,
-      });
-    } else {
-      try {
-        subscription = await SubscriptionRepository.create({
-          organization: organization._id,
-          stripeCustomerId: customer.id,
-        });
-      } catch (err) {
-        if (err.code === 11000) {
-          subscription = await SubscriptionRepository.findByOrganization(organization._id);
-        } else {
-          throw err;
-        }
-      }
-    }
-    // Re-read to handle race: if another request already set stripeCustomerId, use that
-    const latest = await SubscriptionRepository.findByOrganization(organization._id);
-    if (latest?.stripeCustomerId) subscription = latest;
-  }
+  const subscription = await _ensureStripeCustomer(stripe, organization);
 
   const checkoutParams = {
     customer: subscription.stripeCustomerId,
@@ -178,41 +191,7 @@ const createExtrasCheckout = async (organization, packId, successUrl, cancelUrl)
   const priceId = config?.stripe?.prices?.packs?.[packId];
   if (!priceId) throw new Error(`Invalid packId: no Stripe price configured for pack: ${packId}`);
 
-  // Find or create subscription record with Stripe customer
-  let subscription = await SubscriptionRepository.findByOrganization(organization._id);
-
-  if (!subscription?.stripeCustomerId) {
-    const customer = await stripe.customers.create(
-      {
-        name: organization.name,
-        metadata: { organizationId: String(organization._id) },
-      },
-      { idempotencyKey: `cus_create_${String(organization._id)}` },
-    );
-
-    if (subscription) {
-      subscription = await SubscriptionRepository.update({
-        _id: subscription._id,
-        stripeCustomerId: customer.id,
-      });
-    } else {
-      try {
-        subscription = await SubscriptionRepository.create({
-          organization: organization._id,
-          stripeCustomerId: customer.id,
-        });
-      } catch (err) {
-        if (err.code === 11000) {
-          subscription = await SubscriptionRepository.findByOrganization(organization._id);
-        } else {
-          throw err;
-        }
-      }
-    }
-    // Re-read to handle race: if another request already set stripeCustomerId, use that
-    const latest = await SubscriptionRepository.findByOrganization(organization._id);
-    if (latest?.stripeCustomerId) subscription = latest;
-  }
+  const subscription = await _ensureStripeCustomer(stripe, organization);
 
   // Use a timestamped idempotency key (debounce double-click within ~1s granularity)
   const idempotencyKey = `extras_checkout_${String(organization._id)}_${packId}_${Date.now()}`;

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -6,24 +6,10 @@ import UsageRepository from '../repositories/billing.usage.repository.js';
 import BillingSubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import BillingMeterOutboxRepository from '../repositories/billing.meter.outbox.repository.js';
 import BillingPlanService from './billing.plan.service.js';
-
-/**
- * @function getBillingEvents
- * @description Lazily import the billing events emitter to avoid circular dependency
- *              at module load time. Returns the emitter instance, or null if the
- *              import fails (e.g. events module not available in test env).
- * @async
- * @returns {Promise<import('node:events').EventEmitter|null>} The billing event emitter, or null.
- */
-// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const getBillingEvents = async () => {
-  try {
-    const { default: billingEvents } = await import('../lib/events.js');
-    return billingEvents;
-  } catch {
-    return null;
-  }
-};
+import billingEvents from '../lib/events.js';
+import { currentWeekKey } from '../lib/billing.isoWeek.js';
+import { getAlertThresholdPercents } from '../lib/billing.constants.js';
+import { isDuplicateKeyError } from '../lib/billing.errors.js';
 
 /**
  * Compute the current month string in YYYY-MM format.
@@ -36,21 +22,9 @@ const currentMonth = () => {
   return `${year}-${month}`;
 };
 
-/**
- * @function currentWeekKey
- * @description Compute the current ISO 8601 week key in YYYY-Www format.
- *              ISO week starts on Monday; week 1 contains the first Thursday.
- * @returns {string} e.g. '2026-W18'
- */
-// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const currentWeekKey = () => {
-  const now = new Date();
-  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  // Shift to nearest Thursday (ISO anchor)
-  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
-  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+const thresholdFields = {
+  80: 'alertedAt80',
+  100: 'alertedAt100',
 };
 
 /**
@@ -87,7 +61,7 @@ const reset = (organizationId) => UsageRepository.reset(organizationId, currentM
  *              2. Fetches the active plan snapshot (meterQuota + planVersion).
  *              3. Calls repo.incrementMeter atomically with replay protection.
  *              4. If quota is exceeded, overflows into extras balance.
- *              5. Detects 80%/100% threshold crossings (emits meter.threshold_crossed event, once per cycle).
+ *              5. Detects configured threshold crossings (emits meter.threshold_crossed event, once per cycle).
  *
  *              Returns applied=false when the idempotencyKey was already consumed (replay).
  *
@@ -154,54 +128,32 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
     extrasConsumed = newMeterUsed - overflowStart;
   }
 
-  // Threshold detection — emit event at 80% and 100%, deduplicated per cycle
+  // Threshold detection — emit configured thresholds, deduplicated per cycle
   let alertCrossed = null;
-  const billingEvents = await getBillingEvents();
 
   if (effectiveQuota > 0) {
-    const pct = newMeterUsed / effectiveQuota;
+    const pct = (newMeterUsed / effectiveQuota) * 100;
+    for (const threshold of getAlertThresholdPercents()) {
+      const field = thresholdFields[threshold];
+      if (!field || pct < threshold || updatedDoc[field]) continue;
 
-    if (pct >= 1.0 && !updatedDoc.alertedAt100) {
-      // Only emit when we win the dedup race (modifiedCount > 0).
-      // If another pod already set alertedAt100, markThreshold returns modifiedCount=0 — skip emit.
       let marked = false;
       try {
-        const markResult = await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt100');
+        const markResult = await UsageRepository.markThreshold(updatedDoc._id, field);
         marked = markResult?.modifiedCount > 0;
-      } catch {
-        // Best-effort — if mark fails, skip emit to avoid double-fire
+      } catch (err) {
+        console.warn('[billing.usage] threshold mark failed, skipping emit:', err?.message ?? err);
       }
       if (marked) {
-        alertCrossed = '100';
-        if (billingEvents) {
-          billingEvents.emit('meter.threshold_crossed', {
-            organizationId,
-            weekKey,
-            threshold: 100,
-            meterUsed: newMeterUsed,
-            meterQuota: effectiveQuota,
-          });
-        }
-      }
-    } else if (pct >= 0.8 && !updatedDoc.alertedAt80) {
-      let marked = false;
-      try {
-        const markResult = await UsageRepository.markThreshold(updatedDoc._id, 'alertedAt80');
-        marked = markResult?.modifiedCount > 0;
-      } catch {
-        // Best-effort — if mark fails, skip emit to avoid double-fire
-      }
-      if (marked) {
-        alertCrossed = '80';
-        if (billingEvents) {
-          billingEvents.emit('meter.threshold_crossed', {
-            organizationId,
-            weekKey,
-            threshold: 80,
-            meterUsed: newMeterUsed,
-            meterQuota: effectiveQuota,
-          });
-        }
+        alertCrossed = String(threshold);
+        billingEvents.emit('meter.threshold_crossed', {
+          organizationId,
+          weekKey,
+          threshold,
+          meterUsed: newMeterUsed,
+          meterQuota: effectiveQuota,
+        });
+        break;
       }
     }
   }
@@ -234,11 +186,26 @@ const incrementMeterWithOutbox = async (organizationId, units, breakdown, idempo
   const result = await incrementMeter(organizationId, units, breakdown, idempotencyKey);
   if (!result.applied || result.extrasConsumed <= 0) return result;
 
-  const outbox = await BillingMeterOutboxRepository.create({
-    organizationId,
-    idempotencyKey,
-    extrasUnits: result.extrasConsumed,
-  });
+  let outbox;
+  try {
+    outbox = await BillingMeterOutboxRepository.create({
+      organizationId,
+      idempotencyKey,
+      extrasUnits: result.extrasConsumed,
+    });
+  } catch (err) {
+    if (isDuplicateKeyError(err)) {
+      outbox = await BillingMeterOutboxRepository.findByIdempotencyKey(idempotencyKey);
+      if (!outbox) {
+        throw new Error('[billing] outbox state desynced — meter incremented but outbox missing');
+      }
+    } else {
+      console.error('[billing] CRITICAL outbox create failed after meter increment', { idempotencyKey, err });
+      const wrapped = new Error(`[billing] outbox create failed after meter increment: ${err?.message ?? err}`);
+      wrapped.cause = err;
+      throw wrapped;
+    }
+  }
 
   return { ...result, outbox };
 };

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -135,7 +135,11 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
     const pct = (newMeterUsed / effectiveQuota) * 100;
     for (const threshold of getAlertThresholdPercents()) {
       const field = thresholdFields[threshold];
-      if (!field || pct < threshold || updatedDoc[field]) continue;
+      if (!field) {
+        console.warn(`[billing.usage] threshold ${threshold}% has no schema field (only 80/100 are supported) — skipping`);
+        continue;
+      }
+      if (pct < threshold || updatedDoc[field]) continue;
 
       let marked = false;
       try {

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -260,12 +260,15 @@ const handleSubscriptionUpdated = async (subscription, event) => {
         previousPeriodStart !== undefined &&
         subscription.current_period_start !== previousPeriodStart &&
         newPeriodStart;
+      planChangeResetTriggered = !periodAlsoChanged;
       try {
         await BillingResetService.forceRotateForPlanChange(organizationId, { preserveUsage: true });
-        planChangeResetTriggered = !periodAlsoChanged;
       } catch (err) {
-        // Log for monitoring — not thrown so webhook processing continues
-        console.error('[billing.webhook] forceRotateForPlanChange failed (non-fatal):', err?.message ?? err);
+        planChangeResetTriggered = false;
+        console.error(
+          '[billing.webhook] forceRotateForPlanChange failed, falling back to resetWeek:',
+          err?.message ?? err,
+        );
       }
     }
   }
@@ -379,8 +382,8 @@ const handleInvoicePaymentSucceeded = async (invoice) => {
  *       silently skip. Downstream (trawl_node) is responsible for setting these at session creation.
  *       Calls BillingExtraService.refundPartial which computes refundUnits from
  *       the original topup entry and config.billing.packs.
- *       Uses charge.refunds.data[0].amount (this event's refund delta) rather than
- *       charge.amount_refunded (cumulative total) to avoid over-debiting on multiple partial refunds.
+ *       Uses the latest refund's amount rather than charge.amount_refunded
+ *       (cumulative total) to avoid over-debiting on multiple partial refunds.
  *       Skips if metadata is incomplete or the refund amount is zero.
  * @param {Object} charge - Stripe charge object
  * @returns {Promise<void>}
@@ -397,9 +400,11 @@ const handleChargeRefunded = async (charge) => {
   if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
   if (!stripeSessionId) return;
 
-  // Use this event's refund delta (charge.refunds.data[0].amount), not the cumulative
+  // Use the latest refund delta, not the cumulative
   // charge.amount_refunded — prevents over-debiting when multiple partial refunds occur.
-  const thisRefundAmount = charge.refunds?.data?.[0]?.amount;
+  const refunds = Array.isArray(charge.refunds?.data) ? charge.refunds.data : [];
+  const latestRefund = [...refunds].sort((a, b) => (b?.created ?? 0) - (a?.created ?? 0))[0];
+  const thisRefundAmount = latestRefund?.amount;
   if (!thisRefundAmount || thisRefundAmount <= 0) return;
 
   // Service layer computes proportional refundUnits from config.billing.packs.

--- a/modules/billing/tests/billing.config-knobs.unit.tests.js
+++ b/modules/billing/tests/billing.config-knobs.unit.tests.js
@@ -1,0 +1,78 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+describe('billing config knob helpers:', () => {
+  let mockConfig;
+  let constants;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockConfig = {
+      billing: {
+        plans: ['free', 'pro'],
+        meter: {
+          runBase: 9,
+          runBaseUnits: 3,
+          fallbackPlanId: 'enterprise',
+        },
+        outbox: {
+          maxRetryAttempts: 7,
+          retryIntervalSec: 42,
+        },
+        crons: {
+          jitterMaxMs: 1234,
+        },
+        planChange: {
+          preserveUsageDefault: false,
+        },
+        alerts: {
+          thresholdPercents: [95, 50],
+        },
+        events: {
+          extrasExhausted: 'billing.custom.exhausted',
+        },
+      },
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
+
+    constants = await import('../lib/billing.constants.js');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('reads explicit billing hardening config overrides', () => {
+    expect(constants.getMeterRunBase()).toBe(9);
+    expect(constants.getMeterFallbackPlanId()).toBe('enterprise');
+    expect(constants.getOutboxMaxRetryAttempts()).toBe(7);
+    expect(constants.getOutboxRetryIntervalMs()).toBe(42_000);
+    expect(constants.getCronJitterMaxMs()).toBe(1234);
+    expect(constants.getPlanChangePreserveUsageDefault()).toBe(false);
+    expect(constants.getAlertThresholdPercents()).toEqual([95, 50]);
+    expect(constants.getExtrasExhaustedEventName()).toBe('billing.custom.exhausted');
+  });
+
+  test('keeps backward-compatible defaults and runBaseUnits alias', async () => {
+    mockConfig.billing = {
+      plans: ['free'],
+      meter: {
+        runBaseUnits: 4,
+      },
+    };
+
+    expect(constants.getMeterRunBase()).toBe(4);
+    expect(constants.getMeterFallbackPlanId()).toBe('free');
+    expect(constants.getOutboxMaxRetryAttempts()).toBe(5);
+    expect(constants.getOutboxRetryIntervalMs()).toBe(300_000);
+    expect(constants.getCronJitterMaxMs()).toBe(60_000);
+    expect(constants.getPlanChangePreserveUsageDefault()).toBe(true);
+    expect(constants.getAlertThresholdPercents()).toEqual([100, 80]);
+    expect(constants.getExtrasExhaustedEventName()).toBe('billing.extras_debit.exhausted');
+  });
+});

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -72,7 +72,11 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Stripe is not configured' });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+      message: 'Bad Request',
+      description: 'Stripe is not configured',
+    }));
   });
 
   test('should return 400 when signature verification fails', async () => {
@@ -91,7 +95,11 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Webhook signature verification failed' });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+      message: 'Bad Request',
+      description: 'Webhook signature verification failed',
+    }));
   });
 
   test('should handle checkout.session.completed event', async () => {
@@ -206,6 +214,10 @@ describe('Billing webhook controller unit tests:', () => {
 
     expect(loggerMod.default.error).toHaveBeenCalledWith('Stripe webhook handler error:', expect.any(Error));
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Webhook handler failed' });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+      message: 'Internal Server Error',
+      description: 'Webhook handler failed',
+    }));
   });
 });

--- a/modules/billing/tests/billing.cron-utils.unit.tests.js
+++ b/modules/billing/tests/billing.cron-utils.unit.tests.js
@@ -1,0 +1,33 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+describe('billing cron utils:', () => {
+  let randomInt;
+  let applyJitter;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    randomInt = jest.fn().mockReturnValue(0);
+    jest.unstable_mockModule('node:crypto', () => ({ randomInt }));
+    ({ applyJitter } = await import('../lib/billing.cron-utils.js'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('applyJitter uses crypto randomInt with configured max', async () => {
+    const slept = await applyJitter(1234);
+
+    expect(randomInt).toHaveBeenCalledWith(0, 1234);
+    expect(slept).toBe(0);
+  });
+
+  test('applyJitter skips invalid or disabled jitter', async () => {
+    await expect(applyJitter(0)).resolves.toBe(0);
+    await expect(applyJitter(Infinity)).resolves.toBe(0);
+    expect(randomInt).not.toHaveBeenCalled();
+  });
+});

--- a/modules/billing/tests/billing.cron.retryPendingExtrasDebit.unit.tests.js
+++ b/modules/billing/tests/billing.cron.retryPendingExtrasDebit.unit.tests.js
@@ -11,6 +11,7 @@ describe('billing.retryPendingExtrasDebit cron — BillingMeterOutboxService:', 
   let mockOutboxRepository;
   let mockExtraService;
   let mockEvents;
+  let mockConfig;
 
   const orgId = '507f1f77bcf86cd799439011';
 
@@ -44,6 +45,17 @@ describe('billing.retryPendingExtrasDebit cron — BillingMeterOutboxService:', 
     mockEvents = {
       emit: jest.fn(),
     };
+
+    mockConfig = {
+      billing: {
+        outbox: { maxRetryAttempts: 5 },
+        events: { extrasExhausted: 'billing.extras_debit.exhausted' },
+      },
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: mockConfig,
+    }));
 
     jest.unstable_mockModule('../repositories/billing.meter.outbox.repository.js', () => ({
       default: mockOutboxRepository,
@@ -115,5 +127,39 @@ describe('billing.retryPendingExtrasDebit cron — BillingMeterOutboxService:', 
       lastError: 'still failing',
     });
     expect(result).toEqual({ scanned: 1, committed: 0, failedAttempts: 1, exhausted: 1 });
+  });
+
+  test('uses configured exhausted event name and max retry attempts', async () => {
+    mockConfig.billing.outbox.maxRetryAttempts = 3;
+    mockConfig.billing.events.extrasExhausted = 'billing.custom.exhausted';
+    const row = makeOutbox({ attempts: 2 });
+    const failed = makeOutbox({
+      attempts: 3,
+      status: 'failed',
+      lastError: 'still failing',
+    });
+    mockOutboxRepository.findPendingDue.mockResolvedValue([row]);
+    mockExtraService.debit.mockResolvedValue({ applied: false });
+    mockOutboxRepository.markFailedAttempt.mockResolvedValue(failed);
+
+    const result = await BillingMeterOutboxService.retryPendingExtrasDebits();
+
+    expect(mockEvents.emit).toHaveBeenCalledWith('billing.custom.exhausted', expect.objectContaining({
+      attempts: 3,
+    }));
+    expect(result.exhausted).toBe(1);
+  });
+
+  test('does not emit exhausted event when failed row is past transition attempt', async () => {
+    const row = makeOutbox({ attempts: 5 });
+    const failed = makeOutbox({ attempts: 6, status: 'failed' });
+    mockOutboxRepository.findPendingDue.mockResolvedValue([row]);
+    mockExtraService.debit.mockResolvedValue({ applied: false });
+    mockOutboxRepository.markFailedAttempt.mockResolvedValue(failed);
+
+    const result = await BillingMeterOutboxService.retryPendingExtrasDebits();
+
+    expect(mockEvents.emit).not.toHaveBeenCalled();
+    expect(result.exhausted).toBe(0);
   });
 });

--- a/modules/billing/tests/billing.cron.weeklyReset.unit.tests.js
+++ b/modules/billing/tests/billing.cron.weeklyReset.unit.tests.js
@@ -38,7 +38,6 @@ describe('billing.weeklyReset cron — BillingResetService.resetAllDue:', () => 
     };
 
     mockSubscriptionRepository = {
-      findAllDueForReset: jest.fn(),
       findAllDueForResetByLastReset: jest.fn(),
       findByOrganization: jest.fn().mockResolvedValue({ plan: 'pro' }),
       findPlan: jest.fn().mockResolvedValue({ plan: 'pro' }),

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -44,6 +44,7 @@ describe('BillingExtraService unit tests:', () => {
       debit: jest.fn(),
       addExpirationEntries: jest.fn(),
       getOrCreate: jest.fn(),
+      getBalance: jest.fn(),
       refundPartial: jest.fn(),
     };
 
@@ -131,6 +132,17 @@ describe('BillingExtraService unit tests:', () => {
 
       expect(r1.applied).toBe(true);
       expect(r2.applied).toBe(false);
+    });
+  });
+
+  describe('getOrgBalanceContext', () => {
+    test('should delegate balance lookup to repository', async () => {
+      mockRepository.getBalance.mockResolvedValue(150000);
+
+      const result = await BillingExtraService.getOrgBalanceContext(orgId);
+
+      expect(mockRepository.getBalance).toHaveBeenCalledWith(orgId);
+      expect(result).toBe(150000);
     });
   });
 

--- a/modules/billing/tests/billing.extras.controller.unit.tests.js
+++ b/modules/billing/tests/billing.extras.controller.unit.tests.js
@@ -12,7 +12,6 @@ describe('Billing extras controller unit tests:', () => {
   let mockBillingService;
   let mockBillingExtraService;
   let mockBillingUsageService;
-  let mockBillingExtraBalanceRepository;
   let mockConfig;
   let req;
   let res;
@@ -38,16 +37,13 @@ describe('Billing extras controller unit tests:', () => {
 
     mockBillingExtraService = {
       listLedger: jest.fn(),
+      getOrgBalanceContext: jest.fn(),
     };
 
     mockBillingUsageService = {
       getMeter: jest.fn(),
       get: jest.fn(),
       currentWeekKey: jest.fn().mockReturnValue('2026-W18'),
-    };
-
-    mockBillingExtraBalanceRepository = {
-      getBalance: jest.fn(),
     };
 
     mockConfig = {
@@ -70,10 +66,6 @@ describe('Billing extras controller unit tests:', () => {
 
     jest.unstable_mockModule('../services/billing.usage.service.js', () => ({
       default: mockBillingUsageService,
-    }));
-
-    jest.unstable_mockModule('../repositories/billing.extraBalance.repository.js', () => ({
-      default: mockBillingExtraBalanceRepository,
     }));
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -151,11 +143,11 @@ describe('Billing extras controller unit tests:', () => {
 
   describe('extrasBalance', () => {
     test('should return 200 with balance and packsAvailable', async () => {
-      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(150000);
+      mockBillingExtraService.getOrgBalanceContext.mockResolvedValue(150000);
 
       await BillingController.extrasBalance(req, res);
 
-      expect(mockBillingExtraBalanceRepository.getBalance).toHaveBeenCalledWith(orgId);
+      expect(mockBillingExtraService.getOrgBalanceContext).toHaveBeenCalledWith(orgId);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
         type: 'success',
@@ -167,7 +159,7 @@ describe('Billing extras controller unit tests:', () => {
     });
 
     test('should return 500 when repository throws', async () => {
-      mockBillingExtraBalanceRepository.getBalance.mockRejectedValue(new Error('DB error'));
+      mockBillingExtraService.getOrgBalanceContext.mockRejectedValue(new Error('DB error'));
 
       await BillingController.extrasBalance(req, res);
 
@@ -234,7 +226,7 @@ describe('Billing extras controller unit tests:', () => {
         meterQuota: 5000,
         meterBreakdown: { scrape: 1000, llm: 200 },
       });
-      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(2500);
+      mockBillingExtraService.getOrgBalanceContext.mockResolvedValue(2500);
 
       await BillingController.getUsage(req, res);
 
@@ -257,7 +249,7 @@ describe('Billing extras controller unit tests:', () => {
       mockConfig.billing.meterMode = true;
       mockBillingService.getSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
       mockBillingUsageService.getMeter.mockResolvedValue(null);
-      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(0);
+      mockBillingExtraService.getOrgBalanceContext.mockResolvedValue(0);
 
       await BillingController.getUsage(req, res);
 

--- a/modules/billing/tests/billing.init.unit.tests.js
+++ b/modules/billing/tests/billing.init.unit.tests.js
@@ -9,6 +9,7 @@ import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globa
 describe('billing.init unit tests:', () => {
   let billingInit;
   let mockBillingPlanService;
+  let mockBillingUsageRepository;
   let mockConfig;
   let mockDistinct;
   let mockMongoose;
@@ -29,6 +30,10 @@ describe('billing.init unit tests:', () => {
       ensureSeeded: jest.fn().mockResolvedValue({ seeded: 0, skipped: 0 }),
     };
 
+    mockBillingUsageRepository = {
+      countLegacyConsumedHistoryIds: jest.fn().mockResolvedValue(0),
+    };
+
     mockDistinct = jest.fn().mockResolvedValue([]);
     mockMongoose = {
       model: jest.fn().mockReturnValue({ distinct: mockDistinct }),
@@ -40,6 +45,10 @@ describe('billing.init unit tests:', () => {
 
     jest.unstable_mockModule('../services/billing.plan.service.js', () => ({
       default: mockBillingPlanService,
+    }));
+
+    jest.unstable_mockModule('../repositories/billing.usage.repository.js', () => ({
+      default: mockBillingUsageRepository,
     }));
 
     // Stub analytics and events to avoid side effects
@@ -111,6 +120,13 @@ describe('billing.init unit tests:', () => {
     // Known plan 'free' must NOT trigger a warning
     const warnings = warnSpy.mock.calls.map((c) => c[0]);
     expect(warnings.some((w) => w.includes('"free"'))).toBe(false);
+  });
+
+  test('meterMode=true aborts boot when legacy consumedHistoryIds fields remain', async () => {
+    mockConfig.billing.meterMode = true;
+    mockBillingUsageRepository.countLegacyConsumedHistoryIds.mockResolvedValue(2);
+
+    await expect(billingInit(mockApp)).rejects.toThrow('legacy consumedHistoryIds field still present');
   });
 
   test('boot validator failure does not crash boot', async () => {

--- a/modules/billing/tests/billing.isoWeek.unit.tests.js
+++ b/modules/billing/tests/billing.isoWeek.unit.tests.js
@@ -1,0 +1,51 @@
+/**
+ * Module dependencies.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { currentWeekKey, isoWeekKey } from '../lib/billing.isoWeek.js';
+
+/**
+ * @function referenceIsoWeekKey
+ * @description Independent ISO week implementation used for randomized regression checks.
+ * @param {Date} date - Date to compute.
+ * @returns {string} ISO week key.
+ */
+const referenceIsoWeekKey = (date) => {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = utc.getUTCDay() || 7;
+  utc.setUTCDate(utc.getUTCDate() + 4 - day);
+  const year = utc.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(year, 0, 4));
+  const firstDay = firstThursday.getUTCDay() || 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() + 4 - firstDay);
+  const week = 1 + Math.round((utc - firstThursday) / (7 * 24 * 60 * 60 * 1000));
+  return `${year}-W${String(week).padStart(2, '0')}`;
+};
+
+describe('billing.isoWeek unit tests:', () => {
+  test('handles year rollover and leap-year edge cases', () => {
+    expect(isoWeekKey(new Date('2020-12-31T12:00:00.000Z'))).toBe('2020-W53');
+    expect(isoWeekKey(new Date('2021-01-01T12:00:00.000Z'))).toBe('2020-W53');
+    expect(isoWeekKey(new Date('2021-01-04T12:00:00.000Z'))).toBe('2021-W01');
+    expect(isoWeekKey(new Date('2024-02-29T12:00:00.000Z'))).toBe('2024-W09');
+  });
+
+  test('handles Europe/Paris DST transition dates', () => {
+    expect(isoWeekKey(new Date('2026-03-29T12:00:00+02:00'))).toBe('2026-W13');
+    expect(isoWeekKey(new Date('2026-10-25T12:00:00+01:00'))).toBe('2026-W43');
+  });
+
+  test('matches reference implementation for 100 deterministic random dates', () => {
+    let seed = 1777791760;
+    for (let i = 0; i < 100; i += 1) {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      const timestamp = Date.UTC(1995, 0, 1) + (seed % (45 * 366 * 24 * 60 * 60 * 1000));
+      const date = new Date(timestamp);
+      expect(isoWeekKey(date)).toBe(referenceIsoWeekKey(date));
+    }
+  });
+
+  test('currentWeekKey returns an ISO week key', () => {
+    expect(currentWeekKey()).toMatch(/^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/);
+  });
+});

--- a/modules/billing/tests/billing.lifecycle.integration.tests.js
+++ b/modules/billing/tests/billing.lifecycle.integration.tests.js
@@ -19,8 +19,10 @@ describe('Billing meter lifecycle integration tests:', () => {
   let BillingExtraBalance;
   let BillingResetService;
   let BillingWebhookService;
+  let BillingUsageService;
   let BillingMeterService;
   let BillingMeterOutboxService;
+  let BillingMeterOutboxRepository;
   let BillingPlanService;
   let billingEvents;
   let originalMeterMode;
@@ -57,10 +59,14 @@ describe('Billing meter lifecycle integration tests:', () => {
 
     BillingResetService = (await import('../services/billing.reset.service.js')).default;
     BillingWebhookService = (await import('../services/billing.webhook.service.js')).default;
+    BillingUsageService = (await import('../services/billing.usage.service.js')).default;
     BillingMeterService = (await import('../services/billing.meter.service.js')).default;
     BillingMeterOutboxService = (await import('../services/billing.meter.outbox.service.js')).default;
+    BillingMeterOutboxRepository = (await import('../repositories/billing.meter.outbox.repository.js')).default;
     BillingPlanService = (await import('../services/billing.plan.service.js')).default;
     billingEvents = (await import('../lib/events.js')).default;
+
+    await BillingMeterOutbox.collection.createIndex({ idempotencyKey: 1 }, { unique: true });
   });
 
   beforeEach(async () => {
@@ -207,5 +213,73 @@ describe('Billing meter lifecycle integration tests:', () => {
         attempts: 5,
       }),
     ]);
+  });
+
+  test('concurrent failed-attempt accounting emits exactly one exhausted event', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+    const exhaustedEvents = [];
+    billingEvents.on('billing.extras_debit.exhausted', (payload) => exhaustedEvents.push(payload));
+
+    const row = await BillingMeterOutbox.create({
+      organizationId,
+      idempotencyKey: '507f1f77bcf86cd799439099:initial',
+      extrasUnits: 500,
+      status: 'pending',
+      attempts: 0,
+      lastAttemptedAt: null,
+    });
+
+    const updates = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        BillingMeterOutboxRepository.markFailedAttempt(row._id, 'extras debit not applied')),
+    );
+
+    for (const updated of updates) {
+      if (updated?.status === 'failed' && updated.attempts === 5) {
+        billingEvents.emit('billing.extras_debit.exhausted', {
+          organizationId: organizationId.toString(),
+          idempotencyKey: row.idempotencyKey,
+          extrasUnits: row.extrasUnits,
+          attempts: updated.attempts,
+          lastError: updated.lastError,
+        });
+      }
+    }
+
+    const failed = await BillingMeterOutbox.findById(row._id).lean();
+    expect(failed.status).toBe('failed');
+    expect(failed.attempts).toBe(5);
+    expect(updates.filter((updated) => updated?.status === 'failed' && updated.attempts === 5)).toHaveLength(1);
+    expect(exhaustedEvents).toHaveLength(1);
+  });
+
+  test('outbox E11000 after meter increment returns existing row instead of failing', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+    const idempotencyKey = '507f1f77bcf86cd799439088:initial';
+    await createActivePlan('pro', 'pro-v1', 5);
+    await Subscription.create({
+      organization: organizationId,
+      plan: 'pro',
+      status: 'active',
+    });
+    const existingOutbox = await BillingMeterOutbox.create({
+      organizationId,
+      idempotencyKey,
+      extrasUnits: 5,
+      status: 'pending',
+    });
+
+    const result = await BillingUsageService.incrementMeterWithOutbox(
+      organizationId.toString(),
+      10,
+      { scrap: 10 },
+      idempotencyKey,
+    );
+
+    const outboxRows = await BillingMeterOutbox.find({ idempotencyKey }).lean();
+    expect(result.applied).toBe(true);
+    expect(result.extrasConsumed).toBe(5);
+    expect(String(result.outbox._id)).toBe(String(existingOutbox._id));
+    expect(outboxRows).toHaveLength(1);
   });
 });

--- a/modules/billing/tests/billing.meter.outbox.unit.tests.js
+++ b/modules/billing/tests/billing.meter.outbox.unit.tests.js
@@ -67,6 +67,7 @@ describe('BillingMeterOutbox unit tests:', () => {
       mockModel = {
         create: jest.fn(),
         find: jest.fn(),
+        findOne: jest.fn(),
         updateOne: jest.fn(),
         findOneAndUpdate: jest.fn(),
       };
@@ -144,42 +145,52 @@ describe('BillingMeterOutbox unit tests:', () => {
       );
     });
 
+    test('findByIdempotencyKey returns a lean row', async () => {
+      const row = makeOutbox();
+      const lean = jest.fn().mockResolvedValue(row);
+      mockModel.findOne.mockReturnValue({ lean });
+
+      const result = await BillingMeterOutboxRepository.findByIdempotencyKey(row.idempotencyKey);
+
+      expect(mockModel.findOne).toHaveBeenCalledWith({ idempotencyKey: row.idempotencyKey });
+      expect(lean).toHaveBeenCalled();
+      expect(result).toBe(row);
+    });
+
     test('markFailedAttempt increments attempts and marks failed on fifth attempt', async () => {
-      const leanFirst = jest.fn().mockResolvedValue(makeOutbox({ attempts: 5 }));
-      const leanSecond = jest.fn().mockResolvedValue(makeOutbox({ attempts: 5, status: 'failed' }));
-      mockModel.findOneAndUpdate
-        .mockReturnValueOnce({ lean: leanFirst })
-        .mockReturnValueOnce({ lean: leanSecond });
+      const lean = jest.fn().mockResolvedValue(makeOutbox({ attempts: 5, status: 'failed' }));
+      mockModel.findOneAndUpdate.mockReturnValue({ lean });
 
       const result = await BillingMeterOutboxRepository.markFailedAttempt(outboxId, new Error('debit failed'));
 
-      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
-      // First call: increment with status:'pending' filter to guard against concurrent updates
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
       expect(mockModel.findOneAndUpdate.mock.calls[0][0]).toEqual({ _id: outboxId, status: 'pending' });
-      expect(mockModel.findOneAndUpdate.mock.calls[0][1]).toEqual({
-        $inc: { attempts: 1 },
-        $set: {
-          lastError: 'debit failed',
-          lastAttemptedAt: expect.any(Date),
+      expect(mockModel.findOneAndUpdate.mock.calls[0][1]).toEqual([
+        {
+          $set: {
+            attempts: { $add: [{ $ifNull: ['$attempts', 0] }, 1] },
+            lastError: 'debit failed',
+            lastAttemptedAt: expect.any(Date),
+            status: {
+              $cond: [
+                { $gte: [{ $add: [{ $ifNull: ['$attempts', 0] }, 1] }, 5] },
+                'failed',
+                '$status',
+              ],
+            },
+          },
         },
-      });
-      // Second call: exhaustion transition also guarded by status:'pending' so only one cron wins
-      expect(mockModel.findOneAndUpdate.mock.calls[1][0]).toEqual({ _id: outboxId, status: 'pending' });
+      ]);
       expect(result.status).toBe('failed');
     });
 
-    test('markFailedAttempt returns null on exhaustion transition when concurrent cron already marked failed', async () => {
-      // Simulates second concurrent cron: first update finds pending row, increments to attempts=5,
-      // second update returns null because status is already 'failed' (first cron won the race).
-      const leanFirst = jest.fn().mockResolvedValue(makeOutbox({ attempts: 5 }));
-      const leanSecond = jest.fn().mockResolvedValue(null);
-      mockModel.findOneAndUpdate
-        .mockReturnValueOnce({ lean: leanFirst })
-        .mockReturnValueOnce({ lean: leanSecond });
+    test('markFailedAttempt returns null when concurrent cron already marked failed', async () => {
+      const lean = jest.fn().mockResolvedValue(null);
+      mockModel.findOneAndUpdate.mockReturnValue({ lean });
 
       const result = await BillingMeterOutboxRepository.markFailedAttempt(outboxId, new Error('concurrent'));
 
-      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
       expect(result).toBeNull();
     });
   });

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -38,7 +38,7 @@ describe('BillingMeterService unit tests:', () => {
         meterMode: true,
         plans: ['pro'],
         meter: {
-          runBaseUnits: 1,
+          runBase: 1,
           dollarsToUnitRatio: 1000,
           maxUnitsPerOperation: 10000,
         },
@@ -163,6 +163,34 @@ describe('BillingMeterService unit tests:', () => {
     test('should return METER_RUN_BASE when costs is null', async () => {
       const result = await BillingMeterService.unitsFromCosts(null, 'pro', 'v1');
       expect(result.totalUnits).toBe(1);
+    });
+
+    test('uses config billing.meter.runBase override when costs is null', async () => {
+      mockConfig.billing.meter.runBase = 7;
+
+      const result = await BillingMeterService.unitsFromCosts(null, 'pro', 'v1');
+
+      expect(result.totalUnits).toBe(7);
+    });
+
+    test('throws when positive costs have no ratioVersion in meterMode', async () => {
+      await expect(
+        BillingMeterService.unitsFromCosts({ scrap: 0.001 }, 'pro', null),
+      ).rejects.toThrow('[billing.meter] non-null costs without ratioVersion in meterMode');
+      expect(mockBillingPlanService.getPlanByVersion).not.toHaveBeenCalled();
+    });
+
+    test('warns and uses ratio=1 when positive costs have no ratioVersion outside meterMode', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockConfig.billing.meterMode = false;
+
+      const result = await BillingMeterService.unitsFromCosts({ scrap: 0.002 }, 'pro', null);
+
+      expect(result).toEqual({ totalUnits: 2, breakdown: { scrap: 2 } });
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[billing.meter] non-null costs without ratioVersion in meterMode',
+      );
+      expect(mockBillingPlanService.getPlanByVersion).not.toHaveBeenCalled();
     });
 
     test('should throw when plan version is missing and meterMode is enabled', async () => {
@@ -370,7 +398,8 @@ describe('BillingMeterService unit tests:', () => {
   });
 
   describe('attribute — per-step idempotency keys', () => {
-    test('costsOverride empty object skips without writing idempotency key', async () => {
+    test('costsOverride empty object writes idempotency key with zero units', async () => {
+      mockBillingUsageService.incrementMeter.mockResolvedValue({ applied: true, meterUsed: 0, extrasConsumed: 0 });
       const history = {
         _id: '507f1f77bcf86cd799439044',
         costs: { scrap: 1 },
@@ -389,8 +418,53 @@ describe('BillingMeterService unit tests:', () => {
         extrasConsumed: 0,
         reason: 'zero_cost_skipped',
       });
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        0,
+        {},
+        '507f1f77bcf86cd799439044:digest',
+      );
       expect(mockBillingUsageService.incrementMeterWithOutbox).not.toHaveBeenCalled();
       expect(mockBillingExtraService.debit).not.toHaveBeenCalled();
+    });
+
+    test('zero-cost attribution blocks a later non-zero replay for the same stepKey', async () => {
+      mockBillingUsageService.incrementMeter.mockResolvedValue({ applied: true, meterUsed: 0, extrasConsumed: 0 });
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(makePlan({ ratios: { digest: 2 } }));
+      mockBillingUsageService.incrementMeterWithOutbox.mockResolvedValue({
+        applied: false,
+        meterUsed: 0,
+      });
+      const history = {
+        _id: '507f1f77bcf86cd799439055',
+        costs: { scrap: 1 },
+        planId: 'pro',
+        planVersion: 'v1',
+      };
+
+      const first = await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        costsOverride: {},
+      });
+      const second = await BillingMeterService.attribute(history, orgId, {
+        stepKey: 'digest',
+        costsOverride: { digest: 0.5 },
+      });
+
+      expect(first.reason).toBe('zero_cost_skipped');
+      expect(second).toEqual({ applied: false, meterUsed: 0, extrasConsumed: 0 });
+      expect(mockBillingUsageService.incrementMeter).toHaveBeenCalledWith(
+        orgId,
+        0,
+        {},
+        '507f1f77bcf86cd799439055:digest',
+      );
+      expect(mockBillingUsageService.incrementMeterWithOutbox).toHaveBeenCalledWith(
+        orgId,
+        1000,
+        { digest: 1000 },
+        '507f1f77bcf86cd799439055:digest',
+      );
     });
 
     test('costsOverride charges only the override delta', async () => {
@@ -480,6 +554,28 @@ describe('BillingMeterService unit tests:', () => {
         { digest: 1500 },
         '507f1f77bcf86cd799439046:digest',
       );
+    });
+
+    test('uses billing.meter.fallbackPlanId when history has no planId', async () => {
+      mockConfig.billing.meter.fallbackPlanId = 'starter';
+      delete mockConfig.billing.plans;
+      mockBillingPlanService.getPlanByVersion.mockResolvedValue(
+        makePlan({ planId: 'starter', version: 'v1', ratios: { digest: 1 } }),
+      );
+      mockBillingUsageService.incrementMeterWithOutbox.mockResolvedValue({
+        applied: true,
+        meterUsed: 500,
+        extrasConsumed: 0,
+      });
+      const history = {
+        _id: '507f1f77bcf86cd799439056',
+        costs: { digest: 0.5 },
+        planVersion: 'v1',
+      };
+
+      await BillingMeterService.attribute(history, orgId, { stepKey: 'digest' });
+
+      expect(mockBillingPlanService.getPlanByVersion).toHaveBeenCalledWith('starter', 'v1');
     });
 
     test('same history attributed twice with default stepKey: 2nd is no-op (regression)', async () => {

--- a/modules/billing/tests/billing.plans.controller.unit.tests.js
+++ b/modules/billing/tests/billing.plans.controller.unit.tests.js
@@ -1,0 +1,61 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+describe('Billing plans controller unit tests:', () => {
+  let BillingPlansController;
+  let mockBillingPlansService;
+  let res;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockBillingPlansService = {
+      getPlans: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../services/billing.plans.service.js', () => ({
+      default: mockBillingPlansService,
+    }));
+
+    const mod = await import('../controllers/billing.plans.controller.js');
+    BillingPlansController = mod.default;
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('getPlans returns billing plans on success', async () => {
+    const plans = [{ planId: 'free', monthlyPrice: 0 }];
+    mockBillingPlansService.getPlans.mockResolvedValue(plans);
+
+    await BillingPlansController.getPlans({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'success',
+      message: 'billing plans',
+      data: plans,
+    }));
+  });
+
+  test('getPlans returns error envelope when Stripe is unavailable', async () => {
+    mockBillingPlansService.getPlans.mockRejectedValue(new Error('Stripe down'));
+
+    await BillingPlansController.getPlans({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+      message: 'Internal Server Error',
+      description: 'Failed to retrieve billing plans',
+    }));
+  });
+});

--- a/modules/billing/tests/billing.processedStripeEvent.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.unit.tests.js
@@ -1,23 +1,19 @@
 /**
  * Module dependencies.
  */
-import { describe, test, beforeEach, expect } from '@jest/globals';
-import { z } from 'zod';
-
-/**
- * Inline Zod schema for ProcessedStripeEvent validation tests.
- * Mirrors billing.processedStripeEvent.model.mongoose.js field requirements.
- */
-const ProcessedStripeEventSchema = z.object({
-  eventId: z.string().trim().min(1, 'eventId is required'),
-  type: z.string().trim().min(1, 'type is required'),
-  processedAt: z.coerce.date().default(() => new Date()),
-});
+import { describe, test, beforeEach, beforeAll, expect } from '@jest/globals';
 
 /**
  * Unit tests for ProcessedStripeEvent model
  */
 describe('ProcessedStripeEvent unit tests:', () => {
+  let ProcessedStripeEventSchema;
+
+  beforeAll(async () => {
+    const mod = await import('../models/billing.processedStripeEvent.schema.js');
+    ProcessedStripeEventSchema = mod.default.ProcessedStripeEvent;
+  });
+
   describe('Schema validation', () => {
     let event;
 

--- a/modules/billing/tests/billing.reset.service.unit.tests.js
+++ b/modules/billing/tests/billing.reset.service.unit.tests.js
@@ -51,6 +51,9 @@ describe('BillingResetService unit tests:', () => {
       billing: {
         meterMode: true,
         defaultPlan: 'starter',
+        planChange: {
+          preserveUsageDefault: true,
+        },
       },
     };
 
@@ -72,7 +75,6 @@ describe('BillingResetService unit tests:', () => {
     mockSubscriptionRepository = {
       findByOrganization: jest.fn(),
       findPlan: jest.fn(),
-      findAllDueForReset: jest.fn(),
       findAllDueForResetByLastReset: jest.fn(),
       updateLastResetAt: jest.fn(),
     };
@@ -310,6 +312,24 @@ describe('BillingResetService unit tests:', () => {
       );
       expect(result.meterUsed).toBe(0);
       expect(result.meterBreakdown).toEqual({});
+    });
+
+    test('uses billing.planChange.preserveUsageDefault when option is omitted', async () => {
+      mockConfig.billing.planChange.preserveUsageDefault = false;
+      const existingDoc = makeUsageDoc({ meterUsed: 1234, meterBreakdown: { scrap: 1234 } });
+      mockUsageRepository.findByWeek.mockResolvedValue(existingDoc);
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'starter' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 100000, version: 'v3' }));
+      mockUsageRepository.rotateWeekSnapshotForPlanChange.mockResolvedValue(makeUsageDoc({ meterUsed: 0 }));
+
+      await BillingResetService.forceRotateForPlanChange(orgId);
+
+      expect(mockUsageRepository.rotateWeekSnapshotForPlanChange).toHaveBeenCalledWith(
+        orgId,
+        '2026-W18',
+        { meterQuota: 100000, planVersion: 'v3', month: '2026-05' },
+        false,
+      );
     });
 
     test('returns null without fetching plan when no current week doc exists', async () => {

--- a/modules/billing/tests/billing.routes.integration.tests.js
+++ b/modules/billing/tests/billing.routes.integration.tests.js
@@ -13,7 +13,6 @@ describe('Billing extras routes integration tests:', () => {
   let mockBillingService;
   let mockBillingExtraService;
   let mockBillingUsageService;
-  let mockBillingExtraBalanceRepository;
   let req;
   let res;
 
@@ -37,16 +36,13 @@ describe('Billing extras routes integration tests:', () => {
 
     mockBillingExtraService = {
       listLedger: jest.fn().mockResolvedValue({ entries: [], total: 0, balance: 0 }),
+      getOrgBalanceContext: jest.fn().mockResolvedValue(0),
     };
 
     mockBillingUsageService = {
       getMeter: jest.fn().mockResolvedValue(null),
       get: jest.fn().mockResolvedValue({ month: '2026-04', counters: {} }),
       currentWeekKey: jest.fn().mockReturnValue('2026-W18'),
-    };
-
-    mockBillingExtraBalanceRepository = {
-      getBalance: jest.fn().mockResolvedValue(0),
     };
 
     jest.unstable_mockModule('../services/billing.service.js', () => ({
@@ -59,10 +55,6 @@ describe('Billing extras routes integration tests:', () => {
 
     jest.unstable_mockModule('../services/billing.usage.service.js', () => ({
       default: mockBillingUsageService,
-    }));
-
-    jest.unstable_mockModule('../repositories/billing.extraBalance.repository.js', () => ({
-      default: mockBillingExtraBalanceRepository,
     }));
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -143,7 +135,7 @@ describe('Billing extras routes integration tests:', () => {
     });
 
     test('returns 200 with non-zero balance after pack credit', async () => {
-      mockBillingExtraBalanceRepository.getBalance.mockResolvedValue(500000);
+      mockBillingExtraService.getOrgBalanceContext.mockResolvedValue(500000);
 
       await BillingController.extrasBalance(req, res);
 
@@ -153,7 +145,7 @@ describe('Billing extras routes integration tests:', () => {
     });
 
     test('returns 500 when repository throws', async () => {
-      mockBillingExtraBalanceRepository.getBalance.mockRejectedValue(new Error('DB down'));
+      mockBillingExtraService.getOrgBalanceContext.mockRejectedValue(new Error('DB down'));
 
       await BillingController.extrasBalance(req, res);
 

--- a/modules/billing/tests/billing.subscription.repository.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.unit.tests.js
@@ -185,27 +185,6 @@ describe('BillingSubscriptionRepository unit tests:', () => {
     });
   });
 
-  // ── findAllDueForReset (existing — smoke test) ────────────────────────────
-
-  describe('findAllDueForReset', () => {
-    test('queries for active/trialing status within window', async () => {
-      const from = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-      const to = new Date();
-      const leanMock = jest.fn().mockResolvedValue([]);
-      mockModel.find.mockReturnValue({ lean: leanMock });
-
-      await BillingSubscriptionRepository.findAllDueForReset(from, to);
-
-      expect(mockModel.find).toHaveBeenCalledWith(
-        {
-          status: { $in: ['active', 'trialing'] },
-          currentPeriodStart: { $gte: from, $lte: to },
-        },
-        { organization: 1, currentPeriodStart: 1 },
-      );
-    });
-  });
-
   describe('findAllDueForResetByLastReset', () => {
     test('includes subscriptions with lastResetAt=null', async () => {
       const now = new Date('2026-05-01T12:00:00.000Z');

--- a/modules/billing/tests/billing.usage.repository.integration.tests.js
+++ b/modules/billing/tests/billing.usage.repository.integration.tests.js
@@ -8,7 +8,7 @@ import mongooseService from '../../../lib/services/mongoose.js';
 import { up as renameConsumedHistoryIds } from '../migrations/20260502100000-rename-consumed-history-ids-to-attribution-keys.js';
 
 /**
- * Integration tests for BillingUsageRepository migration-window replay protection.
+ * Integration tests for BillingUsageRepository migration completion checks.
  */
 describe('BillingUsageRepository integration tests:', () => {
   let BillingUsageRepository;
@@ -35,7 +35,7 @@ describe('BillingUsageRepository integration tests:', () => {
     await mongooseService.disconnect();
   });
 
-  test('incrementMeter rejects legacy initial attribution before and after rename migration', async () => {
+  test('legacy consumedHistoryIds are detected until the rename migration runs', async () => {
     const organizationId = new mongoose.Types.ObjectId();
     const historyId = new mongoose.Types.ObjectId();
     const weekKey = '2099-W01';
@@ -53,16 +53,7 @@ describe('BillingUsageRepository integration tests:', () => {
       consumedAttributionKeys: [],
     });
 
-    const preMigrationReplay = await BillingUsageRepository.incrementMeter(
-      organizationId.toString(),
-      weekKey,
-      25,
-      {},
-      idempotencyKey,
-      { meterQuota: 1000, planVersion: 'v1', resetAt: null, month: '2099-01' },
-    );
-
-    expect(preMigrationReplay).toBeNull();
+    await expect(BillingUsageRepository.countLegacyConsumedHistoryIds()).resolves.toBe(1);
     let doc = await collection.findOne({ organizationId, weekKey });
     expect(doc.meterUsed).toBe(100);
     expect(doc.consumedHistoryIds).toEqual([historyId]);
@@ -73,6 +64,7 @@ describe('BillingUsageRepository integration tests:', () => {
     doc = await collection.findOne({ organizationId, weekKey });
     expect(doc.consumedHistoryIds).toBeUndefined();
     expect(doc.consumedAttributionKeys).toEqual([idempotencyKey]);
+    await expect(BillingUsageRepository.countLegacyConsumedHistoryIds()).resolves.toBe(0);
 
     const postMigrationReplay = await BillingUsageRepository.incrementMeter(
       organizationId.toString(),

--- a/modules/billing/tests/billing.usage.repository.unit.tests.js
+++ b/modules/billing/tests/billing.usage.repository.unit.tests.js
@@ -444,4 +444,15 @@ describe('BillingUsageRepository — meter extensions unit tests:', () => {
       expect(result.modifiedCount).toBe(0);
     });
   });
+
+  describe('countLegacyConsumedHistoryIds', () => {
+    test('counts documents with the legacy consumedHistoryIds field', async () => {
+      mockModel.countDocuments.mockResolvedValue(2);
+
+      const result = await BillingUsageRepository.countLegacyConsumedHistoryIds();
+
+      expect(mockModel.countDocuments).toHaveBeenCalledWith({ consumedHistoryIds: { $exists: true } });
+      expect(result).toBe(2);
+    });
+  });
 });

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -54,8 +54,11 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
         meterMode: true,
         defaultPlan: 'starter',
         meter: {
-          runBaseUnits: 1,
+          runBase: 1,
           dollarsToUnitRatio: 1000,
+        },
+        alerts: {
+          thresholdPercents: [80, 100],
         },
       },
     };
@@ -80,6 +83,7 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
 
     mockMeterOutboxRepository = {
       create: jest.fn(),
+      findByIdempotencyKey: jest.fn(),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -266,6 +270,41 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       expect(result.extrasConsumed).toBe(10000);
     });
 
+    test('incrementMeterWithOutbox treats E11000 outbox create as existing row', async () => {
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 });
+      const existingOutbox = { _id: 'outbox_existing', idempotencyKey: 'hist_overflow:initial' };
+      const e11000 = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+      mockMeterOutboxRepository.create.mockRejectedValue(e11000);
+      mockMeterOutboxRepository.findByIdempotencyKey.mockResolvedValue(existingOutbox);
+
+      const result = await BillingUsageService.incrementMeterWithOutbox(
+        orgId,
+        50000,
+        {},
+        'hist_overflow:initial',
+      );
+
+      expect(mockMeterOutboxRepository.findByIdempotencyKey).toHaveBeenCalledWith('hist_overflow:initial');
+      expect(result.outbox).toBe(existingOutbox);
+      expect(result.extrasConsumed).toBe(10000);
+    });
+
+    test('incrementMeterWithOutbox throws desync error when E11000 row cannot be fetched', async () => {
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const e11000 = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 }));
+      mockMeterOutboxRepository.create.mockRejectedValue(e11000);
+      mockMeterOutboxRepository.findByIdempotencyKey.mockResolvedValue(null);
+
+      await expect(
+        BillingUsageService.incrementMeterWithOutbox(orgId, 50000, {}, 'hist_desync:initial'),
+      ).rejects.toThrow('[billing] outbox state desynced');
+    });
+
     test('incrementMeterWithOutbox does not create outbox row for replay', async () => {
       mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
@@ -297,6 +336,19 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       expect(result.alertCrossed).toBe('80');
       // Should mark alertedAt80 atomically via repository
       expect(mockUsageRepository.markThreshold).toHaveBeenCalledWith(updatedDoc._id, 'alertedAt80');
+    });
+
+    test('respects thresholdPercents config override', async () => {
+      mockConfig.billing.alerts.thresholdPercents = [100];
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 400001, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_threshold_override');
+
+      expect(result.alertCrossed).toBeNull();
+      expect(mockUsageRepository.markThreshold).not.toHaveBeenCalled();
     });
 
     test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -351,6 +351,22 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       expect(mockUsageRepository.markThreshold).not.toHaveBeenCalled();
     });
 
+    test('warns and skips when thresholdPercents contains unsupported value (not 80/100)', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockConfig.billing.alerts.thresholdPercents = [90];
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 460000, meterQuota: 500000, alertedAt80: null, alertedAt100: null });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 1, {}, 'hist_threshold_unsupported');
+
+      expect(result.alertCrossed).toBeNull();
+      expect(mockUsageRepository.markThreshold).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('threshold 90% has no schema field'));
+      warnSpy.mockRestore();
+    });
+
     test('should NOT re-emit threshold 80 when already alerted (alertedAt80 set)', async () => {
       mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockResolvedValue(makePlan({ meterQuota: 500000 }));

--- a/modules/billing/tests/billing.usageHeader.integration.tests.js
+++ b/modules/billing/tests/billing.usageHeader.integration.tests.js
@@ -94,6 +94,7 @@ describe('Billing usage header integration tests:', () => {
     };
     mockBillingExtraService = {
       listLedger: jest.fn(),
+      getOrgBalanceContext: jest.fn().mockResolvedValue(700),
     };
     mockBillingExtraBalanceRepository = {
       getBalance: jest.fn().mockResolvedValue(700),

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -17,14 +17,13 @@ describe('Billing webhook refund integration tests:', () => {
   /**
    * Build a stub Stripe charge object for charge.refunded webhook tests.
    * @param {Object} [overrides={}] - Fields to override on the stub charge object.
-   * @returns {Object} A stub Stripe charge object with refunds.data[0].amount set.
+   * @returns {Object} A stub Stripe charge object with refund data set.
    */
   const makeCharge = (overrides = {}) => ({
     id: 'ch_test_001',
     amount: 4900,
     amount_refunded: 4900,
-    // charge.refunds.data[0].amount = this event's refund delta (not cumulative)
-    refunds: { data: [{ id: 'rf_test_001', amount: 4900 }] },
+    refunds: { data: [{ id: 'rf_test_001', amount: 4900, created: 1770000000 }] },
     metadata: {
       organizationId: orgId,
       stripeSessionId,
@@ -95,9 +94,9 @@ describe('Billing webhook refund integration tests:', () => {
 
   describe('handleChargeRefunded', () => {
     test('full refund — calls refundPartial with correct orgId, sessionId, delta amount and packId', async () => {
-      // refunds.data[0].amount = 4900 (this event's delta, same as total for single refund)
+      // latest refund amount = 4900 (this event's delta, same as total for single refund)
       await BillingWebhookService.handleChargeRefunded(
-        makeCharge({ refunds: { data: [{ id: 'rf_001', amount: 4900 }] } }),
+        makeCharge({ refunds: { data: [{ id: 'rf_001', amount: 4900, created: 1770000000 }] } }),
       );
 
       expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 4900, 'pack_500k');
@@ -105,15 +104,31 @@ describe('Billing webhook refund integration tests:', () => {
 
     test('partial refund — calls refundPartial with delta amount (not cumulative total)', async () => {
       // Simulates 2nd of two 2450¢ partial refunds: amount_refunded=4900 (cumulative) but
-      // refunds.data[0].amount=2450 (this event's delta) — handler must use delta to avoid over-debit
+      // latest refund amount=2450 (this event's delta) — handler must use delta to avoid over-debit
       await BillingWebhookService.handleChargeRefunded(
         makeCharge({
           amount_refunded: 4900, // cumulative — should NOT be used
-          refunds: { data: [{ id: 'rf_002', amount: 2450 }] }, // delta — correct value
+          refunds: { data: [{ id: 'rf_002', amount: 2450, created: 1770000001 }] }, // delta — correct value
         }),
       );
 
       expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 2450, 'pack_500k');
+    });
+
+    test('uses latest refund by created timestamp instead of array order', async () => {
+      await BillingWebhookService.handleChargeRefunded(
+        makeCharge({
+          amount_refunded: 6000,
+          refunds: {
+            data: [
+              { id: 'rf_old', amount: 1000, created: 1770000000 },
+              { id: 'rf_latest', amount: 5000, created: 1770000100 },
+            ],
+          },
+        }),
+      );
+
+      expect(mockExtraService.refundPartial).toHaveBeenCalledWith(orgId, stripeSessionId, 5000, 'pack_500k');
     });
 
     test('should skip when organizationId is missing', async () => {
@@ -157,7 +172,7 @@ describe('Billing webhook refund integration tests:', () => {
       expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
     });
 
-    test('should skip when refunds.data[0].amount is absent or zero', async () => {
+    test('should skip when latest refund amount is absent or zero', async () => {
       // refunds.data empty — no delta available
       await BillingWebhookService.handleChargeRefunded(
         makeCharge({ refunds: { data: [] } }),

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -387,6 +387,41 @@ describe('Billing webhook subscription unit tests:', () => {
           },
         ),
       ).resolves.not.toThrow();
+      expect(mockResetService.resetWeek).not.toHaveBeenCalled();
+    });
+
+    test('forceRotateForPlanChange throw falls back to resetWeek once when period also changed', async () => {
+      const oldPeriodStart = 1700000000;
+      const newPeriodStart = 1700604800;
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockResetService.forceRotateForPlanChange.mockRejectedValue(new Error('db unavailable'));
+
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: newPeriodStart + 2592000,
+          current_period_start: newPeriodStart,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        {
+          data: {
+            previous_attributes: {
+              current_period_start: oldPeriodStart,
+              items: {
+                data: [{ price: { metadata: { planId: 'starter' } } }],
+              },
+            },
+          },
+        },
+      );
+
+      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledTimes(1);
+      expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
+      expect(mockResetService.resetWeek).toHaveBeenCalledWith(orgId, new Date(newPeriodStart * 1000));
     });
 
     test('plan change with no newPeriodStart still force rotates', async () => {


### PR DESCRIPTION
## Summary

Comprehensive billing module hardening bundling 3 logical groupings on overlapping surfaces. Goal: module the simplest, cleanest, most configurable possible.

Source: 4-agent audit 2026-05-02 found 22 backend findings (1 🔴 + 7 🟠 + 8 🟡 + 4 🔵 + 2 ⚪).

## Sections

### A — Atomicity hardening (🔴 + 7 issues)
- `markFailedAttempt`: single atomic aggregation pipeline op — closes TOCTOU where 2 concurrent crons both win the `$inc` phase then both flip `status: failed`, double-emitting `billing.extras_debit.exhausted`
- `incrementMeterWithOutbox`: try/catch + E11000 fetch for outbox create crash recovery — closes free compute leak where meter incremented but outbox row missing
- Zero-cost `attribute()`: now writes idempotency key even with `units=0` — closes double-charge replay when later retry has non-zero costs
- `forceRotateForPlanChange`: `planChangeResetTriggered` set BEFORE try — closes double-rotate via fallback `resetWeek` on throw
- E11000 retry: legacy `consumedHistoryIds` filter added symmetrically to retry branch
- `unitsFromCosts`: null `ratioVersion` + non-null costs → hard-fail in meterMode, warn otherwise
- `BillingMeterOutbox`: `timestamps:true`, drop manual `createdAt`
- `billing.policy.js`: drop stale ESLint `no-unused-vars` disable

### B — DRY + lib extraction (3 🟠 + 5 🟡 + 3 🔵)
- `billing.webhook.controller`: all 3 raw `res.status().json()` → `responses.error()` canonical envelope
- `billing.controller`: direct repo call → `BillingExtraService.getOrgBalanceContext()` (layering fix)
- `_ensureStripeCustomer`: extracted private helper deduplicating ~50 lines of find-or-create logic between `createCheckout` + `createExtrasCheckout`
- `billing.processedStripeEvent.schema.js`: NEW — Zod schema parity with Mongoose model
- `lib/billing.isoWeek.js`: NEW — `currentWeekKey()` + `isoWeekKey(date)` single source (was duplicated in usage.service + reset.service with DST divergence risk)
- `findAllDueForReset` deprecated: removed from repo + test mocks
- `lib/billing.cron-utils.js`: NEW — `applyJitter(maxMs)` using `crypto.randomInt`, applied to all 3 crons
- `billing.plans.controller`: unit tests added (success + Stripe down paths)
- `lib/billing.errors.js`: NEW — `isDuplicateKeyError(err)` single source (was 3 inline duplicates)
- `lib/billing.constants.js`: NEW — all shared getters/constants, kills dynamic imports in hot path

### C — Config knobs surfacing (NEW)
All magic numbers extracted to `config.billing.*` with safe defaults. Backward-compat: all defaults preserve current behavior. `runBaseUnits` kept as deprecated alias.
- `billing.meter.{runBase, fallbackPlanId, maxUnitsPerOperation}`
- `billing.outbox.{maxRetryAttempts, retryIntervalSec}`
- `billing.crons.jitterMaxMs`
- `billing.planChange.preserveUsageDefault`
- `billing.alerts.thresholdPercents`
- `billing.events.extrasExhausted`

README documents each knob with downstream override examples.

### Boot migration guard (B.7)
Dual-read `consumedHistoryIds` removed. Boot now asserts `countDocuments({consumedHistoryIds: {$exists: true}}) === 0` when `meterMode: true` — aborts deploy if unmigrated docs remain.

## Test plan

- [x] Unit: 88 suites, 1078 tests green
- [x] Integration: 24 suites, 323 tests green (including lifecycle, refund, usageHeader)
- [x] Lint clean
- [x] Critical-review: 0 critical/high (2 nit, 1 medium boot-timing accepted pattern)
- [ ] CI green
- [ ] Concurrent cron simulation: 1 exhausted event for 2 racing pods (`billing.lifecycle.integration.tests.js`)
- [ ] Outbox E11000 recovery (`billing.lifecycle.integration.tests.js`)
- [ ] forceRotate throw fallback (`billing.webhook.subscription.unit.tests.js`)
- [ ] All new config knobs verifiable via override (`billing.config-knobs.unit.tests.js`)