### PR TITLE
fix(billing): Stripe state safety + webhook ordering (audit Codex P0+P1)

### DIFF
--- a/modules/billing/controllers/billing.controller.js
+++ b/modules/billing/controllers/billing.controller.js
@@ -20,6 +20,9 @@ const checkout = async (req, res) => {
     const url = await BillingService.createCheckout(req.organization, priceId, successUrl, cancelUrl);
     responses.success(res, 'checkout session created')({ url });
   } catch (err) {
+    if (err.code === 'subscription_already_active') {
+      return res.status(409).json({ type: 'error', message: err.message, code: 'subscription_already_active', portalUrl: err.portalUrl });
+    }
     const status = err.message?.startsWith('Invalid') || err.message?.includes('not found') ? 422 : 502;
     const title = status === 422 ? 'Unprocessable Entity' : 'Bad Gateway';
     responses.error(res, status, title, 'Failed to create checkout session')(err);

--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -44,12 +44,12 @@ const handleWebhook = async (req, res) => {
         break;
       case 'customer.subscription.deleted':
         await BillingWebhookService.withIdempotency(event, (e) =>
-          BillingWebhookService.handleSubscriptionDeleted(e.data.object),
+          BillingWebhookService.handleSubscriptionDeleted(e.data.object, e),
         );
         break;
       case 'invoice.payment_failed':
         await BillingWebhookService.withIdempotency(event, (e) =>
-          BillingWebhookService.handleInvoicePaymentFailed(e.data.object),
+          BillingWebhookService.handleInvoicePaymentFailed(e.data.object, e),
         );
         break;
       case 'invoice.payment_succeeded':

--- a/modules/billing/crons/billing.dunningSweep.js
+++ b/modules/billing/crons/billing.dunningSweep.js
@@ -57,8 +57,11 @@ try {
 
   for (const sub of staleSubs) {
     try {
-      const subscription = await BillingSubscriptionRepository.markUnpaid(String(sub._id));
-      if (!subscription) continue; // markUnpaid returns null on invalid id
+      const subscription = await BillingSubscriptionRepository.markUnpaid(String(sub._id), threshold);
+      if (!subscription) {
+        console.log(`[billing.dunningSweep] sub ${sub._id} skipped — already recovered`);
+        continue;
+      }
 
       try {
         await OrganizationRepository.setPlan(String(sub.organization), 'free');

--- a/modules/billing/migrations/20260503000000-add-stripe-event-created-at.js
+++ b/modules/billing/migrations/20260503000000-add-stripe-event-created-at.js
@@ -1,0 +1,23 @@
+/**
+ * Migration: Add stripeEventCreatedAt field to subscriptions collection
+ *
+ * Additive only — no backfill needed. The webhook guard uses
+ * `$or: [{ stripeEventCreatedAt: null }, { stripeEventCreatedAt: { $lt: event.created } }]`
+ * so existing documents (null) accept the first event unconditionally.
+ *
+ * Idempotent: safe to run multiple times.
+ *
+ * @returns {Promise<void>}
+ */
+export async function up() {
+  // No raw index creation needed: the Mongoose Subscription model owns
+  // the schema definition; Mongoose syncs indexes at bootstrap.
+  // No document backfill: existing docs with stripeEventCreatedAt=null
+  // are handled by the $exists: false / null branch in webhook guards.
+}
+
+/**
+ * Down: no-op — field is additive and backward-compatible.
+ * @returns {void}
+ */
+export function down() {}

--- a/modules/billing/models/billing.subscription.model.mongoose.js
+++ b/modules/billing/models/billing.subscription.model.mongoose.js
@@ -79,6 +79,14 @@ const SubscriptionMongoose = new Schema(
       type: Date,
       default: null,
     },
+    /**
+     * Stripe event.created timestamp (Unix seconds) of the last processed subscription event.
+     * Used to guard webhook handlers against out-of-order delivery — older events are skipped.
+     */
+    stripeEventCreatedAt: {
+      type: Number,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -25,6 +25,7 @@ const baseShape = {
   currentPeriodStart: z.coerce.date().nullable().optional(),
   pastDueSince: z.coerce.date().nullable().optional(),
   lastResetAt: z.coerce.date().nullable().optional(),
+  stripeEventCreatedAt: z.number().int().nullable().optional(),
 };
 
 const Subscription = z.object({

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -192,19 +192,49 @@ const findStaleDunning = (threshold) => {
 
 /**
  * @function markUnpaid
- * @description Atomically transition a subscription to 'unpaid' and downgrade plan to 'free'.
- *              Idempotent: if the subscription is already unpaid the operation is effectively a no-op.
+ * @description Conditionally transition a subscription to 'unpaid' and downgrade plan to 'free'.
+ *              Guards on status='past_due' AND pastDueSince <= threshold to prevent overwriting
+ *              a subscription recovered by invoice.payment_succeeded between the dunning find and update.
+ *              Returns null when the condition no longer matches (subscription already recovered).
  * @param {string} id - The subscription ObjectId (string).
- * @returns {Promise<Object|null>} The updated subscription document or null if id is invalid.
+ * @param {Date} threshold - Only mark unpaid when pastDueSince <= threshold.
+ * @returns {Promise<Object|null>} The updated subscription document, null if id is invalid or condition unmet.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
-const markUnpaid = (id) => {
+const markUnpaid = (id, threshold) => {
   if (!id || !mongoose.Types.ObjectId.isValid(id)) return null;
-  return Subscription.findByIdAndUpdate(
-    id,
+  if (!(threshold instanceof Date)) throw new TypeError('threshold must be a Date instance');
+  return Subscription.findOneAndUpdate(
+    { _id: id, status: 'past_due', pastDueSince: { $lte: threshold } },
     { $set: { status: 'unpaid', plan: 'free' } },
     { returnDocument: 'after', runValidators: true },
   ).exec();
+};
+
+/**
+ * @function updateIfEventNewer
+ * @description Atomically update a subscription only when the incoming Stripe event is newer
+ *              than the last processed event. Prevents out-of-order webhook delivery from
+ *              overwriting more-recent state.
+ *              Returns null when the guard prevents the write (stale event).
+ * @param {string} id - The subscription ObjectId (string).
+ * @param {number} eventCreatedAt - Stripe event.created Unix timestamp.
+ * @param {Object} fields - Fields to $set on the document.
+ * @returns {Promise<Object|null>} Updated doc, or null if id invalid or event is stale.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const updateIfEventNewer = (id, eventCreatedAt, fields) => {
+  if (!id || !mongoose.Types.ObjectId.isValid(id)) return null;
+  return Subscription.findOneAndUpdate(
+    {
+      _id: id,
+      $or: [{ stripeEventCreatedAt: null }, { stripeEventCreatedAt: { $lt: eventCreatedAt } }],
+    },
+    { $set: { ...fields, stripeEventCreatedAt: eventCreatedAt } },
+    { returnDocument: 'after', runValidators: true },
+  )
+    .populate(defaultPopulate)
+    .exec();
 };
 
 export default {
@@ -221,4 +251,5 @@ export default {
   updateLastResetAt,
   findStaleDunning,
   markUnpaid,
+  updateIfEventNewer,
 };

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -81,6 +81,30 @@ const _ensureStripeCustomer = async (stripe, organization) => {
 };
 
 /**
+ * @desc Create a Stripe Customer Portal session for the given organization
+ * @param {Object} organization - The organization document
+ * @param {String} returnUrl - Optional URL to redirect back to after portal
+ * @returns {Promise<String>} Portal session URL
+ */
+const createPortalSession = async (organization, returnUrl) => {
+  const stripe = getStripe();
+  if (!stripe) throw new Error('Stripe is not configured');
+
+  const subscription = await SubscriptionRepository.findByOrganization(organization._id);
+  if (!subscription?.stripeCustomerId) throw new Error('No Stripe customer found for this organization');
+
+  const params = { customer: subscription.stripeCustomerId };
+  if (returnUrl) {
+    if (!isAllowedUrl(returnUrl)) throw new Error('Invalid return URL: must be a valid URL (production requires HTTPS and a matching application domain)');
+    params.return_url = returnUrl;
+  }
+
+  const session = await stripe.billingPortal.sessions.create(params);
+
+  return session.url;
+};
+
+/**
  * @desc Create a Stripe Checkout Session for the given organization
  * @param {Object} organization - The organization document
  * @param {String} priceId - Stripe price ID
@@ -109,6 +133,18 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
     throw new Error('Invalid priceId: must be an active published price');
   }
 
+  // Block checkout when an active subscription already exists — direct to portal for changes
+  const existingForBlock = await SubscriptionRepository.findByOrganization(organization._id);
+  const blockStatuses = ['active', 'trialing', 'past_due'];
+  if (existingForBlock?.stripeSubscriptionId && blockStatuses.includes(existingForBlock.status)) {
+    const portalUrl = await createPortalSession(organization);
+    const err = new Error('Subscription already active');
+    err.statusCode = 409;
+    err.code = 'subscription_already_active';
+    err.portalUrl = portalUrl;
+    throw err;
+  }
+
   const subscription = await _ensureStripeCustomer(stripe, organization);
 
   const checkoutParams = {
@@ -130,30 +166,6 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
     checkoutParams,
     { idempotencyKey: `sub_checkout_${String(organization._id)}_${priceId}` },
   );
-
-  return session.url;
-};
-
-/**
- * @desc Create a Stripe Customer Portal session for the given organization
- * @param {Object} organization - The organization document
- * @param {String} returnUrl - Optional URL to redirect back to after portal
- * @returns {Promise<String>} Portal session URL
- */
-const createPortalSession = async (organization, returnUrl) => {
-  const stripe = getStripe();
-  if (!stripe) throw new Error('Stripe is not configured');
-
-  const subscription = await SubscriptionRepository.findByOrganization(organization._id);
-  if (!subscription?.stripeCustomerId) throw new Error('No Stripe customer found for this organization');
-
-  const params = { customer: subscription.stripeCustomerId };
-  if (returnUrl) {
-    if (!isAllowedUrl(returnUrl)) throw new Error('Invalid return URL: must be a valid URL (production requires HTTPS and a matching application domain)');
-    params.return_url = returnUrl;
-  }
-
-  const session = await stripe.billingPortal.sessions.create(params);
 
   return session.url;
 };

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 
 import config from '../../../config/index.js';
 import getStripe from '../lib/stripe.js';
+import logger from '../../../lib/services/logger.js';
 import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
 import ProcessedStripeEventRepository from '../repositories/billing.processedStripeEvent.repository.js';
 import OrganizationRepository from '../../organizations/repositories/organizations.repository.js';
@@ -208,16 +209,19 @@ const handleSubscriptionUpdated = async (subscription, event) => {
     ? new Date(subscription.current_period_start * 1000)
     : undefined;
 
-  const updatePayload = {
-    _id: existing._id,
+  const fields = {
     plan: newPlan,
     status: subscription.status,
     currentPeriodEnd: new Date(subscription.current_period_end * 1000),
     cancelAtPeriodEnd: subscription.cancel_at_period_end,
   };
-  if (newPeriodStart) updatePayload.currentPeriodStart = newPeriodStart;
+  if (newPeriodStart) fields.currentPeriodStart = newPeriodStart;
 
-  await SubscriptionRepository.update(updatePayload);
+  const updated = await SubscriptionRepository.updateIfEventNewer(String(existing._id), event.created, fields);
+  if (!updated) {
+    logger.info('[billing.webhook] skipped stale event', { eventId: event.id, type: event.type });
+    return;
+  }
 
   const organizationId = String(existing.organization?._id || existing.organization);
   await syncOrganizationPlan(organizationId, newPlan);
@@ -297,15 +301,18 @@ const handleSubscriptionUpdated = async (subscription, event) => {
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const handleSubscriptionDeleted = async (subscription) => {
+const handleSubscriptionDeleted = async (subscription, event) => {
   const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
   if (!existing) return;
 
-  await SubscriptionRepository.update({
-    _id: existing._id,
+  const updated = await SubscriptionRepository.updateIfEventNewer(String(existing._id), event.created, {
     plan: 'free',
     status: 'canceled',
   });
+  if (!updated) {
+    logger.info('[billing.webhook] skipped stale event', { eventId: event.id, type: event.type });
+    return;
+  }
 
   await syncOrganizationPlan(existing.organization?._id || existing.organization, 'free');
 };
@@ -319,21 +326,25 @@ const handleSubscriptionDeleted = async (subscription) => {
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const handleInvoicePaymentFailed = async (invoice) => {
+const handleInvoicePaymentFailed = async (invoice, event) => {
   const { subscription: stripeSubscriptionId } = invoice;
   if (!stripeSubscriptionId) return;
 
   const existing = await SubscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId);
   if (!existing) return;
 
-  const updatePayload = { _id: existing._id, status: 'past_due' };
+  const fields = { status: 'past_due' };
 
   // Only set pastDueSince on first failure — do not reset the grace-period clock on retries.
   if (existing.pastDueSince == null) {
-    updatePayload.pastDueSince = new Date();
+    fields.pastDueSince = new Date();
   }
 
-  await SubscriptionRepository.update(updatePayload);
+  const updated = await SubscriptionRepository.updateIfEventNewer(String(existing._id), event.created, fields);
+  if (!updated) {
+    logger.info('[billing.webhook] skipped stale event', { eventId: event.id, type: event.type });
+    return;
+  }
 
   const organizationId = String(existing.organization?._id || existing.organization);
   try {

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -167,8 +167,9 @@ describe('Billing service unit tests:', () => {
 
       const createdSub = { stripeCustomerId: 'cus_new123' };
       mockSubscriptionRepository.findByOrganization
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(createdSub);
+        .mockResolvedValueOnce(null)   // block guard: no active sub
+        .mockResolvedValueOnce(null)   // _ensureStripeCustomer: no existing sub → create customer
+        .mockResolvedValueOnce(createdSub); // _ensureStripeCustomer: final check
       mockSubscriptionRepository.create.mockResolvedValue(createdSub);
 
       const mod = await import('../services/billing.service.js');
@@ -195,8 +196,9 @@ describe('Billing service unit tests:', () => {
       const existingSub = { _id: 'sub_existing', stripeCustomerId: null };
       const updatedSub = { _id: 'sub_existing', stripeCustomerId: 'cus_new123' };
       mockSubscriptionRepository.findByOrganization
-        .mockResolvedValueOnce(existingSub)
-        .mockResolvedValueOnce(updatedSub);
+        .mockResolvedValueOnce(existingSub)  // block guard: no stripeSubscriptionId → no block
+        .mockResolvedValueOnce(existingSub)  // _ensureStripeCustomer: has no stripeCustomerId → create
+        .mockResolvedValueOnce(updatedSub);  // _ensureStripeCustomer: final check
       mockSubscriptionRepository.update.mockResolvedValue(updatedSub);
 
       const mod = await import('../services/billing.service.js');
@@ -298,6 +300,92 @@ describe('Billing service unit tests:', () => {
       const callArgs = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
       expect(callArgs.automatic_tax).toBeUndefined();
       expect(callArgs.customer_update).toBeUndefined();
+    });
+
+    test('should throw 409 with portalUrl when active subscription exists', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_block_active' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_active',
+        stripeSubscriptionId: 'sub_active',
+        status: 'active',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await expect(
+        BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel'),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'subscription_already_active',
+        portalUrl: 'https://billing.stripe.com/portal_123',
+      });
+
+      expect(mockStripeInstance.checkout.sessions.create).not.toHaveBeenCalled();
+      expect(mockStripeInstance.billingPortal.sessions.create).toHaveBeenCalledWith({
+        customer: 'cus_active',
+      });
+    });
+
+    test('should throw 409 with portalUrl when past_due subscription exists', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_block_past_due' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_past_due',
+        stripeSubscriptionId: 'sub_past_due',
+        status: 'past_due',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      await expect(
+        BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel'),
+      ).rejects.toMatchObject({ statusCode: 409, code: 'subscription_already_active' });
+    });
+
+    test('should allow checkout when subscription is canceled', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_allow_canceled' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_canceled',
+        stripeSubscriptionId: 'sub_old',
+        status: 'canceled',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      const url = await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
+
+      expect(url).toBe('https://checkout.stripe.com/session_123');
+      expect(mockStripeInstance.checkout.sessions.create).toHaveBeenCalled();
+    });
+
+    test('should allow checkout when no stripeSubscriptionId even if status is active', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_allow_no_sub_id' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue({
+        stripeCustomerId: 'cus_no_sub_id',
+        stripeSubscriptionId: null,
+        status: 'active',
+      });
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      const url = await BillingService.createCheckout(mockOrganization, 'price_starter_m', 'http://ok', 'http://cancel');
+
+      expect(url).toBe('https://checkout.stripe.com/session_123');
     });
   });
 

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -154,7 +154,7 @@ describe('Billing webhook controller unit tests:', () => {
     const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw' };
     await BillingWebhookController.handleWebhook(req, res);
 
-    expect(mockBillingWebhookService.handleSubscriptionDeleted).toHaveBeenCalledWith({ id: 'sub_del' });
+    expect(mockBillingWebhookService.handleSubscriptionDeleted).toHaveBeenCalledWith({ id: 'sub_del' }, eventData);
     expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -173,7 +173,7 @@ describe('Billing webhook controller unit tests:', () => {
     const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw' };
     await BillingWebhookController.handleWebhook(req, res);
 
-    expect(mockBillingWebhookService.handleInvoicePaymentFailed).toHaveBeenCalledWith({ id: 'inv_fail' });
+    expect(mockBillingWebhookService.handleInvoicePaymentFailed).toHaveBeenCalledWith({ id: 'inv_fail' }, eventData);
     expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/modules/billing/tests/billing.cron.dunningSweep.unit.tests.js
+++ b/modules/billing/tests/billing.cron.dunningSweep.unit.tests.js
@@ -35,6 +35,7 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
     mockModel = {
       find: jest.fn(),
       findByIdAndUpdate: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     mockOrganizationModel = {
@@ -94,14 +95,16 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
   });
 
   describe('markUnpaid', () => {
-    test('sets status to unpaid and plan to free', async () => {
+    const threshold = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
+    test('sets status to unpaid and plan to free with conditional guard', async () => {
       const updated = { _id: subId, status: 'unpaid', plan: 'free' };
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
 
-      const result = await BillingSubscriptionRepository.markUnpaid(subId);
+      const result = await BillingSubscriptionRepository.markUnpaid(subId, threshold);
 
-      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledWith(
-        subId,
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: subId, status: 'past_due', pastDueSince: { $lte: threshold } },
         { $set: { status: 'unpaid', plan: 'free' } },
         expect.objectContaining({ returnDocument: 'after' }),
       );
@@ -109,18 +112,28 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
     });
 
     test('returns null for invalid id', async () => {
-      const result = await BillingSubscriptionRepository.markUnpaid('not-valid');
+      const result = await BillingSubscriptionRepository.markUnpaid('not-valid', threshold);
       expect(result).toBeNull();
-      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
     test('returns null for missing id', async () => {
-      const result = await BillingSubscriptionRepository.markUnpaid(undefined);
+      const result = await BillingSubscriptionRepository.markUnpaid(undefined, threshold);
+      expect(result).toBeNull();
+    });
+
+    test('returns null when sub no longer matches condition (recovered)', async () => {
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+
+      const result = await BillingSubscriptionRepository.markUnpaid(subId, threshold);
+
       expect(result).toBeNull();
     });
   });
 
   describe('dunning sweep logic (integration of findStaleDunning + markUnpaid + OrganizationRepository)', () => {
+    const threshold = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
     test('processes multiple stale subscriptions', async () => {
       const staleSubs = [
         { _id: subId, organization: orgId },
@@ -128,15 +141,15 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
       ];
       const leanMock = jest.fn().mockResolvedValue(staleSubs);
       mockModel.find.mockReturnValue({ lean: leanMock });
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue({}) });
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue({}) });
 
       const returned = await BillingSubscriptionRepository.findStaleDunning(new Date());
       let processed = 0;
       let errors = 0;
       for (const sub of returned) {
         try {
-          await BillingSubscriptionRepository.markUnpaid(String(sub._id));
-          processed += 1;
+          const result = await BillingSubscriptionRepository.markUnpaid(String(sub._id), threshold);
+          if (result) processed += 1;
         } catch {
           errors += 1;
         }
@@ -144,7 +157,7 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
 
       expect(processed).toBe(2);
       expect(errors).toBe(0);
-      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledTimes(2);
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
     });
 
     test('counts errors and continues when markUnpaid throws', async () => {
@@ -154,7 +167,7 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
       ];
       const leanMock = jest.fn().mockResolvedValue(staleSubs);
       mockModel.find.mockReturnValue({ lean: leanMock });
-      mockModel.findByIdAndUpdate
+      mockModel.findOneAndUpdate
         .mockReturnValueOnce({ exec: jest.fn().mockRejectedValue(new Error('DB error')) })
         .mockReturnValue({ exec: jest.fn().mockResolvedValue({}) });
 
@@ -163,8 +176,8 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
       let errors = 0;
       for (const sub of returned) {
         try {
-          await BillingSubscriptionRepository.markUnpaid(String(sub._id));
-          processed += 1;
+          const result = await BillingSubscriptionRepository.markUnpaid(String(sub._id), threshold);
+          if (result) processed += 1;
         } catch {
           errors += 1;
         }
@@ -175,19 +188,16 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
     });
 
     test('desync: markUnpaid succeeds but setPlan throws — increments desyncErrors', async () => {
-      // Simulate the cron compensation path: markUnpaid OK, OrganizationRepository.setPlan fails.
-      // Cron should not rethrow — it logs and increments desyncErrors, continues processing.
       const updatedSub = { _id: subId, organization: orgId, status: 'unpaid', plan: 'free' };
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updatedSub) });
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updatedSub) });
 
       const setPlanMock = jest.fn().mockRejectedValue(new Error('org DB error'));
 
-      // Replicate cron loop logic inline (cron imports are not re-executed in unit context)
       let processed = 0;
       let desyncErrors = 0;
       const staleSubs = [{ _id: subId, organization: orgId }];
       for (const sub of staleSubs) {
-        const subscription = await BillingSubscriptionRepository.markUnpaid(String(sub._id));
+        const subscription = await BillingSubscriptionRepository.markUnpaid(String(sub._id), threshold);
         if (!subscription) continue;
         try {
           await setPlanMock(String(sub.organization), 'free');
@@ -203,12 +213,25 @@ describe('billing.dunningSweep cron — BillingSubscriptionRepository:', () => {
     });
 
     test('markUnpaid returns null for invalid sub id — cron skips (continue)', async () => {
-      // markUnpaid returns null for invalid ids; cron should continue without incrementing errors.
       const badSubId = 'not-a-valid-objectid';
-      const result = await BillingSubscriptionRepository.markUnpaid(badSubId);
+      const result = await BillingSubscriptionRepository.markUnpaid(badSubId, threshold);
 
       expect(result).toBeNull();
-      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('markUnpaid returns null when sub recovered between find and update — cron skips gracefully', async () => {
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+
+      let processed = 0;
+      const staleSubs = [{ _id: subId, organization: orgId }];
+      for (const sub of staleSubs) {
+        const subscription = await BillingSubscriptionRepository.markUnpaid(String(sub._id), threshold);
+        if (!subscription) continue;
+        processed += 1;
+      }
+
+      expect(processed).toBe(0);
     });
   });
 });

--- a/modules/billing/tests/billing.events.unit.tests.js
+++ b/modules/billing/tests/billing.events.unit.tests.js
@@ -23,6 +23,7 @@ describe('Billing plan.changed event unit tests:', () => {
       findByStripeCustomerId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue({ _id: subId }),
     };
 
     jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
@@ -46,6 +47,10 @@ describe('Billing plan.changed event unit tests:', () => {
       },
     }));
 
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
     // Import service and events from the same module context
     const mod = await import('../services/billing.webhook.service.js');
     BillingWebhookService = mod.default;
@@ -61,7 +66,6 @@ describe('Billing plan.changed event unit tests:', () => {
   test('should emit plan.changed event when plan changes (downgrade)', async () => {
     const existing = { _id: subId, organization: { _id: orgId } };
     mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-    mockSubscriptionRepository.update.mockResolvedValue({});
 
     const handler = jest.fn();
     billingEvents.on('plan.changed', handler);
@@ -75,6 +79,7 @@ describe('Billing plan.changed event unit tests:', () => {
     };
 
     const event = {
+      id: 'evt_1', created: 1700000100,
       data: {
         object: subscription,
         previous_attributes: {
@@ -98,7 +103,6 @@ describe('Billing plan.changed event unit tests:', () => {
   test('should not emit plan.changed event when plan has not changed', async () => {
     const existing = { _id: subId, organization: { _id: orgId } };
     mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-    mockSubscriptionRepository.update.mockResolvedValue({});
 
     const handler = jest.fn();
     billingEvents.on('plan.changed', handler);
@@ -112,7 +116,7 @@ describe('Billing plan.changed event unit tests:', () => {
     };
 
     // No previous_attributes means no plan change
-    const event = { data: { object: subscription } };
+    const event = { id: 'evt_no_plan', created: 1700000100, data: { object: subscription } };
 
     await BillingWebhookService.handleSubscriptionUpdated(subscription, event);
 
@@ -122,7 +126,6 @@ describe('Billing plan.changed event unit tests:', () => {
   test('should detect upgrade (isDowngrade = false) when moving to higher plan', async () => {
     const existing = { _id: subId, organization: orgId };
     mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-    mockSubscriptionRepository.update.mockResolvedValue({});
 
     const handler = jest.fn();
     billingEvents.on('plan.changed', handler);
@@ -136,6 +139,7 @@ describe('Billing plan.changed event unit tests:', () => {
     };
 
     const event = {
+      id: 'evt_upgrade', created: 1700000100,
       data: {
         object: subscription,
         previous_attributes: {
@@ -159,7 +163,6 @@ describe('Billing plan.changed event unit tests:', () => {
   test('should detect downgrade from enterprise to free', async () => {
     const existing = { _id: subId, organization: orgId };
     mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-    mockSubscriptionRepository.update.mockResolvedValue({});
 
     const handler = jest.fn();
     billingEvents.on('plan.changed', handler);
@@ -173,6 +176,7 @@ describe('Billing plan.changed event unit tests:', () => {
     };
 
     const event = {
+      id: 'evt_downgrade', created: 1700000100,
       data: {
         object: subscription,
         previous_attributes: {
@@ -196,7 +200,6 @@ describe('Billing plan.changed event unit tests:', () => {
   test('should not emit when previous_attributes has items but same plan', async () => {
     const existing = { _id: subId, organization: orgId };
     mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-    mockSubscriptionRepository.update.mockResolvedValue({});
 
     const handler = jest.fn();
     billingEvents.on('plan.changed', handler);
@@ -210,6 +213,7 @@ describe('Billing plan.changed event unit tests:', () => {
     };
 
     const event = {
+      id: 'evt_same_plan', created: 1700000100,
       data: {
         object: subscription,
         previous_attributes: {

--- a/modules/billing/tests/billing.service.unit.tests.js
+++ b/modules/billing/tests/billing.service.unit.tests.js
@@ -23,6 +23,7 @@ describe('Billing webhook service unit tests:', () => {
       findByStripeCustomerId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue({ _id: '507f1f77bcf86cd799439022' }),
     };
 
     mockOrganizationRepository = {
@@ -54,6 +55,10 @@ describe('Billing webhook service unit tests:', () => {
 
     jest.unstable_mockModule('../lib/events.js', () => ({
       default: { emit: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -174,29 +179,31 @@ describe('Billing webhook service unit tests:', () => {
   });
 
   describe('handleSubscriptionUpdated', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_1', created: 1700000100, data: {}, ...overrides });
+
     test('should update subscription when found', async () => {
       const existing = { _id: subId, organization: { _id: orgId } };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionUpdated({
-        id: 'sub_456',
-        status: 'active',
-        current_period_end: 1700000000,
-        cancel_at_period_end: false,
-        items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
-      });
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        makeEvent(),
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith({
-        _id: subId,
-        plan: 'pro',
-        status: 'active',
-        currentPeriodEnd: new Date(1700000000 * 1000),
-        cancelAtPeriodEnd: false,
-      });
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000100,
+        expect.objectContaining({ plan: 'pro', status: 'active', cancelAtPeriodEnd: false }),
+      );
       expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
     });
 
@@ -206,28 +213,32 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionUpdated({ id: 'sub_unknown', items: {} });
+      await BillingWebhookService.handleSubscriptionUpdated({ id: 'sub_unknown', items: {} }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
     });
 
     test('should fall back to plan metadata from item.plan', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionUpdated({
-        id: 'sub_456',
-        status: 'active',
-        current_period_end: 1700000000,
-        cancel_at_period_end: true,
-        items: { data: [{ plan: { metadata: { planId: 'starter' } } }] },
-      });
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000,
+          cancel_at_period_end: true,
+          items: { data: [{ plan: { metadata: { planId: 'starter' } } }] },
+        },
+        makeEvent(),
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000100,
         expect.objectContaining({ plan: 'starter' }),
       );
     });
@@ -235,41 +246,46 @@ describe('Billing webhook service unit tests:', () => {
     test('should default plan to free when no metadata', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionUpdated({
-        id: 'sub_456',
-        status: 'active',
-        current_period_end: 1700000000,
-        cancel_at_period_end: false,
-        items: { data: [{}] },
-      });
+      await BillingWebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000,
+          cancel_at_period_end: false,
+          items: { data: [{}] },
+        },
+        makeEvent(),
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000100,
         expect.objectContaining({ plan: 'free' }),
       );
     });
   });
 
   describe('handleSubscriptionDeleted', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_del', created: 1700000200, ...overrides });
+
     test('should cancel subscription and reset to free', async () => {
       const existing = { _id: subId, organization: { _id: orgId } };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionDeleted({ id: 'sub_456' });
+      await BillingWebhookService.handleSubscriptionDeleted({ id: 'sub_456' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith({
-        _id: subId,
-        plan: 'free',
-        status: 'canceled',
-      });
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000200,
+        { plan: 'free', status: 'canceled' },
+      );
       expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'free');
     });
 
@@ -279,25 +295,28 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleSubscriptionDeleted({ id: 'sub_unknown' });
+      await BillingWebhookService.handleSubscriptionDeleted({ id: 'sub_unknown' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
     });
   });
 
   describe('handleInvoicePaymentFailed', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_fail', created: 1700000300, ...overrides });
+
     test('should mark subscription as past_due and set pastDueSince on first failure', async () => {
       const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, status: 'past_due', pastDueSince: expect.any(Date) }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000300,
+        expect.objectContaining({ status: 'past_due', pastDueSince: expect.any(Date) }),
       );
     });
 
@@ -305,7 +324,7 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: null });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: null }, makeEvent());
 
       expect(mockSubscriptionRepository.findByStripeSubscriptionId).not.toHaveBeenCalled();
     });
@@ -316,9 +335,9 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
     });
   });
 });

--- a/modules/billing/tests/billing.subscription.repository.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.unit.tests.js
@@ -95,14 +95,16 @@ describe('BillingSubscriptionRepository unit tests:', () => {
   // ── markUnpaid ────────────────────────────────────────────────────────────
 
   describe('markUnpaid', () => {
-    test('sets status to unpaid and plan to free atomically', async () => {
+    const threshold = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
+    test('sets status to unpaid and plan to free with conditional guard', async () => {
       const updated = { _id: subId, status: 'unpaid', plan: 'free' };
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
 
-      const result = await BillingSubscriptionRepository.markUnpaid(subId);
+      const result = await BillingSubscriptionRepository.markUnpaid(subId, threshold);
 
-      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledWith(
-        subId,
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: subId, status: 'past_due', pastDueSince: { $lte: threshold } },
         { $set: { status: 'unpaid', plan: 'free' } },
         { returnDocument: 'after', runValidators: true },
       );
@@ -110,41 +112,78 @@ describe('BillingSubscriptionRepository unit tests:', () => {
     });
 
     test('returns null for invalid ObjectId string', async () => {
-      const result = await BillingSubscriptionRepository.markUnpaid('not-a-valid-id');
+      const result = await BillingSubscriptionRepository.markUnpaid('not-a-valid-id', threshold);
       expect(result).toBeNull();
-      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
     test('returns null for undefined id', async () => {
-      const result = await BillingSubscriptionRepository.markUnpaid(undefined);
+      const result = await BillingSubscriptionRepository.markUnpaid(undefined, threshold);
       expect(result).toBeNull();
-      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
     test('returns null for null id', async () => {
-      const result = await BillingSubscriptionRepository.markUnpaid(null);
+      const result = await BillingSubscriptionRepository.markUnpaid(null, threshold);
       expect(result).toBeNull();
-      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
-    test('is idempotent — already-unpaid subscription can be called again without error', async () => {
-      const already = { _id: subId, status: 'unpaid', plan: 'free' };
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(already) });
+    test('throws TypeError when threshold is not a Date', async () => {
+      expect(() => BillingSubscriptionRepository.markUnpaid(subId, '2026-01-01')).toThrow(TypeError);
+      expect(() => BillingSubscriptionRepository.markUnpaid(subId, null)).toThrow(TypeError);
+    });
 
-      const result = await BillingSubscriptionRepository.markUnpaid(subId);
+    test('returns null when sub no longer matches (recovered between find and update)', async () => {
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
 
-      expect(result.status).toBe('unpaid');
-      expect(result.plan).toBe('free');
+      const result = await BillingSubscriptionRepository.markUnpaid(subId, threshold);
+
+      expect(result).toBeNull();
     });
 
     test('uses returnDocument: after to return the updated document', async () => {
       const updated = { _id: subId, status: 'unpaid', plan: 'free' };
-      mockModel.findByIdAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
+      mockModel.findOneAndUpdate.mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
 
-      await BillingSubscriptionRepository.markUnpaid(subId);
+      await BillingSubscriptionRepository.markUnpaid(subId, threshold);
 
-      const callArgs = mockModel.findByIdAndUpdate.mock.calls[0];
+      const callArgs = mockModel.findOneAndUpdate.mock.calls[0];
       expect(callArgs[2]).toMatchObject({ returnDocument: 'after' });
+    });
+  });
+
+  // ── updateIfEventNewer ────────────────────────────────────────────────────
+
+  describe('updateIfEventNewer', () => {
+    test('updates when stripeEventCreatedAt is null (first event)', async () => {
+      const updated = { _id: subId, status: 'canceled', stripeEventCreatedAt: 1000 };
+      const populateMock = jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
+      mockModel.findOneAndUpdate.mockReturnValue({ populate: populateMock });
+
+      const result = await BillingSubscriptionRepository.updateIfEventNewer(subId, 1000, { status: 'canceled' });
+
+      expect(mockModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { _id: subId, $or: [{ stripeEventCreatedAt: null }, { stripeEventCreatedAt: { $lt: 1000 } }] },
+        { $set: { status: 'canceled', stripeEventCreatedAt: 1000 } },
+        { returnDocument: 'after', runValidators: true },
+      );
+      expect(result).toEqual(updated);
+    });
+
+    test('returns null when event is stale (older than stored)', async () => {
+      const populateMock = jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
+      mockModel.findOneAndUpdate.mockReturnValue({ populate: populateMock });
+
+      const result = await BillingSubscriptionRepository.updateIfEventNewer(subId, 500, { status: 'canceled' });
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for invalid id', async () => {
+      const result = await BillingSubscriptionRepository.updateIfEventNewer('not-valid', 1000, {});
+      expect(result).toBeNull();
+      expect(mockModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -29,6 +29,7 @@ describe('Billing webhook checkout unit tests:', () => {
       findByStripeSubscriptionId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue({ _id: subId }),
     };
 
     mockOrganizationRepository = {
@@ -81,6 +82,10 @@ describe('Billing webhook checkout unit tests:', () => {
       default: {
         billing: { plans: ['free', 'starter', 'pro', 'enterprise'] },
       },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
     jest.unstable_mockModule('mongoose', () => ({

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -49,7 +49,12 @@ describe('Billing webhook idempotency unit tests:', () => {
         findByStripeSubscriptionId: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
+        updateIfEventNewer: jest.fn().mockResolvedValue(null),
       },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
     jest.unstable_mockModule('../services/billing.extra.service.js', () => ({

--- a/modules/billing/tests/billing.webhook.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.integration.tests.js
@@ -23,6 +23,7 @@ describe('Billing webhook integration tests:', () => {
       findByStripeSubscriptionId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue({ _id: subId }),
     };
 
     mockOrganizationRepository = {
@@ -54,6 +55,10 @@ describe('Billing webhook integration tests:', () => {
 
     jest.unstable_mockModule('../lib/events.js', () => ({
       default: { emit: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
     const mod = await import('../services/billing.webhook.service.js');
@@ -168,10 +173,16 @@ describe('Billing webhook integration tests:', () => {
   });
 
   describe('handleSubscriptionUpdated', () => {
-    test('should update plan, status, currentPeriodEnd, cancelAtPeriodEnd', async () => {
+    const makeEvent = (overrides = {}) => ({
+      id: 'evt_updated',
+      created: 1700000100,
+      data: {},
+      ...overrides,
+    });
+
+    test('should update plan, status, currentPeriodEnd, cancelAtPeriodEnd via updateIfEventNewer', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const periodEnd = Math.floor(Date.now() / 1000) + 86400;
 
@@ -183,12 +194,13 @@ describe('Billing webhook integration tests:', () => {
           cancel_at_period_end: true,
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
-        { data: {} },
+        makeEvent(),
       );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000100,
         expect.objectContaining({
-          _id: subId,
           plan: 'pro',
           status: 'active',
           currentPeriodEnd: new Date(periodEnd * 1000),
@@ -203,16 +215,34 @@ describe('Billing webhook integration tests:', () => {
 
       await WebhookService.handleSubscriptionUpdated(
         { id: 'sub_unknown', items: { data: [] } },
-        { data: {} },
+        makeEvent(),
       );
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+    });
+
+    test('should skip org sync when event is stale', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+      await WebhookService.handleSubscriptionUpdated(
+        {
+          id: 'sub_456',
+          status: 'active',
+          current_period_end: 1700000000,
+          cancel_at_period_end: false,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        },
+        makeEvent({ created: 500 }),
+      );
+
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
     });
 
     test('should fall back to free when plan metadata is invalid', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await WebhookService.handleSubscriptionUpdated(
         {
@@ -222,25 +252,30 @@ describe('Billing webhook integration tests:', () => {
           cancel_at_period_end: false,
           items: { data: [{ price: { metadata: { planId: 'prod_INVALID' } } }] },
         },
-        { data: {} },
+        makeEvent(),
       );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        expect.any(Number),
         expect.objectContaining({ plan: 'free' }),
       );
     });
   });
 
   describe('handleSubscriptionDeleted', () => {
-    test('should reset plan to free and status to canceled', async () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_deleted', created: 1700000200, ...overrides });
+
+    test('should reset plan to free and status to canceled via updateIfEventNewer', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      await WebhookService.handleSubscriptionDeleted({ id: 'sub_456' });
+      await WebhookService.handleSubscriptionDeleted({ id: 'sub_456' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, plan: 'free', status: 'canceled' }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000200,
+        { plan: 'free', status: 'canceled' },
       );
       expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'free');
     });
@@ -248,27 +283,40 @@ describe('Billing webhook integration tests:', () => {
     test('should return early when subscription not found', async () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
 
-      await WebhookService.handleSubscriptionDeleted({ id: 'sub_unknown' });
+      await WebhookService.handleSubscriptionDeleted({ id: 'sub_unknown' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+    });
+
+    test('should skip org sync when event is stale', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+      await WebhookService.handleSubscriptionDeleted({ id: 'sub_456' }, makeEvent({ created: 100 }));
+
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
     });
   });
 
   describe('handleInvoicePaymentFailed', () => {
-    test('should set status to past_due', async () => {
-      const existing = { _id: subId, organization: orgId };
+    const makeEvent = (overrides = {}) => ({ id: 'evt_failed', created: 1700000300, ...overrides });
+
+    test('should set status to past_due via updateIfEventNewer', async () => {
+      const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, status: 'past_due' }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000300,
+        expect.objectContaining({ status: 'past_due' }),
       );
     });
 
     test('should return early when no subscription ID in invoice', async () => {
-      await WebhookService.handleInvoicePaymentFailed({ subscription: null });
+      await WebhookService.handleInvoicePaymentFailed({ subscription: null }, makeEvent());
 
       expect(mockSubscriptionRepository.findByStripeSubscriptionId).not.toHaveBeenCalled();
     });
@@ -276,9 +324,44 @@ describe('Billing webhook integration tests:', () => {
     test('should return early when subscription not found', async () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
 
-      await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' });
+      await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+    });
+
+    test('should skip when event is stale', async () => {
+      const existing = { _id: subId, organization: orgId, pastDueSince: null };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+      await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent({ created: 50 }));
+
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('webhook ordering guard — stale event is skipped', () => {
+    test('subscription.updated: event t=10 then t=5 keeps state from t=10', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+
+      // First call (t=10) succeeds
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce({ _id: subId, stripeEventCreatedAt: 10 });
+      await WebhookService.handleSubscriptionUpdated(
+        { id: 'sub_456', status: 'active', current_period_end: 9999999999, cancel_at_period_end: false, items: { data: [] } },
+        { id: 'evt_1', created: 10, data: {} },
+      );
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(subId, 10, expect.any(Object));
+
+      // Second call (t=5, older) — repository returns null (guard rejected)
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce(null);
+      await WebhookService.handleSubscriptionUpdated(
+        { id: 'sub_456', status: 'canceled', current_period_end: 9999999999, cancel_at_period_end: false, items: { data: [] } },
+        { id: 'evt_2', created: 5, data: {} },
+      );
+
+      // org plan was synced only once (for the first event)
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/modules/billing/tests/billing.webhook.refund.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.refund.integration.tests.js
@@ -46,6 +46,7 @@ describe('Billing webhook refund integration tests:', () => {
       findByStripeSubscriptionId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue(null),
     };
 
     jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
@@ -82,6 +83,10 @@ describe('Billing webhook refund integration tests:', () => {
         Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
         model: () => ({ findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn() }) }),
       },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
     const mod = await import('../services/billing.webhook.service.js');

--- a/modules/billing/tests/billing.webhook.subscription.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription.unit.tests.js
@@ -28,6 +28,7 @@ describe('Billing webhook subscription unit tests:', () => {
       findByStripeSubscriptionId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      updateIfEventNewer: jest.fn().mockResolvedValue({ _id: subId }),
     };
 
     mockOrganizationRepository = {
@@ -68,6 +69,10 @@ describe('Billing webhook subscription unit tests:', () => {
       default: mockEvents,
     }));
 
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
     jest.unstable_mockModule('../../../config/index.js', () => ({
       default: {
         billing: {
@@ -98,7 +103,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const newPeriodStart = 1700604800;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -110,6 +114,7 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
+          id: 'evt_1', created: 1700000100,
           data: {
             previous_attributes: {
               current_period_start: oldPeriodStart,
@@ -128,9 +133,7 @@ describe('Billing webhook subscription unit tests:', () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      // previous_attributes.current_period_start equals current value → no period change
       await BillingWebhookService.handleSubscriptionUpdated(
         {
           id: 'sub_456',
@@ -140,7 +143,7 @@ describe('Billing webhook subscription unit tests:', () => {
           cancel_at_period_end: false,
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
-        { data: { previous_attributes: { current_period_start: periodStart } } },
+        { id: 'evt_2', created: 1700000100, data: { previous_attributes: { current_period_start: periodStart } } },
       );
 
       expect(mockResetService.resetWeek).not.toHaveBeenCalled();
@@ -149,7 +152,6 @@ describe('Billing webhook subscription unit tests:', () => {
     test('should NOT call resetWeek when previous_attributes has no current_period_start', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -160,7 +162,7 @@ describe('Billing webhook subscription unit tests:', () => {
           cancel_at_period_end: false,
           items: { data: [] },
         },
-        { data: { previous_attributes: { cancel_at_period_end: true } } },
+        { id: 'evt_3', created: 1700000100, data: { previous_attributes: { cancel_at_period_end: true } } },
       );
 
       expect(mockResetService.resetWeek).not.toHaveBeenCalled();
@@ -169,10 +171,8 @@ describe('Billing webhook subscription unit tests:', () => {
     test('resetWeek errors should not disrupt webhook processing (logged, not thrown)', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
       mockResetService.resetWeek.mockRejectedValue(new Error('reset failed'));
 
-      // Should NOT throw
       await expect(
         BillingWebhookService.handleSubscriptionUpdated(
           {
@@ -183,7 +183,7 @@ describe('Billing webhook subscription unit tests:', () => {
             cancel_at_period_end: false,
             items: { data: [] },
           },
-          { data: { previous_attributes: { current_period_start: 1700000000 } } },
+          { id: 'evt_4', created: 1700000100, data: { previous_attributes: { current_period_start: 1700000000 } } },
         ),
       ).resolves.not.toThrow();
     });
@@ -194,7 +194,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -206,34 +205,25 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
+          id: 'evt_5', created: 1700000100,
           data: {
             previous_attributes: {
-              // Same period_start → only plan changed
-              items: {
-                data: [{ price: { metadata: { planId: 'starter' } } }],
-              },
+              items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
             },
           },
         },
       );
 
       expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledTimes(1);
-      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(
-        orgId,
-        { preserveUsage: true },
-      );
+      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(orgId, { preserveUsage: true });
       expect(mockResetService.resetWeek).not.toHaveBeenCalled();
     });
 
     test('plan change AND period_start change — forceRotateForPlanChange AND resetWeek both called', async () => {
-      // Combined plan+period change (e.g. annual→monthly on renewal):
-      // forceRotateForPlanChange refreshes quota snapshot; resetWeek archives the old week.
-      // planChangeResetTriggered must NOT suppress resetWeek when period also changed.
       const oldPeriodStart = 1700000000;
       const newPeriodStart = 1700604800;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -245,23 +235,18 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
+          id: 'evt_6', created: 1700000100,
           data: {
             previous_attributes: {
               current_period_start: oldPeriodStart,
-              items: {
-                data: [{ price: { metadata: { planId: 'starter' } } }],
-              },
+              items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
             },
           },
         },
       );
 
       expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledTimes(1);
-      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(
-        orgId,
-        { preserveUsage: true },
-      );
-      // resetWeek must also run to archive the old week on the period rollover
+      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(orgId, { preserveUsage: true });
       expect(mockResetService.resetWeek).toHaveBeenCalledTimes(1);
       expect(mockResetService.resetWeek).toHaveBeenCalledWith(orgId, new Date(newPeriodStart * 1000));
     });
@@ -270,7 +255,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -282,12 +266,8 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
-          data: {
-            previous_attributes: {
-              // cancel_at_period_end changed, plan did not change
-              cancel_at_period_end: true,
-            },
-          },
+          id: 'evt_7', created: 1700000100,
+          data: { previous_attributes: { cancel_at_period_end: true } },
         },
       );
 
@@ -298,7 +278,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -310,13 +289,8 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
-          data: {
-            previous_attributes: {
-              items: {
-                data: [{ price: { metadata: { planId: 'starter' } } }],
-              },
-            },
-          },
+          id: 'evt_8', created: 1700000100,
+          data: { previous_attributes: { items: { data: [{ price: { metadata: { planId: 'starter' } } }] } } },
         },
       );
 
@@ -330,7 +304,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -342,28 +315,19 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
         },
         {
-          data: {
-            previous_attributes: {
-              items: {
-                data: [{ price: { metadata: { planId: 'pro' } } }],
-              },
-            },
-          },
+          id: 'evt_9', created: 1700000100,
+          data: { previous_attributes: { items: { data: [{ price: { metadata: { planId: 'pro' } } }] } } },
         },
       );
 
       expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledTimes(1);
-      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(
-        orgId,
-        { preserveUsage: true },
-      );
+      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(orgId, { preserveUsage: true });
     });
 
     test('forceRotateForPlanChange errors do not throw (non-fatal)', async () => {
       const periodStart = 1700000000;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
       mockResetService.forceRotateForPlanChange.mockRejectedValue(new Error('db unavailable'));
 
       await expect(
@@ -377,13 +341,8 @@ describe('Billing webhook subscription unit tests:', () => {
             items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
           },
           {
-            data: {
-              previous_attributes: {
-                items: {
-                  data: [{ price: { metadata: { planId: 'starter' } } }],
-                },
-              },
-            },
+            id: 'evt_10', created: 1700000100,
+            data: { previous_attributes: { items: { data: [{ price: { metadata: { planId: 'starter' } } }] } } },
           },
         ),
       ).resolves.not.toThrow();
@@ -395,7 +354,6 @@ describe('Billing webhook subscription unit tests:', () => {
       const newPeriodStart = 1700604800;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
       mockResetService.forceRotateForPlanChange.mockRejectedValue(new Error('db unavailable'));
 
       await BillingWebhookService.handleSubscriptionUpdated(
@@ -408,12 +366,11 @@ describe('Billing webhook subscription unit tests:', () => {
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
+          id: 'evt_11', created: 1700000100,
           data: {
             previous_attributes: {
               current_period_start: oldPeriodStart,
-              items: {
-                data: [{ price: { metadata: { planId: 'starter' } } }],
-              },
+              items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
             },
           },
         },
@@ -427,40 +384,29 @@ describe('Billing webhook subscription unit tests:', () => {
     test('plan change with no newPeriodStart still force rotates', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
           id: 'sub_456',
           status: 'active',
           current_period_end: 1700000000 + 2592000,
-          // No current_period_start field
           cancel_at_period_end: false,
           items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
         },
         {
-          data: {
-            previous_attributes: {
-              items: {
-                data: [{ price: { metadata: { planId: 'starter' } } }],
-              },
-            },
-          },
+          id: 'evt_12', created: 1700000100,
+          data: { previous_attributes: { items: { data: [{ price: { metadata: { planId: 'starter' } } }] } } },
         },
       );
 
       expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledTimes(1);
-      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(
-        orgId,
-        { preserveUsage: true },
-      );
+      expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(orgId, { preserveUsage: true });
     });
 
     test('should update currentPeriodStart in subscription when period_start is present', async () => {
       const newPeriodStart = 1700604800;
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       await BillingWebhookService.handleSubscriptionUpdated(
         {
@@ -471,13 +417,13 @@ describe('Billing webhook subscription unit tests:', () => {
           cancel_at_period_end: false,
           items: { data: [] },
         },
-        { data: { previous_attributes: {} } },
+        { id: 'evt_13', created: 1700000100, data: { previous_attributes: {} } },
       );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          currentPeriodStart: new Date(newPeriodStart * 1000),
-        }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000100,
+        expect.objectContaining({ currentPeriodStart: new Date(newPeriodStart * 1000) }),
       );
     });
   });
@@ -530,28 +476,30 @@ describe('Billing webhook subscription unit tests:', () => {
   });
 
   describe('handleInvoicePaymentFailed', () => {
-    test('should set status to past_due', async () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_failed', created: 1700000300, ...overrides });
+
+    test('should set status to past_due via updateIfEventNewer', async () => {
       const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, status: 'past_due' }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000300,
+        expect.objectContaining({ status: 'past_due' }),
       );
     });
 
     test('should set pastDueSince on first failure (when currently null)', async () => {
       const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
       const before = new Date();
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
       const after = new Date();
 
-      const callArg = mockSubscriptionRepository.update.mock.calls[0][0];
+      const callArg = mockSubscriptionRepository.updateIfEventNewer.mock.calls[0][2];
       expect(callArg.pastDueSince).toBeInstanceOf(Date);
       expect(callArg.pastDueSince.getTime()).toBeGreaterThanOrEqual(before.getTime());
       expect(callArg.pastDueSince.getTime()).toBeLessThanOrEqual(after.getTime());
@@ -561,21 +509,18 @@ describe('Billing webhook subscription unit tests:', () => {
       const originalDate = new Date('2026-04-01T00:00:00Z');
       const existing = { _id: subId, organization: orgId, pastDueSince: originalDate };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
 
-      const callArg = mockSubscriptionRepository.update.mock.calls[0][0];
-      // pastDueSince must NOT be present in the update payload (preserves original date)
+      const callArg = mockSubscriptionRepository.updateIfEventNewer.mock.calls[0][2];
       expect(callArg.pastDueSince).toBeUndefined();
     });
 
     test('should emit payment.failed event with organizationId', async () => {
       const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent());
 
       expect(mockEvents.emit).toHaveBeenCalledWith('payment.failed', { organizationId: orgId });
     });
@@ -583,16 +528,15 @@ describe('Billing webhook subscription unit tests:', () => {
     test('should not throw when event listener errors', async () => {
       const existing = { _id: subId, organization: orgId, pastDueSince: null };
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
       mockEvents.emit.mockImplementation(() => { throw new Error('listener error'); });
 
       await expect(
-        BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }),
+        BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent()),
       ).resolves.not.toThrow();
     });
 
     test('should return early when no subscription ID in invoice', async () => {
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: null });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: null }, makeEvent());
 
       expect(mockSubscriptionRepository.findByStripeSubscriptionId).not.toHaveBeenCalled();
     });
@@ -600,9 +544,9 @@ describe('Billing webhook subscription unit tests:', () => {
     test('should return early when subscription not found', async () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
 
-      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' });
+      await BillingWebhookService.handleInvoicePaymentFailed({ subscription: 'sub_unknown' }, makeEvent());
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- **P0-1 — Block double checkout**: `createCheckout()` now checks for an existing `active`/`trialing`/`past_due` subscription with a `stripeSubscriptionId` before creating a Checkout Session. If found, throws 409 with a portal URL. Controller maps this to `{ code: 'subscription_already_active', portalUrl }`.
- **P0-2 — Race-safe dunning sweep**: `markUnpaid(id, threshold)` now uses `findOneAndUpdate` with a conditional filter `{ status: 'past_due', pastDueSince: { $lte: threshold } }` — atomic, prevents clobbering a subscription that recovered between `findStaleDunning` and the update.
- **P1-3 — Webhook event ordering**: `handleSubscriptionUpdated`, `handleSubscriptionDeleted`, and `handleInvoicePaymentFailed` now use `updateIfEventNewer(id, event.created, fields)` — a new repository method that guards on a `stripeEventCreatedAt` timestamp field, rejecting out-of-order Stripe retries.

## Changes

- `billing.service.js`: block guard in `createCheckout`, `createPortalSession` moved before (fixes forward-ref)
- `billing.webhook.service.js`: all 3 handlers use `updateIfEventNewer`; logger import added
- `billing.webhook.controller.js`: passes full event to `handleSubscriptionDeleted` + `handleInvoicePaymentFailed`
- `billing.controller.js`: 409 branch for `subscription_already_active`
- `billing.subscription.repository.js`: new `markUnpaid(id, threshold)` + `updateIfEventNewer(id, ts, fields)`
- `billing.subscription.model.mongoose.js` + `billing.subscription.schema.js`: `stripeEventCreatedAt` field
- `migrations/20260503000000-add-stripe-event-created-at.js`: no-op additive migration
- All billing test files: logger + `updateIfEventNewer` mocks, updated assertions, 4 new 409 tests

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 88 suites, 1089 tests, all pass
- [x] `npm run test:integration` — 24 suites, 327 tests, all pass