### PR TITLE
fix(billing): V6 P1 #1 #2 + P2 — applied:false debit + admin refundRequestId + /usage local

### DIFF
--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -1,8 +1,6 @@
 /**
  * Module dependencies
  */
-import { randomUUID } from 'node:crypto';
-
 import responses from '../../../lib/helpers/responses.js';
 import getStripe from '../lib/stripe.js';
 
@@ -10,6 +8,9 @@ import getStripe from '../lib/stripe.js';
  * @desc Admin endpoint to trigger a Stripe refund for a charge.
  *       Initiates the Stripe refund; actual ledger debit happens via the
  *       `charge.refunded` webhook (single source of truth).
+ *       Idempotency: uses caller-provided refundRequestId when present to prevent
+ *       double-refund on admin double-click. Falls back to minute-resolution key
+ *       when refundRequestId is absent — 2 clicks within the same minute → 1 refund.
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
  * @returns {Promise<void>}
@@ -17,7 +18,7 @@ import getStripe from '../lib/stripe.js';
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
 const adminRefundCharge = async (req, res) => {
   try {
-    const { chargeId, amountCents, reason } = req.body;
+    const { chargeId, amountCents, reason, refundRequestId } = req.body;
 
     if (typeof chargeId !== 'string' || chargeId.trim() === '') {
       return responses.error(res, 422, 'Unprocessable Entity', 'Failed to refund charge')(
@@ -39,7 +40,11 @@ const adminRefundCharge = async (req, res) => {
       );
     }
 
-    const idempotencyKey = `refund_${chargeId}_${amountCents ?? 'full'}_${randomUUID()}`;
+    // Prefer caller-supplied stable key; fall back to minute-resolution to bound double-click window.
+    const idempotencyKey = refundRequestId
+      ? `refund_admin_${refundRequestId}`
+      : `refund_${chargeId}_${amountCents ?? 'full'}_${Math.floor(Date.now() / 60000)}`;
+
     const params = { charge: chargeId, reason: reason || 'requested_by_customer' };
     if (amountCents !== undefined) params.amount = amountCents;
 

--- a/modules/billing/controllers/billing.controller.js
+++ b/modules/billing/controllers/billing.controller.js
@@ -73,8 +73,8 @@ const getSubscription = async (req, res) => {
  */
 const getUsage = async (req, res) => {
   try {
-    // Determine current plan via service layer
-    const subscription = await BillingService.getSubscription(req.organization._id);
+    // Local DB read only — no Stripe fetch needed for plan/status on the usage page.
+    const subscription = await BillingService.getLocalSubscription(req.organization._id);
     const plan = (!subscription || !activeStatuses.includes(subscription.status)) ? 'free' : (subscription.plan || 'free');
 
     if (config.billing?.meterMode) {

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -82,6 +82,8 @@ const AdminRefundRequest = z
     amountCents: z.number().int().positive().optional(),
     // Stripe refund reason: https://stripe.com/docs/api/refunds/create#create_refund-reason
     reason: z.enum(['duplicate', 'fraudulent', 'requested_by_customer']).optional(),
+    // Caller-provided stable key for Stripe idempotency (prevents admin double-click double-refund).
+    refundRequestId: z.string().min(8).max(128).optional(),
   })
   .strict();
 

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -88,9 +88,11 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
 /**
  * @function debit
  * @description Atomically debit meter units from the extra balance.
- *              Guards: (1) cachedBalance >= amount, (2) no existing ledger entry with refId.
- *              Both checks are in the atomic filter — no TOCTOU.
- *              Returns applied=false if balance is insufficient OR refId already used.
+ *              Guard: no existing ledger entry with refId (idempotency).
+ *              Negative cachedBalance is allowed — the requireQuota middleware gates entry
+ *              at scrap-start (remaining > 0); mid-operation overages may push the balance
+ *              below zero, which correctly reflects economic debt (same pattern as refundPartial).
+ *              Returns applied=false only when refId is already present (replay).
  * @param {string} orgId - The organization ObjectId (string).
  * @param {number} amount - Meter units to debit (must be > 0).
  * @param {string} refId - Unique reference for this debit (idempotency key).
@@ -111,7 +113,6 @@ const debit = async (orgId, amount, refId) => {
   const doc = await BillingExtraBalance().findOneAndUpdate(
     {
       organization: orgId,
-      cachedBalance: { $gte: amount },
       'ledger.refId': { $ne: refId },
     },
     {

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -217,7 +217,7 @@ const markUnpaid = (id, threshold) => {
  *              than the last processed event. Prevents out-of-order webhook delivery from
  *              overwriting more-recent state.
  *              Same-second events are ordered by lex-string comparison of event IDs (evt_ prefix
- *              makes these globally monotonic within a second) — V5 P1 #2 tiebreaker.
+ *              makes these globally deterministic within a second) — V5 P1 #2 tiebreaker.
  *              Returns null when the guard prevents the write (stale event).
  * @param {string} id - The subscription ObjectId (string).
  * @param {number} eventCreatedAt - Stripe event.created Unix timestamp (seconds).

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -268,6 +268,16 @@ const fetchSubscriptionDetails = async (stripeSubscriptionId) => {
 };
 
 /**
+ * @desc Get subscription for the given organization — local DB only, no Stripe fetch.
+ *       Use for lightweight reads (e.g. /usage endpoint) that only need plan/status fields.
+ *       Does NOT include currentPeriodEnd, cancelAtPeriodEnd or other live Stripe fields.
+ * @param {String} organizationId - The organization ID
+ * @returns {Promise<Object|null>} Local subscription document or null
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const getLocalSubscription = (organizationId) => SubscriptionRepository.findByOrganization(organizationId);
+
+/**
  * @desc Get subscription for the given organization.
  *       Merges cached local fields with live Stripe details for UI consumers.
  *       Falls back gracefully when Stripe is not configured or the subscription is free.
@@ -288,5 +298,6 @@ export default {
   createExtrasCheckout,
   createPortalSession,
   fetchSubscriptionDetails,
+  getLocalSubscription,
   getSubscription,
 };

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -188,7 +188,7 @@ describe('Billing admin integration tests:', () => {
     expect(res.status).toHaveBeenCalledWith(403);
   });
 
-  test('admin user can POST refund with valid body', async () => {
+  test('admin user can POST refund with valid body (fallback minute-resolution key)', async () => {
     const routes = await buildRoutes();
     const refundRoute = routes.get('/api/admin/billing/refund');
     const res = {
@@ -204,17 +204,17 @@ describe('Billing admin integration tests:', () => {
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_123', reason: 'duplicate', amount: 2500 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_2500_[0-9a-f-]{36}$/) },
+      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_2500_\d+$/) },
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
-  test('two calls same charge same amount produce two separate idempotency keys', async () => {
+  test('two calls with same refundRequestId use identical idempotency key (double-click protection)', async () => {
     const routes = await buildRoutes();
     const refundRoute = routes.get('/api/admin/billing/refund');
 
     const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() });
-    const body = { chargeId: 'ch_test_dup', amountCents: 1000, reason: 'duplicate' };
+    const body = { chargeId: 'ch_test_dup', amountCents: 1000, reason: 'duplicate', refundRequestId: 'req-abc12345' };
 
     await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
     await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
@@ -223,10 +223,28 @@ describe('Billing admin integration tests:', () => {
     expect(calls).toHaveLength(2);
     const key1 = calls[0][1].idempotencyKey;
     const key2 = calls[1][1].idempotencyKey;
-    expect(key1).toMatch(/^refund_ch_test_dup_1000_[0-9a-f-]{36}$/);
-    expect(key2).toMatch(/^refund_ch_test_dup_1000_[0-9a-f-]{36}$/);
-    // Keys are distinct — each call gets its own idempotency window
-    expect(key1).not.toBe(key2);
+    // Both calls share the same key → Stripe deduplicates → 1 effective refund
+    expect(key1).toBe('refund_admin_req-abc12345');
+    expect(key2).toBe('refund_admin_req-abc12345');
+  });
+
+  test('two calls without refundRequestId in the same minute use the same minute-resolution key', async () => {
+    const routes = await buildRoutes();
+    const refundRoute = routes.get('/api/admin/billing/refund');
+
+    const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() });
+    const body = { chargeId: 'ch_test_dup2', amountCents: 500, reason: 'duplicate' };
+
+    await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
+    await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
+
+    const calls = mockStripeInstance.refunds.create.mock.calls;
+    expect(calls).toHaveLength(2);
+    const key1 = calls[0][1].idempotencyKey;
+    const key2 = calls[1][1].idempotencyKey;
+    expect(key1).toMatch(/^refund_ch_test_dup2_500_\d+$/);
+    // Within a test (same millisecond) both calls land in the same minute → same key
+    expect(key1).toBe(key2);
   });
 
   test('invalid body returns 422 from schema validation', async () => {
@@ -279,7 +297,7 @@ describe('Billing admin integration tests:', () => {
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_123', reason: 'requested_by_customer' },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_full_[0-9a-f-]{36}$/) },
+      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_full_\d+$/) },
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -625,6 +625,43 @@ describe('Billing service unit tests:', () => {
     });
   });
 
+  describe('getLocalSubscription', () => {
+    test('should return local subscription without calling Stripe', async () => {
+      // V6 P2: getLocalSubscription is a lightweight DB-only read, no Stripe fetch.
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_local_sub' } },
+      }));
+
+      mockStripeInstance.subscriptions = { retrieve: jest.fn() };
+
+      const mockSub = { organization: orgId, plan: 'pro', stripeSubscriptionId: 'sub_local_999' };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(mockSub);
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      const result = await BillingService.getLocalSubscription(orgId);
+
+      expect(result).toBe(mockSub);
+      expect(mockStripeInstance.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+
+    test('should return null when no subscription exists', async () => {
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { stripe: { secretKey: 'sk_test_local_sub_null' } },
+      }));
+
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+
+      const mod = await import('../services/billing.service.js');
+      BillingService = mod.default;
+
+      const result = await BillingService.getLocalSubscription(orgId);
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('fetchSubscriptionDetails', () => {
     test('should return mapped Stripe fields', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -256,13 +256,27 @@ describe('BillingExtraBalance unit tests:', () => {
         expect(result.doc).toBe(updatedDoc);
       });
 
-      test('should return applied=false when balance is insufficient', async () => {
-        mockModel.findOneAndUpdate.mockResolvedValue(null);
+      test('should apply debit and allow negative balance when amount exceeds cachedBalance (overage)', async () => {
+        // cachedBalance=10, amount=15 → balance becomes -5; applied=true (no balance guard)
+        const updatedDoc = makeDoc({ cachedBalance: -5, ledger: [{ kind: 'debit', amount: -15, refId: 'ref_overage' }] });
+        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
 
-        const result = await BillingExtraBalanceRepository.debit(orgId, 999999, 'ref_big');
+        const result = await BillingExtraBalanceRepository.debit(orgId, 15, 'ref_overage');
 
-        expect(result.applied).toBe(false);
-        expect(result.doc).toBeNull();
+        expect(result.applied).toBe(true);
+        expect(result.doc.cachedBalance).toBe(-5);
+      });
+
+      test('filter does NOT include cachedBalance guard (allows negative balance)', async () => {
+        let capturedFilter;
+        mockModel.findOneAndUpdate.mockImplementation((filter) => {
+          capturedFilter = filter;
+          return Promise.resolve(makeDoc({ cachedBalance: -5 }));
+        });
+
+        await BillingExtraBalanceRepository.debit(orgId, 15, 'ref_no_balance_guard');
+
+        expect(capturedFilter).not.toHaveProperty('cachedBalance');
       });
 
       test('should return applied=false when refId already used (replay protection)', async () => {

--- a/modules/billing/tests/billing.extras.controller.unit.tests.js
+++ b/modules/billing/tests/billing.extras.controller.unit.tests.js
@@ -32,6 +32,7 @@ describe('Billing extras controller unit tests:', () => {
 
     mockBillingService = {
       createExtrasCheckout: jest.fn(),
+      getLocalSubscription: jest.fn(),
       getSubscription: jest.fn(),
     };
 
@@ -217,7 +218,7 @@ describe('Billing extras controller unit tests:', () => {
   describe('getUsage (meter mode)', () => {
     test('should return meter fields when meterMode=true', async () => {
       mockConfig.billing.meterMode = true;
-      mockBillingService.getSubscription.mockResolvedValue({ plan: 'pro', status: 'active' });
+      mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'pro', status: 'active' });
       mockBillingUsageService.getMeter.mockResolvedValue({
         weekKey: '2026-W18',
         planVersion: 'v2',
@@ -247,7 +248,7 @@ describe('Billing extras controller unit tests:', () => {
 
     test('should return zeroed meter fields when meter doc is null', async () => {
       mockConfig.billing.meterMode = true;
-      mockBillingService.getSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
+      mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
       mockBillingUsageService.getMeter.mockResolvedValue(null);
       mockBillingExtraService.getOrgBalanceContext.mockResolvedValue(0);
 
@@ -266,7 +267,7 @@ describe('Billing extras controller unit tests:', () => {
 
     test('should return legacy usage shape when meterMode=false', async () => {
       mockConfig.billing.meterMode = false;
-      mockBillingService.getSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
+      mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
       mockBillingUsageService.get.mockResolvedValue({ month: '2026-04', counters: { scraps_create: 1 } });
 
       await BillingController.getUsage(req, res);

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -65,7 +65,7 @@ describe('Admin refund controller unit tests:', () => {
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'requested_by_customer' },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_full_[0-9a-f-]{36}$/) },
+      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_full_\d+$/) },
     );
     expect(mockResponses.success).toHaveBeenCalledWith(res, 'billing refund created');
   });
@@ -78,7 +78,7 @@ describe('Admin refund controller unit tests:', () => {
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'requested_by_customer', amount: 2000 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_[0-9a-f-]{36}$/) },
+      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_\d+$/) },
     );
   });
 
@@ -90,28 +90,49 @@ describe('Admin refund controller unit tests:', () => {
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'duplicate', amount: 2000 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_[0-9a-f-]{36}$/) },
+      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_\d+$/) },
     );
   });
 
-  test('idempotency key is "refund_{chargeId}_full" for full refund', async () => {
+  test('idempotency key uses minute-resolution fallback for full refund (no refundRequestId)', async () => {
     const req = { body: { chargeId: 'ch_abc' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
     const call = mockStripeInstance.refunds.create.mock.calls[0];
-    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_full_[0-9a-f-]{36}$/);
+    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_full_\d+$/);
   });
 
-  test('idempotency key is "refund_{chargeId}_{amountCents}_{uuid}" for partial refund', async () => {
+  test('idempotency key uses minute-resolution fallback for partial refund (no refundRequestId)', async () => {
     const req = { body: { chargeId: 'ch_abc', amountCents: 500 } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
     const call = mockStripeInstance.refunds.create.mock.calls[0];
-    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_500_[0-9a-f-]{36}$/);
+    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_500_\d+$/);
+  });
+
+  test('refundRequestId generates stable "refund_admin_{id}" key (double-click protection)', async () => {
+    const req = { body: { chargeId: 'ch_abc', amountCents: 500, refundRequestId: 'req-stable12345' } };
+    const res = makeRes();
+
+    await adminRefundCharge(req, res);
+
+    const call = mockStripeInstance.refunds.create.mock.calls[0];
+    expect(call[1].idempotencyKey).toBe('refund_admin_req-stable12345');
+  });
+
+  test('two calls with same refundRequestId use identical idempotency key', async () => {
+    const body = { chargeId: 'ch_dup', amountCents: 1000, refundRequestId: 'req-dup12345' };
+
+    await adminRefundCharge({ body }, makeRes());
+    await adminRefundCharge({ body }, makeRes());
+
+    const calls = mockStripeInstance.refunds.create.mock.calls;
+    expect(calls[0][1].idempotencyKey).toBe('refund_admin_req-dup12345');
+    expect(calls[1][1].idempotencyKey).toBe('refund_admin_req-dup12345');
   });
 
   test('should return 502 when Stripe is not configured', async () => {

--- a/modules/billing/tests/billing.usage.endpoint.unit.tests.js
+++ b/modules/billing/tests/billing.usage.endpoint.unit.tests.js
@@ -19,6 +19,7 @@ describe('Billing usage endpoint unit tests:', () => {
     jest.resetModules();
 
     mockBillingService = {
+      getLocalSubscription: jest.fn(),
       getSubscription: jest.fn(),
     };
 
@@ -62,7 +63,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return usage and limits for active subscription', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'starter', status: 'active' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'starter', status: 'active' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: { 'documents_create': 5, 'requests_execute': 42 } });
 
     const req = { organization: { _id: orgId } };
@@ -81,7 +82,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return free plan when no subscription', async () => {
-    mockBillingService.getSubscription.mockResolvedValue(null);
+    mockBillingService.getLocalSubscription.mockResolvedValue(null);
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -105,7 +106,7 @@ describe('Billing usage endpoint unit tests:', () => {
     'incomplete_expired',
     'paused',
   ])('should return free plan when subscription status is %s', async (status) => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'starter', status });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'starter', status });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: { 'documents_create': 2 } });
 
     const req = { organization: { _id: orgId } };
@@ -121,7 +122,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return paid plan when subscription status is trialing', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'starter', status: 'trialing' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'starter', status: 'trialing' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -137,7 +138,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return empty limits when plan has no quota config', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'enterprise', status: 'active' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'enterprise', status: 'active' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -153,7 +154,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return correct flattened limits format', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'pro', status: 'active' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'pro', status: 'active' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -169,7 +170,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return empty counters for new org (no usage yet)', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'starter', status: 'active' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'starter', status: 'active' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -184,7 +185,7 @@ describe('Billing usage endpoint unit tests:', () => {
   });
 
   test('should return period from usage month field', async () => {
-    mockBillingService.getSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'free', status: 'active' });
     mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
 
     const req = { organization: { _id: orgId } };
@@ -195,8 +196,20 @@ describe('Billing usage endpoint unit tests:', () => {
     expect(data.period).toBe('2026-03');
   });
 
+  test('should NOT call getSubscription (no Stripe fetch) on usage endpoint', async () => {
+    // V6 P2: /usage uses getLocalSubscription, not getSubscription, to avoid +50ms Stripe call.
+    mockBillingService.getLocalSubscription.mockResolvedValue({ plan: 'starter', status: 'active' });
+    mockBillingUsageService.get.mockResolvedValue({ month: '2026-03', counters: {} });
+
+    const req = { organization: { _id: orgId } };
+    await billingController.getUsage(req, res);
+
+    expect(mockBillingService.getLocalSubscription).toHaveBeenCalledWith(orgId);
+    expect(mockBillingService.getSubscription).not.toHaveBeenCalled();
+  });
+
   test('should return 500 when an error occurs', async () => {
-    mockBillingService.getSubscription.mockRejectedValue(new Error('DB error'));
+    mockBillingService.getLocalSubscription.mockRejectedValue(new Error('DB error'));
 
     const req = { organization: { _id: orgId } };
     await billingController.getUsage(req, res);

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -241,6 +241,23 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
       expect(mockExtraService.debit).toHaveBeenCalledWith(orgId, 10000, 'hist_overflow');
     });
 
+    test('debit is called even when extras balance would go negative (overage allowed)', async () => {
+      // Validates V6 P1 #1 fix: debit repo no longer gates on balance >= amount.
+      // The service always calls debit on overflow; repo allows negative balance.
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockReturnValue(makePlan({ meterQuota: 500000 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 510000, meterQuota: 500000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+      // Simulate repo returning applied=true with negative balance (new behaviour)
+      mockExtraService.debit.mockResolvedValue({ applied: true, doc: { cachedBalance: -5 } });
+
+      const result = await BillingUsageService.incrementMeter(orgId, 50000, {}, 'hist_overage_negative');
+
+      expect(result.applied).toBe(true);
+      expect(result.extrasConsumed).toBe(10000);
+      expect(mockExtraService.debit).toHaveBeenCalledWith(orgId, 10000, 'hist_overage_negative');
+    });
+
     test('should return extrasConsumed=0 and not call debit when within quota', async () => {
       mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
       mockPlanService.getActivePlan.mockReturnValue(makePlan({ meterQuota: 500000 }));

--- a/modules/billing/tests/billing.usageHeader.integration.tests.js
+++ b/modules/billing/tests/billing.usageHeader.integration.tests.js
@@ -78,6 +78,7 @@ describe('Billing usage header integration tests:', () => {
     jest.resetModules();
 
     mockBillingService = {
+      getLocalSubscription: jest.fn().mockResolvedValue({ plan: 'pro', status: 'active' }),
       getSubscription: jest.fn().mockResolvedValue({ plan: 'pro', status: 'active' }),
     };
     mockBillingUsageService = {


### PR DESCRIPTION
## Summary

- **V6 P1 #1** — `debit()` repo: drop `cachedBalance >= amount` filter. Negative balance allowed (same pattern as `refundPartial`). The `requireQuota` middleware is the entry gate; mid-operation overages no longer silently fail to debit, eliminating business loss on weekly reset.
- **V6 P1 #2** — Admin refund: accept optional `refundRequestId` from request body as stable Stripe idempotency key (`refund_admin_{id}`). Fallback without it uses minute-resolution timestamp (`refund_{chargeId}_{amount}_{minute}`) so double-clicks within a minute share a key. Removes `randomUUID()` which guaranteed 2 refunds on double-click.
- **V6 P2** — Add `getLocalSubscription()` (DB-only, no Stripe fetch) to `billing.service.js`. Wire `getUsage` controller to use it instead of `getSubscription()` — eliminates unnecessary +50ms Stripe call on every `/api/billing/usage` request. `getSubscription()` unchanged for the `/subscription` endpoint.
- **V6 P3** — Rename "monotonic tiebreaker" → "deterministic tiebreaker" in `billing.subscription.repository.js:220`. evt_xxx Stripe IDs are not chronologically monotonic — they provide deterministic ordering via lex comparison.

## Files touched

| File | Change |
|------|--------|
| `repositories/billing.extraBalance.repository.js` | Remove `cachedBalance: { $gte: amount }` filter + JSDoc update |
| `controllers/billing.admin.controller.js` | `refundRequestId` param + idempotency key logic, drop `randomUUID` import |
| `models/billing.subscription.schema.js` | Add `refundRequestId: z.string().min(8).max(128).optional()` |
| `services/billing.service.js` | Add `getLocalSubscription()`, export it |
| `controllers/billing.controller.js` | `getUsage` → `getLocalSubscription()` |
| `repositories/billing.subscription.repository.js` | Comment: monotonic → deterministic |
| 6 test files | Updated existing + new tests for all 4 findings |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 1057 passed / 82 suites
- [x] `npm run test:integration` — 326 passed / 23 suites
- [x] `debit()` with overage → `applied:true`, `cachedBalance` negative, ledger entry created
- [x] `debit()` replay (same refId) → `applied:false` (unchanged)
- [x] Admin refund with `refundRequestId` → stable key, double-click → same key
- [x] Admin refund without `refundRequestId`, same minute → same minute-resolution key
- [x] `GET /api/billing/usage` → 0 calls to `stripe.subscriptions.retrieve()`
- [x] `GET /api/billing/subscription` → still calls `getSubscription()` (Stripe fetch intact)