### PR TITLE
fix(billing): V7 polish — debit upsert + concurrent integration tests + refundRequestId required

### DIFF
--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -8,9 +8,8 @@ import getStripe from '../lib/stripe.js';
  * @desc Admin endpoint to trigger a Stripe refund for a charge.
  *       Initiates the Stripe refund; actual ledger debit happens via the
  *       `charge.refunded` webhook (single source of truth).
- *       Idempotency: uses caller-provided refundRequestId when present to prevent
- *       double-refund on admin double-click. Falls back to minute-resolution key
- *       when refundRequestId is absent — 2 clicks within the same minute → 1 refund.
+ *       Idempotency: refundRequestId is required (frontend generates a UUID per click)
+ *       to prevent double-refund on admin double-click at any time interval.
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
  * @returns {Promise<void>}
@@ -33,6 +32,12 @@ const adminRefundCharge = async (req, res) => {
       }
     }
 
+    if (typeof refundRequestId !== 'string' || refundRequestId.trim().length < 8) {
+      return responses.error(res, 422, 'Unprocessable Entity', 'Failed to refund charge')(
+        new Error('invalid argument: refundRequestId must be a string of at least 8 characters'),
+      );
+    }
+
     const stripe = getStripe();
     if (!stripe) {
       return responses.error(res, 502, 'Bad Gateway', 'Failed to refund charge')(
@@ -40,11 +45,7 @@ const adminRefundCharge = async (req, res) => {
       );
     }
 
-    // Prefer caller-supplied stable key; fall back to minute-resolution to bound double-click window.
-    const idempotencyKey = refundRequestId
-      ? `refund_admin_${refundRequestId}`
-      : `refund_${chargeId}_${amountCents ?? 'full'}_${Math.floor(Date.now() / 60000)}`;
-
+    const idempotencyKey = `refund_admin_${refundRequestId}`;
     const params = { charge: chargeId, reason: reason || 'requested_by_customer' };
     if (amountCents !== undefined) params.amount = amountCents;
 

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -83,7 +83,9 @@ const AdminRefundRequest = z
     // Stripe refund reason: https://stripe.com/docs/api/refunds/create#create_refund-reason
     reason: z.enum(['duplicate', 'fraudulent', 'requested_by_customer']).optional(),
     // Caller-provided stable key for Stripe idempotency (prevents admin double-click double-refund).
-    refundRequestId: z.string().min(8).max(128).optional(),
+    // Required — frontend MUST generate a UUID per click and send it. Without this, two clicks
+    // separated by >1 minute could produce two separate Stripe refunds.
+    refundRequestId: z.string().min(8).max(128),
   })
   .strict();
 

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -92,11 +92,13 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
  *              Negative cachedBalance is allowed — the requireQuota middleware gates entry
  *              at scrap-start (remaining > 0); mid-operation overages may push the balance
  *              below zero, which correctly reflects economic debt (same pattern as refundPartial).
+ *              Upserts the document when none exists yet (org paying without prior pack purchase)
+ *              so overage debt is never silently lost on the next weekly meter reset.
  *              Returns applied=false only when refId is already present (replay).
  * @param {string} orgId - The organization ObjectId (string).
  * @param {number} amount - Meter units to debit (must be > 0).
  * @param {string} refId - Unique reference for this debit (idempotency key).
- * @returns {Promise<{doc: Object|null, applied: boolean}>} Updated doc and whether debit was applied.
+ * @returns {Promise<{doc: Object|null, applied: boolean, reason?: string}>} Updated doc and whether debit was applied.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const debit = async (orgId, amount, refId) => {
@@ -110,6 +112,14 @@ const debit = async (orgId, amount, refId) => {
     at: new Date(),
   };
 
+  // Step 1: ensure the document exists (atomic getOrCreate, no-op if already present).
+  await BillingExtraBalance().findOneAndUpdate(
+    { organization: orgId },
+    { $setOnInsert: { organization: orgId, ledger: [], cachedBalance: 0, cachedBalanceAt: new Date() } },
+    { upsert: true },
+  );
+
+  // Step 2: apply the debit with idempotency guard.
   const doc = await BillingExtraBalance().findOneAndUpdate(
     {
       organization: orgId,
@@ -124,7 +134,7 @@ const debit = async (orgId, amount, refId) => {
   );
 
   if (doc) return { doc, applied: true };
-  return { doc: null, applied: false };
+  return { doc: null, applied: false, reason: 'duplicate_step' };
 };
 
 /**

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -133,7 +133,16 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
   // Atomic extras debit — best-effort on the hot path; log and continue on failure
   if (extrasConsumed > 0) {
     try {
-      await BillingExtraService.debit(organizationId, extrasConsumed, idempotencyKey);
+      const debitResult = await BillingExtraService.debit(organizationId, extrasConsumed, idempotencyKey);
+      if (debitResult.applied === false && debitResult.reason !== 'duplicate_step') {
+        // Debit unexpectedly silenced — not a replay. Log for monitoring.
+        console.error('[billing.usage] extras debit unexpectedly not applied', {
+          organizationId,
+          extrasConsumed,
+          idempotencyKey,
+          reason: debitResult.reason,
+        });
+      }
     } catch (err) {
       // Usage is already counted. Log for monitoring — a retry cron or manual backfill
       // can reconcile if needed. Never let a debit failure block the usage write.

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -188,7 +188,7 @@ describe('Billing admin integration tests:', () => {
     expect(res.status).toHaveBeenCalledWith(403);
   });
 
-  test('admin user can POST refund with valid body (fallback minute-resolution key)', async () => {
+  test('admin user can POST refund with valid body and stable idempotency key', async () => {
     const routes = await buildRoutes();
     const refundRoute = routes.get('/api/admin/billing/refund');
     const res = {
@@ -198,13 +198,13 @@ describe('Billing admin integration tests:', () => {
 
     await runHandlers(
       [...refundRoute.all, ...refundRoute.post],
-      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500, reason: 'duplicate' } },
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500, reason: 'duplicate', refundRequestId: 'req-int-test001' } },
       res,
     );
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_123', reason: 'duplicate', amount: 2500 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_2500_\d+$/) },
+      { idempotencyKey: 'refund_admin_req-int-test001' },
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -228,23 +228,17 @@ describe('Billing admin integration tests:', () => {
     expect(key2).toBe('refund_admin_req-abc12345');
   });
 
-  test('two calls without refundRequestId in the same minute use the same minute-resolution key', async () => {
+  test('missing refundRequestId returns 422 from schema validation (BREAKING — required field)', async () => {
     const routes = await buildRoutes();
     const refundRoute = routes.get('/api/admin/billing/refund');
 
-    const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() });
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
     const body = { chargeId: 'ch_test_dup2', amountCents: 500, reason: 'duplicate' };
 
-    await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
-    await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, makeRes());
+    await runHandlers([...refundRoute.all, ...refundRoute.post], { method: 'POST', headers: { 'x-role': 'admin' }, body }, res);
 
-    const calls = mockStripeInstance.refunds.create.mock.calls;
-    expect(calls).toHaveLength(2);
-    const key1 = calls[0][1].idempotencyKey;
-    const key2 = calls[1][1].idempotencyKey;
-    expect(key1).toMatch(/^refund_ch_test_dup2_500_\d+$/);
-    // Within a test (same millisecond) both calls land in the same minute → same key
-    expect(key1).toBe(key2);
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(mockStripeInstance.refunds.create).not.toHaveBeenCalled();
   });
 
   test('invalid body returns 422 from schema validation', async () => {
@@ -291,13 +285,13 @@ describe('Billing admin integration tests:', () => {
 
     await runHandlers(
       [...refundRoute.all, ...refundRoute.post],
-      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', reason: 'requested_by_customer' } },
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', reason: 'requested_by_customer', refundRequestId: 'req-int-full001' } },
       res,
     );
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_123', reason: 'requested_by_customer' },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_123_full_\d+$/) },
+      { idempotencyKey: 'refund_admin_req-int-full001' },
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -314,7 +308,7 @@ describe('Billing admin integration tests:', () => {
 
     await runHandlers(
       [...refundRoute.all, ...refundRoute.post],
-      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500 } },
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500, refundRequestId: 'req-int-err001' } },
       res,
     );
 
@@ -333,7 +327,7 @@ describe('Billing admin integration tests:', () => {
 
     await runHandlers(
       [...refundRoute.all, ...refundRoute.post],
-      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500 } },
+      { method: 'POST', headers: { 'x-role': 'admin' }, body: { chargeId: 'ch_test_123', amountCents: 2500, refundRequestId: 'req-int-arg001' } },
       res,
     );
 

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -247,19 +247,27 @@ describe('BillingExtraBalance unit tests:', () => {
 
     describe('debit', () => {
       test('should apply debit when balance is sufficient and refId is new', async () => {
+        const existingDoc = makeDoc();
         const updatedDoc = makeDoc({ cachedBalance: 400000, ledger: [{ kind: 'debit', amount: -100000, refId: 'ref_1' }] });
-        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+        // Step 1: getOrCreate (no-op on existing); Step 2: actual debit
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(existingDoc)
+          .mockResolvedValueOnce(updatedDoc);
 
         const result = await BillingExtraBalanceRepository.debit(orgId, 100000, 'ref_1');
 
         expect(result.applied).toBe(true);
         expect(result.doc).toBe(updatedDoc);
+        expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
       });
 
       test('should apply debit and allow negative balance when amount exceeds cachedBalance (overage)', async () => {
         // cachedBalance=10, amount=15 → balance becomes -5; applied=true (no balance guard)
+        const existingDoc = makeDoc({ cachedBalance: 10 });
         const updatedDoc = makeDoc({ cachedBalance: -5, ledger: [{ kind: 'debit', amount: -15, refId: 'ref_overage' }] });
-        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(existingDoc)
+          .mockResolvedValueOnce(updatedDoc);
 
         const result = await BillingExtraBalanceRepository.debit(orgId, 15, 'ref_overage');
 
@@ -267,39 +275,69 @@ describe('BillingExtraBalance unit tests:', () => {
         expect(result.doc.cachedBalance).toBe(-5);
       });
 
-      test('filter does NOT include cachedBalance guard (allows negative balance)', async () => {
-        let capturedFilter;
-        mockModel.findOneAndUpdate.mockImplementation((filter) => {
-          capturedFilter = filter;
-          return Promise.resolve(makeDoc({ cachedBalance: -5 }));
+      test('step 1 issues upsert getOrCreate with $setOnInsert (fresh org support)', async () => {
+        let step1Filter;
+        let step1Update;
+        let step1Options;
+        const updatedDoc = makeDoc({ cachedBalance: -50 });
+        mockModel.findOneAndUpdate.mockImplementation((filter, update, options) => {
+          if (!step1Filter) {
+            step1Filter = filter;
+            step1Update = update;
+            step1Options = options;
+            return Promise.resolve(null); // fresh org — no doc yet
+          }
+          return Promise.resolve(updatedDoc);
         });
+
+        await BillingExtraBalanceRepository.debit(orgId, 50, 'ref_fresh');
+
+        expect(step1Options?.upsert).toBe(true);
+        expect(step1Update.$setOnInsert).toMatchObject({ organization: orgId, ledger: [], cachedBalance: 0 });
+      });
+
+      test('filter does NOT include cachedBalance guard (allows negative balance)', async () => {
+        const existingDoc = makeDoc();
+        let step2Filter;
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(existingDoc)
+          .mockImplementation((filter) => {
+            step2Filter = filter;
+            return Promise.resolve(makeDoc({ cachedBalance: -5 }));
+          });
 
         await BillingExtraBalanceRepository.debit(orgId, 15, 'ref_no_balance_guard');
 
-        expect(capturedFilter).not.toHaveProperty('cachedBalance');
+        expect(step2Filter).not.toHaveProperty('cachedBalance');
       });
 
-      test('should return applied=false when refId already used (replay protection)', async () => {
-        // The filter `ledger.refId: { $ne: refId }` won't match if refId exists
-        mockModel.findOneAndUpdate.mockResolvedValue(null);
+      test('should return applied=false with reason duplicate_step when refId already used (replay protection)', async () => {
+        // Step 1: getOrCreate succeeds; Step 2: idempotency filter excludes → null
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(makeDoc())
+          .mockResolvedValueOnce(null);
 
         const result = await BillingExtraBalanceRepository.debit(orgId, 100, 'ref_duplicate');
 
         expect(result.applied).toBe(false);
+        expect(result.reason).toBe('duplicate_step');
       });
 
       test('should push a negative amount entry to the ledger', async () => {
-        let capturedUpdate;
-        mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
-          capturedUpdate = update;
-          return Promise.resolve(makeDoc({ cachedBalance: 0 }));
-        });
+        const existingDoc = makeDoc();
+        let step2Update;
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(existingDoc)
+          .mockImplementation((filter, update) => {
+            step2Update = update;
+            return Promise.resolve(makeDoc({ cachedBalance: 0 }));
+          });
 
         await BillingExtraBalanceRepository.debit(orgId, 500, 'ref_check');
 
-        expect(capturedUpdate.$push.ledger.amount).toBe(-500);
-        expect(capturedUpdate.$push.ledger.kind).toBe('debit');
-        expect(capturedUpdate.$inc.cachedBalance).toBe(-500);
+        expect(step2Update.$push.ledger.amount).toBe(-500);
+        expect(step2Update.$push.ledger.kind).toBe('debit');
+        expect(step2Update.$inc.cachedBalance).toBe(-500);
       });
     });
 

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -57,61 +57,61 @@ describe('Admin refund controller unit tests:', () => {
     jest.restoreAllMocks();
   });
 
-  test('should call stripe.refunds.create with charge and default reason', async () => {
-    const req = { body: { chargeId: 'ch_test_xyz' } };
+  test('should call stripe.refunds.create with charge, default reason and stable idempotency key', async () => {
+    const req = { body: { chargeId: 'ch_test_xyz', refundRequestId: 'req-stable-xyz00' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'requested_by_customer' },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_full_\d+$/) },
+      { idempotencyKey: 'refund_admin_req-stable-xyz00' },
     );
     expect(mockResponses.success).toHaveBeenCalledWith(res, 'billing refund created');
   });
 
   test('should include amount when amountCents is provided', async () => {
-    const req = { body: { chargeId: 'ch_test_xyz', amountCents: 2000 } };
+    const req = { body: { chargeId: 'ch_test_xyz', amountCents: 2000, refundRequestId: 'req-stable-xyz01' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'requested_by_customer', amount: 2000 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_\d+$/) },
+      { idempotencyKey: 'refund_admin_req-stable-xyz01' },
     );
   });
 
   test('should forward an explicit reason when provided', async () => {
-    const req = { body: { chargeId: 'ch_test_xyz', amountCents: 2000, reason: 'duplicate' } };
+    const req = { body: { chargeId: 'ch_test_xyz', amountCents: 2000, reason: 'duplicate', refundRequestId: 'req-stable-xyz02' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
     expect(mockStripeInstance.refunds.create).toHaveBeenCalledWith(
       { charge: 'ch_test_xyz', reason: 'duplicate', amount: 2000 },
-      { idempotencyKey: expect.stringMatching(/^refund_ch_test_xyz_2000_\d+$/) },
+      { idempotencyKey: 'refund_admin_req-stable-xyz02' },
     );
   });
 
-  test('idempotency key uses minute-resolution fallback for full refund (no refundRequestId)', async () => {
+  test('missing refundRequestId returns 422 (BREAKING — required field)', async () => {
     const req = { body: { chargeId: 'ch_abc' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
-    const call = mockStripeInstance.refunds.create.mock.calls[0];
-    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_full_\d+$/);
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to refund charge');
+    expect(mockStripeInstance.refunds.create).not.toHaveBeenCalled();
   });
 
-  test('idempotency key uses minute-resolution fallback for partial refund (no refundRequestId)', async () => {
-    const req = { body: { chargeId: 'ch_abc', amountCents: 500 } };
+  test('refundRequestId shorter than 8 chars returns 422', async () => {
+    const req = { body: { chargeId: 'ch_abc', amountCents: 500, refundRequestId: 'short' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
 
-    const call = mockStripeInstance.refunds.create.mock.calls[0];
-    expect(call[1].idempotencyKey).toMatch(/^refund_ch_abc_500_\d+$/);
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to refund charge');
+    expect(mockStripeInstance.refunds.create).not.toHaveBeenCalled();
   });
 
   test('refundRequestId generates stable "refund_admin_{id}" key (double-click protection)', async () => {
@@ -137,7 +137,7 @@ describe('Admin refund controller unit tests:', () => {
 
   test('should return 502 when Stripe is not configured', async () => {
     mockGetStripe.mockReturnValue(null);
-    const req = { body: { chargeId: 'ch_test' } };
+    const req = { body: { chargeId: 'ch_test', refundRequestId: 'req-no-stripe0' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);
@@ -194,7 +194,7 @@ describe('Admin refund controller unit tests:', () => {
   });
 
   test('should succeed with undefined amountCents (full refund)', async () => {
-    const req = { body: { chargeId: 'ch_test', amountCents: undefined } };
+    const req = { body: { chargeId: 'ch_test', amountCents: undefined, refundRequestId: 'req-full-test0' } };
     const res = makeRes();
 
     await adminRefundCharge(req, res);

--- a/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
+++ b/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
@@ -1,0 +1,159 @@
+/**
+ * Module dependencies.
+ */
+import mongoose from 'mongoose';
+import { describe, beforeAll, beforeEach, afterAll, test, expect } from '@jest/globals';
+
+import config from '../../../config/index.js';
+import mongooseService from '../../../lib/services/mongoose.js';
+
+/**
+ * Integration tests for concurrent overage attribution and debit upsert (V7 P1 + P2).
+ *
+ * Validates:
+ * - Concurrent incrementMeter calls correctly accumulate negative balance + deduplicate ledger.
+ * - A fresh org (no BillingExtraBalance doc) gets a doc created with negative balance on overflow.
+ * - Replay of the same idempotencyKey is a no-op (no double debit).
+ */
+describe('BillingUsage concurrent attribution integration tests:', () => {
+  let BillingUsage;
+  let BillingExtraBalance;
+  let Subscription;
+  let BillingUsageService;
+  let originalMeterMode;
+  let originalPlanDefinitions;
+
+  beforeAll(async () => {
+    originalMeterMode = config.billing.meterMode;
+    originalPlanDefinitions = config.billing.planDefinitions;
+    config.billing.meterMode = true;
+    await mongooseService.loadModels();
+    await mongooseService.connect();
+
+    BillingUsage = mongoose.model('BillingUsage');
+    BillingExtraBalance = mongoose.model('BillingExtraBalance');
+    Subscription = mongoose.model('Subscription');
+
+    BillingUsageService = (await import('../services/billing.usage.service.js')).default;
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      BillingUsage.deleteMany({}),
+      BillingExtraBalance.deleteMany({}),
+      Subscription.deleteMany({}),
+    ]);
+    config.billing.planDefinitions = [
+      { planId: 'pro', version: 'pro-v1', meterQuota: 5, ratios: { scrap: 1 } },
+    ];
+  });
+
+  afterAll(async () => {
+    config.billing.meterMode = originalMeterMode;
+    config.billing.planDefinitions = originalPlanDefinitions;
+    await mongooseService.disconnect();
+  });
+
+  test('concurrent overage attributions persist negative balance + distinct ledger entries', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+
+    await Subscription.create({ organization: organizationId, plan: 'pro', status: 'active' });
+
+    // Seed BillingExtraBalance with an initial balance of 10 units
+    await BillingExtraBalance.create({
+      organization: organizationId,
+      ledger: [{ kind: 'topup', amount: 10, stripeSessionId: 'cs_concurrent_seed' }],
+      cachedBalance: 10,
+    });
+
+    // 5 concurrent attributions, each consuming 15 units (all overflow the 5-unit quota)
+    const promises = Array.from({ length: 5 }, (_, i) =>
+      BillingUsageService.incrementMeter(
+        organizationId.toString(),
+        15,
+        { scrap: 15 },
+        `step-concurrent-${i}`,
+      ),
+    );
+    await Promise.all(promises);
+
+    const balance = await BillingExtraBalance.findOne({ organization: organizationId }).lean();
+    expect(balance).not.toBeNull();
+
+    // All 5 attributions produce some overflow (quota=5, each unit=15 → each call overflows).
+    // Exact total depends on concurrent ordering; what matters: balance is negative.
+    expect(balance.cachedBalance).toBeLessThan(10);
+
+    // 5 distinct debit ledger entries
+    const debits = balance.ledger.filter((e) => e.kind === 'debit');
+    expect(debits).toHaveLength(5);
+
+    const refIds = debits.map((e) => e.refId);
+    for (let i = 0; i < 5; i++) {
+      expect(refIds).toContain(`step-concurrent-${i}`);
+    }
+  });
+
+  test('no balance doc + overflow creates doc with negative balance + debit ledger entry (V7 P1)', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+
+    await Subscription.create({ organization: organizationId, plan: 'pro', status: 'active' });
+
+    // No BillingExtraBalance seed — org has no extras doc yet (fresh paying org)
+    const result = await BillingUsageService.incrementMeter(
+      organizationId.toString(),
+      50,
+      { scrap: 50 },
+      'step-fresh-org',
+    );
+
+    expect(result.applied).toBe(true);
+    // quota=5, 50 units → overflow = 45 units charged to extras
+    expect(result.extrasConsumed).toBe(45);
+
+    const balance = await BillingExtraBalance.findOne({ organization: organizationId }).lean();
+    expect(balance).not.toBeNull();
+    // Started at 0 (newly created doc), debited 45 → final = -45
+    expect(balance.cachedBalance).toBe(-45);
+
+    const debits = balance.ledger.filter((e) => e.kind === 'debit');
+    expect(debits).toHaveLength(1);
+    expect(debits[0].refId).toBe('step-fresh-org');
+  });
+
+  test('replay of same idempotencyKey is a no-op (no double debit)', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+
+    await Subscription.create({ organization: organizationId, plan: 'pro', status: 'active' });
+
+    await BillingExtraBalance.create({
+      organization: organizationId,
+      ledger: [{ kind: 'topup', amount: 100, stripeSessionId: 'cs_replay_seed' }],
+      cachedBalance: 100,
+    });
+
+    // First call
+    await BillingUsageService.incrementMeter(
+      organizationId.toString(),
+      30,
+      { scrap: 30 },
+      'step-replay-key',
+    );
+
+    // Second call with the same idempotencyKey — must be a no-op
+    await BillingUsageService.incrementMeter(
+      organizationId.toString(),
+      30,
+      { scrap: 30 },
+      'step-replay-key',
+    );
+
+    const balance = await BillingExtraBalance.findOne({ organization: organizationId }).lean();
+    // quota=5, 30 units → overage = 25; starting balance = 100 → final = 75. Single debit only.
+    expect(balance.cachedBalance).toBe(75);
+
+    const debits = balance.ledger.filter((e) => e.kind === 'debit');
+    // Only one debit despite two calls
+    expect(debits).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **V7 P1 (fix)** `debit()` now uses a two-step atomic pattern: `getOrCreate` to ensure the `BillingExtraBalance` doc exists, then the idempotency-guarded `findOneAndUpdate`. Prevents silent debt loss on weekly meter reset when a paying org has no prior pack purchase. `incrementMeter` now logs an error on unexpected `applied=false` (reason other than `duplicate_step`).
- **V7 P2 (test)** New `billing.usage.concurrent-attribution.integration.tests.js` with 3 real-DB scenarios: 5 concurrent overflows, fresh-org upsert proof, and replay idempotency guard.
- **V7 P3 (BREAKING feat)** `refundRequestId` is now required (`z.string().min(8).max(128)`) in `AdminRefundRequest` Zod schema. Controller also validates defensively (422 if absent/short). Minute-resolution fallback dropped.

## Breaking change

`POST /api/admin/billing/refund` now requires `refundRequestId` in the request body. Frontend admin must generate a UUID per refund click and send it. Without it, the request returns 422.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run test:unit` — 1058/1058 passing
- [x] `npm run test:integration` — 329/329 passing (24 suites, including new concurrent-attribution suite)
- [x] New integration tests exercise V7 P1 (fresh org upsert), concurrent overage, and replay idempotency
- [x] Admin refund tests updated: minute-resolution tests replaced by required-field 422 assertions