### PR TITLE
refactor(billing): align creditPack to 2-step upsert pattern for direct idempotency (V8 P2)

### DIFF
--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -68,11 +68,7 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
   };
 
   // Step 1: ensure the document exists (atomic getOrCreate, no-op if already present).
-  await BillingExtraBalance().findOneAndUpdate(
-    { organization: orgId },
-    { $setOnInsert: { organization: orgId, ledger: [], cachedBalance: 0, cachedBalanceAt: new Date() } },
-    { upsert: true },
-  );
+  await getOrCreate(orgId);
 
   // Step 2: idempotency-guarded credit (no upsert — doc is guaranteed to exist after step 1).
   const doc = await BillingExtraBalance().findOneAndUpdate(

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -44,13 +44,15 @@ const getOrCreate = (orgId) => {
  * @description Atomically credit extra meter units from a Stripe pack purchase.
  *              Idempotent: if a ledger entry with the same stripeSessionId already
  *              exists, the update is a no-op and applied=false is returned.
- *              Uses a native-Mongo filter `ledger.stripeSessionId: { $ne: stripeSessionId }`
- *              so the idempotency check is part of the atomic update, not a separate read.
+ *              2-step pattern (aligned with debit):
+ *                Step 1 — ensure doc exists (atomic getOrCreate, no-op on replay).
+ *                Step 2 — idempotency-guarded credit (no upsert, returns null on replay).
+ *              Eliminates E11000 duplicate-key risk on direct replay outside withIdempotency.
  * @param {string} orgId - The organization ObjectId (string).
  * @param {number} amount - Meter units to credit (must be > 0).
  * @param {string} stripeSessionId - Stripe checkout session ID (idempotency key).
  * @param {Date|null} [expiresAt=null] - Optional expiry date for the topup entry.
- * @returns {Promise<{doc: Object, applied: boolean}>} Updated doc and whether the credit was applied.
+ * @returns {Promise<{doc: Object|null, applied: boolean, reason?: string}>} Updated doc and whether the credit was applied.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
@@ -65,6 +67,14 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
     ...(expiresAt ? { expiresAt } : {}),
   };
 
+  // Step 1: ensure the document exists (atomic getOrCreate, no-op if already present).
+  await BillingExtraBalance().findOneAndUpdate(
+    { organization: orgId },
+    { $setOnInsert: { organization: orgId, ledger: [], cachedBalance: 0, cachedBalanceAt: new Date() } },
+    { upsert: true },
+  );
+
+  // Step 2: idempotency-guarded credit (no upsert — doc is guaranteed to exist after step 1).
   const doc = await BillingExtraBalance().findOneAndUpdate(
     {
       organization: orgId,
@@ -75,14 +85,11 @@ const creditPack = async (orgId, amount, stripeSessionId, expiresAt = null) => {
       $inc: { cachedBalance: amount },
       $set: { cachedBalanceAt: new Date() },
     },
-    { upsert: true, returnDocument: 'after', runValidators: true },
+    { returnDocument: 'after' },
   );
 
   if (doc) return { doc, applied: true };
-
-  // No doc returned — the stripeSessionId already exists (idempotency hit).
-  const existing = await BillingExtraBalance().findOne({ organization: orgId }).lean();
-  return { doc: existing, applied: false };
+  return { doc: null, applied: false, reason: 'duplicate_session' };
 };
 
 /**

--- a/modules/billing/tests/billing.extraBalance.unit.tests.js
+++ b/modules/billing/tests/billing.extraBalance.unit.tests.js
@@ -210,34 +210,75 @@ describe('BillingExtraBalance unit tests:', () => {
     describe('creditPack — idempotency', () => {
       test('should apply credit when stripeSessionId is new', async () => {
         const updatedDoc = makeDoc({ cachedBalance: 500000, ledger: [{ kind: 'topup', amount: 500000, stripeSessionId: 'cs_abc' }] });
-        mockModel.findOneAndUpdate.mockResolvedValue(updatedDoc);
+        // Step 1: getOrCreate (no-op on existing); Step 2: actual credit
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(makeDoc())
+          .mockResolvedValueOnce(updatedDoc);
 
         const result = await BillingExtraBalanceRepository.creditPack(orgId, 500000, 'cs_abc', null);
 
         expect(result.applied).toBe(true);
         expect(result.doc.cachedBalance).toBe(500000);
+        expect(mockModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
       });
 
-      test('should return applied=false when stripeSessionId already exists (idempotency)', async () => {
-        // First findOneAndUpdate returns null (filter excluded — session already present)
-        mockModel.findOneAndUpdate.mockResolvedValue(null);
-        // creditPack fallback uses findOne().lean() to fetch existing doc
-        const existingDoc = makeDoc({ cachedBalance: 500000, ledger: [{ kind: 'topup', amount: 500000, stripeSessionId: 'cs_abc' }] });
-        mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(existingDoc) });
+      test('should return applied=false with reason duplicate_session when stripeSessionId already exists', async () => {
+        // Step 1: getOrCreate succeeds; Step 2: idempotency filter excludes → null
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(makeDoc())
+          .mockResolvedValueOnce(null);
 
         const result = await BillingExtraBalanceRepository.creditPack(orgId, 500000, 'cs_abc', null);
 
         expect(result.applied).toBe(false);
-        expect(result.doc).toBe(existingDoc);
+        expect(result.reason).toBe('duplicate_session');
+        expect(result.doc).toBeNull();
+      });
+
+      test('step 1 issues upsert getOrCreate with $setOnInsert (fresh org support)', async () => {
+        let step1Filter;
+        let step1Update;
+        let step1Options;
+        const updatedDoc = makeDoc({ cachedBalance: 500000 });
+        mockModel.findOneAndUpdate.mockImplementation((filter, update, options) => {
+          if (!step1Filter) {
+            step1Filter = filter;
+            step1Update = update;
+            step1Options = options;
+            return Promise.resolve(null); // fresh org — no doc yet
+          }
+          return Promise.resolve(updatedDoc);
+        });
+
+        await BillingExtraBalanceRepository.creditPack(orgId, 500000, 'cs_fresh', null);
+
+        expect(step1Options?.upsert).toBe(true);
+        expect(step1Update.$setOnInsert).toMatchObject({ organization: orgId, ledger: [], cachedBalance: 0 });
+      });
+
+      test('step 2 does NOT include upsert (doc guaranteed by step 1)', async () => {
+        let step2Options;
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(makeDoc())
+          .mockImplementation((filter, update, options) => {
+            step2Options = options;
+            return Promise.resolve(makeDoc({ cachedBalance: 1000 }));
+          });
+
+        await BillingExtraBalanceRepository.creditPack(orgId, 1000, 'cs_no_upsert', null);
+
+        expect(step2Options?.upsert).toBeFalsy();
       });
 
       test('should set expiresAt on topup entry when provided', async () => {
         const expiresAt = new Date('2027-01-01');
         let capturedUpdate;
-        mockModel.findOneAndUpdate.mockImplementation((filter, update) => {
-          capturedUpdate = update;
-          return Promise.resolve(makeDoc({ cachedBalance: 1000, ledger: [{ kind: 'topup', amount: 1000, stripeSessionId: 'cs_xyz', expiresAt }] }));
-        });
+        mockModel.findOneAndUpdate
+          .mockResolvedValueOnce(makeDoc())
+          .mockImplementation((filter, update) => {
+            capturedUpdate = update;
+            return Promise.resolve(makeDoc({ cachedBalance: 1000, ledger: [{ kind: 'topup', amount: 1000, stripeSessionId: 'cs_xyz', expiresAt }] }));
+          });
 
         await BillingExtraBalanceRepository.creditPack(orgId, 1000, 'cs_xyz', expiresAt);
 

--- a/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
+++ b/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
@@ -157,3 +157,86 @@ describe('BillingUsage concurrent attribution integration tests:', () => {
     expect(debits).toHaveLength(1);
   });
 });
+
+/**
+ * Integration tests for creditPack idempotency (V8 P2).
+ *
+ * Validates that creditPack using the 2-step pattern:
+ * - Credits correctly on first call (fresh org, no pre-existing doc).
+ * - Is idempotent on replay of the same stripeSessionId (applied=false, balance unchanged).
+ */
+describe('BillingExtraBalance creditPack idempotency integration tests:', () => {
+  let BillingExtraBalance;
+  let BillingExtraBalanceRepository;
+  let originalMeterMode;
+
+  beforeAll(async () => {
+    originalMeterMode = config.billing.meterMode;
+    config.billing.meterMode = true;
+    await mongooseService.loadModels();
+    await mongooseService.connect();
+
+    BillingExtraBalance = mongoose.model('BillingExtraBalance');
+    BillingExtraBalanceRepository = (await import('../repositories/billing.extraBalance.repository.js')).default;
+  });
+
+  beforeEach(async () => {
+    await BillingExtraBalance.deleteMany({});
+  });
+
+  afterAll(async () => {
+    config.billing.meterMode = originalMeterMode;
+    await mongooseService.disconnect();
+  });
+
+  test('creditPack on fresh org creates doc and credits balance', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+
+    const result = await BillingExtraBalanceRepository.creditPack(
+      organizationId.toString(),
+      500000,
+      'cs_fresh_org_v8',
+      null,
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.doc).not.toBeNull();
+    expect(result.doc.cachedBalance).toBe(500000);
+
+    const persisted = await BillingExtraBalance.findOne({ organization: organizationId }).lean();
+    expect(persisted).not.toBeNull();
+    expect(persisted.cachedBalance).toBe(500000);
+    expect(persisted.ledger).toHaveLength(1);
+    expect(persisted.ledger[0].kind).toBe('topup');
+    expect(persisted.ledger[0].stripeSessionId).toBe('cs_fresh_org_v8');
+  });
+
+  test('creditPack replay with same stripeSessionId is idempotent (applied=false, balance unchanged)', async () => {
+    const organizationId = new mongoose.Types.ObjectId();
+    const stripeSessionId = 'cs_replay_v8_p2';
+
+    // First call — should credit
+    const first = await BillingExtraBalanceRepository.creditPack(
+      organizationId.toString(),
+      500000,
+      stripeSessionId,
+      null,
+    );
+    expect(first.applied).toBe(true);
+
+    // Second call with same sessionId — must be a no-op
+    const second = await BillingExtraBalanceRepository.creditPack(
+      organizationId.toString(),
+      500000,
+      stripeSessionId,
+      null,
+    );
+    expect(second.applied).toBe(false);
+    expect(second.reason).toBe('duplicate_session');
+
+    // Balance must not have changed
+    const persisted = await BillingExtraBalance.findOne({ organization: organizationId }).lean();
+    expect(persisted.cachedBalance).toBe(500000);
+    expect(persisted.ledger.filter((e) => e.kind === 'topup')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Aligns `creditPack()` in `billing.extraBalance.repository.js` to the 2-step pattern already used by `debit()` (introduced in V7): step 1 is an atomic `$setOnInsert` getOrCreate, step 2 is an idempotency-guarded update with no upsert.
- Eliminates E11000 duplicate-key risk on direct replay outside `withIdempotency` webhook wrapper — the repository now provides idempotency directly, not indirectly.
- Return shape extended: `applied=false` now carries `reason: 'duplicate_session'` (aligned with `debit`'s `reason: 'duplicate_step'`). The existing `withIdempotency` webhook protection is unchanged.

## Test plan

- [x] Unit: `creditPack` step 1 issues upsert with `$setOnInsert` (fresh org)
- [x] Unit: `creditPack` step 2 has no `upsert` option (doc guaranteed by step 1)
- [x] Unit: replay returns `applied=false, reason='duplicate_session'`
- [x] Unit: new session returns `applied=true, doc.cachedBalance` incremented
- [x] Unit: `expiresAt` propagated correctly on step 2 update
- [x] Integration: `creditPack` on fresh org creates doc and credits balance (real Mongo)
- [x] Integration: `creditPack` replay same `stripeSessionId` is idempotent — `applied=false`, balance unchanged (real Mongo)
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 1060 passed
- [x] `npm run test:integration` — 331 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing credit pack now implements robust duplicate detection, preventing the same credit from being applied multiple times and returning detailed status information when duplicates are detected.

* **Tests**
  * Added comprehensive unit and integration test coverage for credit pack idempotency behavior and duplicate session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->