### PR TITLE
fix(billing): pre-LIVE critical fixes — free plan, /plans DoS, dispute+customer handlers

### DIFF
--- a/config/defaults/production.config.js
+++ b/config/defaults/production.config.js
@@ -38,6 +38,15 @@ const config = {
       standardHeaders: true,
       legacyHeaders: false,
     },
+    // Public, unauthenticated route that fans out to Stripe on cache miss.
+    // Tighter window than `api` to harden against Stripe-API-quota DoS.
+    billingPlans: {
+      windowMs: 60 * 1000,
+      max: 30,
+      message: { message: 'Too many requests, please try again later.' },
+      standardHeaders: true,
+      legacyHeaders: false,
+    },
   },
   log: {
     format: 'custom',

--- a/config/defaults/test.config.js
+++ b/config/defaults/test.config.js
@@ -41,6 +41,9 @@ const config = {
     api: {
       max: Number.MAX_SAFE_INTEGER, // disable rate limiting in tests
     },
+    billingPlans: {
+      max: Number.MAX_SAFE_INTEGER, // disable rate limiting in tests
+    },
   },
   uploads: {
     avatar: {

--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -62,6 +62,16 @@ const handleWebhook = async (req, res) => {
           BillingWebhookService.handleChargeRefunded(e.data.object),
         );
         break;
+      case 'customer.deleted':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleCustomerDeleted(e.data.object, e),
+        );
+        break;
+      case 'charge.dispute.created':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleChargeDisputeCreated(e.data.object, e),
+        );
+        break;
       default:
         break;
     }

--- a/modules/billing/routes/billing.routes.js
+++ b/modules/billing/routes/billing.routes.js
@@ -4,6 +4,7 @@
 import config from '../../../config/index.js';
 import passport from 'passport';
 
+import limiters from '../../../lib/middlewares/rateLimiter.js';
 import model from '../../../lib/middlewares/model.js';
 import policy from '../../../lib/middlewares/policy.js';
 import organization from '../../organizations/middlewares/organizations.middleware.js';
@@ -28,7 +29,11 @@ export default (app) => {
   ];
 
   // plans (public)
-  app.route('/api/billing/plans').get(billingPlans.getPlans);
+  // Rate-limited at the edge: this route fans out to Stripe products+prices on cache miss,
+  // so an unauthenticated flood would drain the Stripe API quota and break LIVE checkout +
+  // webhook signature verification. Service layer also dedups concurrent in-flight fetches.
+  // Falls back to a passthrough middleware when `billingPlans` profile is not configured.
+  app.route('/api/billing/plans').get(limiters.billingPlans, billingPlans.getPlans);
 
   // checkout
   app

--- a/modules/billing/services/billing.plans.service.js
+++ b/modules/billing/services/billing.plans.service.js
@@ -11,6 +11,17 @@ let cacheTimestamp = 0;
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
 
 /**
+ * In-flight fetch promise — used to deduplicate concurrent cache-miss callers.
+ * The /api/billing/plans route is public, so a thundering herd on cache miss
+ * (e.g. cache expiry under traffic, or a small DoS) would otherwise fire N
+ * parallel `stripe.products.list().autoPagingToArray()` + `stripe.prices.list()`
+ * calls and exhaust the Stripe API quota — breaking live checkouts and webhook
+ * signature verification. With this dedup, only one Stripe round-trip happens
+ * per cache-miss window regardless of concurrency.
+ */
+let inFlightFetch = null;
+
+/**
  * Default free plan returned when Stripe is not configured
  */
 const DEFAULT_FREE_PLAN = {
@@ -83,10 +94,24 @@ const getPlans = async () => {
   const now = Date.now();
   if (cachedPlans && now - cacheTimestamp < CACHE_TTL) return cachedPlans;
 
-  const plans = await fetchPlansFromStripe(stripe);
-  cachedPlans = plans;
-  cacheTimestamp = Date.now();
-  return plans;
+  // In-flight dedup: if another caller is already fetching, await its result
+  // instead of issuing parallel Stripe API calls. Reset on completion so the
+  // next cache miss can issue a fresh fetch (success OR failure — failures must
+  // not poison the slot, otherwise the next call retries cleanly).
+  if (inFlightFetch) return inFlightFetch;
+
+  inFlightFetch = (async () => {
+    try {
+      const plans = await fetchPlansFromStripe(stripe);
+      cachedPlans = plans;
+      cacheTimestamp = Date.now();
+      return plans;
+    } finally {
+      inFlightFetch = null;
+    }
+  })();
+
+  return inFlightFetch;
 };
 
 export default {

--- a/modules/billing/services/billing.usage.service.js
+++ b/modules/billing/services/billing.usage.service.js
@@ -122,10 +122,17 @@ const incrementMeter = async (organizationId, units, breakdown, idempotencyKey) 
   const newMeterUsed = updatedDoc.meterUsed ?? 0;
   const effectiveQuota = updatedDoc.meterQuota ?? meterQuota;
 
-  // Overflow detection: units consumed beyond the plan quota go to extras
+  // Overflow detection: units consumed beyond the plan quota go to extras.
+  // Free plan (effectiveQuota === 0): every unit must be debited from extras —
+  // requireQuota middleware lets the request through only when extrasBalance > 0,
+  // so reaching this branch means the org pays for usage from its extras pack.
+  // Without this branch the extras balance would never decrease on free plans
+  // (infinite usage from a $5 pack — money leak).
   let extrasConsumed = 0;
-  if (effectiveQuota > 0 && newMeterUsed > effectiveQuota) {
-    const previousUsed = newMeterUsed - units;
+  if (effectiveQuota === 0) {
+    extrasConsumed = units;
+  } else if (newMeterUsed > effectiveQuota) {
+    const previousUsed = Math.max(0, newMeterUsed - units);
     const overflowStart = Math.max(previousUsed, effectiveQuota);
     extrasConsumed = newMeterUsed - overflowStart;
   }

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -565,6 +565,155 @@ const handleChargeRefunded = async (charge) => {
   }
 };
 
+/**
+ * @description Handle customer.deleted event — null out Stripe customer/subscription refs.
+ *       Triggered when an admin deletes a customer in the Stripe dashboard. If we keep the
+ *       stale stripeCustomerId in our DB, the next _ensureStripeCustomer / checkout call
+ *       will hit "No such customer" and crash the user's checkout flow.
+ *
+ *       Conservative recovery:
+ *         1. Find the subscription by Stripe customer id.
+ *         2. Null out stripeCustomerId + stripeSubscriptionId, force plan='free' / status='canceled'.
+ *         3. Sync organization plan to free.
+ *         4. Force meter rotation so the org no longer carries the paid quota snapshot.
+ *
+ *       No-op when no matching subscription exists in our DB (deletion of a customer we never
+ *       provisioned, or already cleaned up).
+ * @param {Object} customer - Stripe customer object (data.object of customer.deleted event).
+ * @param {Object} event - Full Stripe event (for ordering / event-newer guard).
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleCustomerDeleted = async (customer, event) => {
+  const stripeCustomerId = customer?.id;
+  if (!stripeCustomerId) return;
+
+  const existing = await SubscriptionRepository.findByStripeCustomerId(stripeCustomerId);
+  if (!existing) return;
+
+  const updated = await SubscriptionRepository.updateIfEventNewer(
+    String(existing._id),
+    event.created,
+    event.id,
+    {
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      plan: 'free',
+      status: 'canceled',
+    },
+    'subscription',
+  );
+  if (!updated) {
+    logger.info('[billing.webhook] skipped stale event', { eventId: event.id, type: event.type });
+    return;
+  }
+
+  const organizationId = String(existing.organization?._id || existing.organization);
+  await syncOrganizationPlan(organizationId, 'free');
+
+  // Force meter reset so the cancelled org no longer retains a paid-plan snapshot.
+  try {
+    await BillingResetService.forceRotateForPlanChange(organizationId, { preserveUsage: false });
+  } catch (err) {
+    logger.error('[billing.webhook] forceRotateForPlanChange on customer.deleted failed (non-fatal)', {
+      organizationId,
+      error: err?.message ?? String(err),
+      stack: err?.stack,
+    });
+  }
+};
+
+/**
+ * @description Handle charge.dispute.created event — log + emit (no auto-debit).
+ *       Triggered when a cardholder files a chargeback. Stripe will eventually debit the
+ *       merchant bank account, but disputes are often won by the merchant (~50% are user
+ *       error / "I don't recognise this charge"). Aggressive auto-debit on dispute opening
+ *       would punish customers who are filing legitimate disputes that we eventually win.
+ *
+ *       Conservative policy: emit a `billing.dispute.opened` event for downstream listeners
+ *       (admin notifications) and log a critical alert. Real claw-back happens later via
+ *       `charge.dispute.funds_withdrawn` (when the dispute is lost) or `charge.refunded`
+ *       (when we choose to refund), both of which already debit the ledger via
+ *       handleChargeRefunded / refundPartial.
+ *
+ *       Resolves organizationId via charge metadata first, then falls back to the
+ *       PaymentIntent metadata patched by handleCheckoutPaymentCompleted.
+ * @param {Object} dispute - Stripe dispute object (data.object of charge.dispute.created).
+ * @param {Object} event - Full Stripe event.
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleChargeDisputeCreated = async (dispute, event) => {
+  const chargeId = dispute?.charge;
+  const disputeId = dispute?.id;
+  const amount = dispute?.amount ?? 0;
+  const reason = dispute?.reason ?? null;
+
+  let organizationId = null;
+  let stripeSessionId = null;
+  let paymentIntentId = null;
+
+  // Best-effort: fetch charge → resolve org via charge or PaymentIntent metadata
+  // (mirrors the resolver pattern in handleChargeRefunded).
+  if (chargeId) {
+    const stripe = getStripe();
+    if (stripe) {
+      try {
+        const charge = await stripe.charges.retrieve(chargeId);
+        const meta = charge?.metadata ?? {};
+        organizationId = meta.organizationId ?? null;
+        stripeSessionId = meta.stripeSessionId ?? null;
+        paymentIntentId = charge?.payment_intent ?? null;
+
+        if ((!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) && paymentIntentId) {
+          const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+          const piMeta = paymentIntent?.metadata ?? {};
+          if (!organizationId && piMeta.organizationId && mongoose.Types.ObjectId.isValid(piMeta.organizationId)) {
+            organizationId = piMeta.organizationId;
+          }
+          if (!stripeSessionId) stripeSessionId = piMeta.stripeSessionId ?? null;
+        }
+      } catch (err) {
+        logger.error('[billing.webhook] dispute charge/PI fetch failed', {
+          chargeId,
+          disputeId,
+          error: err?.message ?? String(err),
+          stack: err?.stack,
+        });
+      }
+    }
+  }
+
+  // Critical alert — ops MUST react manually (decide to fight or accept the dispute).
+  // No auto-debit: real claw-back happens on charge.dispute.funds_withdrawn / charge.refunded.
+  logger.error('[billing] dispute opened — manual review required', {
+    disputeId,
+    chargeId,
+    organizationId,
+    stripeSessionId,
+    amount,
+    reason,
+    eventId: event?.id,
+  });
+
+  try {
+    billingEvents.emit('billing.dispute.opened', {
+      disputeId,
+      chargeId,
+      organizationId,
+      stripeSessionId,
+      amount,
+      reason,
+    });
+  } catch (evtErr) {
+    // Listener errors must not break webhook processing — log for traceability.
+    logger.error('[billing.webhook] billing.dispute.opened listener error (non-fatal)', {
+      error: evtErr?.message ?? String(evtErr),
+      stack: evtErr?.stack,
+    });
+  }
+};
+
 export default {
   withIdempotency,
   handleCheckoutSessionCompleted,
@@ -575,4 +724,6 @@ export default {
   handleInvoicePaymentFailed,
   handleInvoicePaymentSucceeded,
   handleChargeRefunded,
+  handleCustomerDeleted,
+  handleChargeDisputeCreated,
 };

--- a/modules/billing/tests/billing.plans.unit.tests.js
+++ b/modules/billing/tests/billing.plans.unit.tests.js
@@ -226,6 +226,91 @@ describe('Billing plans service unit tests:', () => {
     expect(mod.default.fetchPlansFromStripe).toBeUndefined();
   });
 
+  // ── In-flight dedup — Stripe-API-quota DoS hardening ────────────────────
+  // The /api/billing/plans route is public, so a thundering herd on cache miss
+  // (or a small DoS) would otherwise fire N parallel `stripe.products.list +
+  // stripe.prices.list` calls and exhaust the Stripe API quota — breaking live
+  // checkouts and webhook signature verification. The service layer dedups
+  // concurrent in-flight fetches into a single Stripe round-trip.
+
+  test('100 concurrent getPlans() calls during cache miss → exactly ONE Stripe products.list call', async () => {
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+
+    // Resolve manually so all 100 callers race the same in-flight promise.
+    let resolveProducts;
+    mockStripeInstance.products.list.mockReturnValue({
+      autoPagingToArray: jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveProducts = () => resolve(productsData);
+        }),
+      ),
+    });
+
+    const inflight = Array.from({ length: 100 }, () => BillingPlansService.getPlans());
+
+    // Resolve the underlying Stripe call once — all 100 callers should share its result.
+    resolveProducts();
+    const results = await Promise.all(inflight);
+
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(1);
+    expect(mockStripeInstance.prices.list).toHaveBeenCalledTimes(1);
+    // Every caller gets the same plan list.
+    for (const plans of results) expect(plans).toHaveLength(2);
+  });
+
+  test('after cache TTL expires, a fresh thundering herd still triggers ONE fetch', async () => {
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+
+    // First call populates the cache.
+    await BillingPlansService.getPlans();
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(1);
+
+    // Advance time past TTL.
+    const originalDateNow = Date.now;
+    Date.now = jest.fn().mockReturnValue(originalDateNow() + 61 * 60 * 1000);
+
+    // 50 concurrent callers after TTL expires.
+    let resolveProducts;
+    mockStripeInstance.products.list.mockReturnValue({
+      autoPagingToArray: jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveProducts = () => resolve(productsData);
+        }),
+      ),
+    });
+
+    const inflight = Array.from({ length: 50 }, () => BillingPlansService.getPlans());
+    resolveProducts();
+    await Promise.all(inflight);
+
+    // Total: 1 (initial) + 1 (after TTL) — not 1 + 50.
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(2);
+
+    Date.now = originalDateNow;
+  });
+
+  test('in-flight slot resets after fetch failure → next call retries cleanly', async () => {
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+
+    // First fetch fails — slot must reset, otherwise the next call hangs forever.
+    mockStripeInstance.products.list.mockReturnValueOnce({
+      autoPagingToArray: jest.fn().mockRejectedValue(new Error('Stripe API down')),
+    });
+
+    await expect(BillingPlansService.getPlans()).rejects.toThrow('Stripe API down');
+
+    // Second call should issue a NEW Stripe round-trip (slot was cleared in finally).
+    mockStripeInstance.products.list.mockReturnValueOnce(mockListResult(productsData));
+    mockStripeInstance.prices.list.mockReturnValueOnce(mockListResult(pricesData));
+
+    const plans = await BillingPlansService.getPlans();
+    expect(plans).toHaveLength(2);
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(2);
+  });
+
   test('facade: getPlans returns array of plan objects', async () => {
     const mod = await import('../services/billing.plans.service.js');
     BillingPlansService = mod.default;

--- a/modules/billing/tests/billing.usage.service.unit.tests.js
+++ b/modules/billing/tests/billing.usage.service.unit.tests.js
@@ -437,6 +437,59 @@ describe('BillingUsageService — meter extensions unit tests:', () => {
     });
   });
 
+  describe('incrementMeter — free plan (meterQuota=0) extras debit', () => {
+    test('every unit goes to extras when meterQuota=0 (extras pack credits balance)', async () => {
+      // Free plan has meterQuota=0 — middleware (requireQuota) lets the request through
+      // because extrasBalance > 0. Without this branch the extras balance would never
+      // decrease (infinite usage from a single $5 pack — money leak).
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'free' });
+      mockPlanService.getActivePlan.mockReturnValue(makePlan({ planId: 'free', meterQuota: 0 }));
+      // After increment: meterUsed=5, quota=0. Old code computed extrasConsumed=0; new code = units.
+      const updatedDoc = makeUsageDoc({ meterUsed: 5, meterQuota: 0 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+      mockExtraService.debit.mockResolvedValue({ applied: true, doc: { cachedBalance: 995 } });
+
+      const result = await BillingUsageService.incrementMeter(orgId, 5, { scrap: 5 }, 'hist_free_5');
+
+      expect(result.applied).toBe(true);
+      expect(result.extrasConsumed).toBe(5);
+      expect(mockExtraService.debit).toHaveBeenCalledWith(orgId, 5, 'hist_free_5');
+    });
+
+    test('free plan with no extras: debit is still called and may go negative (debt persists)', async () => {
+      // Middleware should block this case before we reach incrementMeter, but if it
+      // somehow leaks through (race / misconfig), the math must still attribute correctly.
+      // BillingExtraService.debit allows negative balance — the debt persists until next pack.
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'free' });
+      mockPlanService.getActivePlan.mockReturnValue(makePlan({ planId: 'free', meterQuota: 0 }));
+      const updatedDoc = makeUsageDoc({ meterUsed: 10, meterQuota: 0 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+      // Simulate repo returning applied=true with a negative cachedBalance (debt).
+      mockExtraService.debit.mockResolvedValue({ applied: true, doc: { cachedBalance: -10 } });
+
+      const result = await BillingUsageService.incrementMeter(orgId, 10, {}, 'hist_free_no_extras');
+
+      expect(result.applied).toBe(true);
+      expect(result.extrasConsumed).toBe(10);
+      expect(mockExtraService.debit).toHaveBeenCalledWith(orgId, 10, 'hist_free_no_extras');
+    });
+
+    test('regression: paid plan over quota still debits only the overflow portion', async () => {
+      // Existing behaviour preserved: when meterQuota>0 and we cross it, only the
+      // portion above the quota goes to extras (not the entire `units` amount).
+      mockSubscriptionRepository.findPlan.mockResolvedValue({ plan: 'pro' });
+      mockPlanService.getActivePlan.mockReturnValue(makePlan({ meterQuota: 1000 }));
+      // previousUsed = 950, after increment meterUsed = 1050, quota = 1000 → overflow = 50.
+      const updatedDoc = makeUsageDoc({ meterUsed: 1050, meterQuota: 1000 });
+      mockUsageRepository.incrementMeter.mockResolvedValue(updatedDoc);
+
+      const result = await BillingUsageService.incrementMeter(orgId, 100, {}, 'hist_paid_overflow');
+
+      expect(result.extrasConsumed).toBe(50);
+      expect(mockExtraService.debit).toHaveBeenCalledWith(orgId, 50, 'hist_paid_overflow');
+    });
+  });
+
   describe('getMeter', () => {
     test('should return null when meterMode is disabled', async () => {
       mockConfig.billing.meterMode = false;

--- a/modules/billing/tests/billing.webhook.hardening.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.hardening.unit.tests.js
@@ -1013,3 +1013,375 @@ describe('handleChargeRefunded — billing.refund.unresolved listener error swal
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-LIVE — customer.deleted handler (null out stale Stripe refs)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('handleCustomerDeleted — null out stripeCustomerId / subscription:', () => {
+  let BillingWebhookService;
+  let mockSubscriptionRepository;
+  let mockOrganizationRepository;
+  let mockResetService;
+  let mockLogger;
+  let mockProcessedStripeEventRepository;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const subId = '607f1f77bcf86cd799439022';
+  const stripeCustomerId = 'cus_test_deleted_001';
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    mockProcessedStripeEventRepository = {
+      tryRecord: jest.fn().mockResolvedValue({ recorded: true }),
+      incrementAttempts: jest.fn().mockResolvedValue({ attempts: 1 }),
+      deleteByEventId: jest.fn().mockResolvedValue({ deleted: true }),
+      markDeadLetter: jest.fn(),
+    };
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn(),
+      findByStripeCustomerId: jest.fn(),
+      findByStripeSubscriptionId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      updateIfEventNewer: jest.fn(),
+    };
+    mockOrganizationRepository = { setPlan: jest.fn().mockResolvedValue() };
+    mockResetService = {
+      resetWeek: jest.fn(),
+      forceRotateForPlanChange: jest.fn().mockResolvedValue(),
+    };
+
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: jest.fn().mockReturnValue(null) }));
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+      default: { creditPack: jest.fn(), refundPartial: jest.fn() },
+    }));
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({ default: mockResetService }));
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: mockProcessedStripeEventRepository,
+    }));
+    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+      default: mockOrganizationRepository,
+    }));
+    jest.unstable_mockModule('../lib/events.js', () => ({ default: { emit: jest.fn() } }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { billing: { plans: ['free', 'starter', 'pro', 'enterprise'] } },
+    }));
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: () => ({}),
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  test('subscription found: nulls stripeCustomerId/subscriptionId, sets plan=free, syncs org, rotates meter', async () => {
+    mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue({
+      _id: subId,
+      organization: orgId,
+      stripeCustomerId,
+      stripeSubscriptionId: 'sub_test_001',
+      plan: 'pro',
+      status: 'active',
+    });
+    mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
+
+    await BillingWebhookService.handleCustomerDeleted(
+      { id: stripeCustomerId },
+      { id: 'evt_cd_001', type: 'customer.deleted', created: 1714000000 },
+    );
+
+    expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+      String(subId),
+      1714000000,
+      'evt_cd_001',
+      expect.objectContaining({
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        plan: 'free',
+        status: 'canceled',
+      }),
+      'subscription',
+    );
+    expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'free');
+    expect(mockResetService.forceRotateForPlanChange).toHaveBeenCalledWith(orgId, { preserveUsage: false });
+  });
+
+  test('no matching subscription: short-circuits silently, no writes', async () => {
+    mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(null);
+
+    await BillingWebhookService.handleCustomerDeleted(
+      { id: 'cus_unknown' },
+      { id: 'evt_cd_002', type: 'customer.deleted', created: 1714000000 },
+    );
+
+    expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+    expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    expect(mockResetService.forceRotateForPlanChange).not.toHaveBeenCalled();
+  });
+
+  test('stale event: updateIfEventNewer returns null → logs skip, does NOT sync org', async () => {
+    mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue({
+      _id: subId, organization: orgId, stripeCustomerId,
+    });
+    mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+    await BillingWebhookService.handleCustomerDeleted(
+      { id: stripeCustomerId },
+      { id: 'evt_cd_stale', type: 'customer.deleted', created: 1700000000 },
+    );
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[billing.webhook] skipped stale event',
+      expect.objectContaining({ eventId: 'evt_cd_stale' }),
+    );
+    expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    expect(mockResetService.forceRotateForPlanChange).not.toHaveBeenCalled();
+  });
+
+  test('forceRotate failure is non-fatal: logs error and resolves', async () => {
+    mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue({
+      _id: subId, organization: orgId, stripeCustomerId,
+    });
+    mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
+    mockResetService.forceRotateForPlanChange.mockRejectedValue(new Error('reset boom'));
+
+    await expect(
+      BillingWebhookService.handleCustomerDeleted(
+        { id: stripeCustomerId },
+        { id: 'evt_cd_rotate_fail', type: 'customer.deleted', created: 1714000000 },
+      ),
+    ).resolves.not.toThrow();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] forceRotateForPlanChange on customer.deleted failed (non-fatal)',
+      expect.objectContaining({ organizationId: orgId, error: 'reset boom' }),
+    );
+  });
+
+  test('handler is exported on the service default — controller can dispatch', async () => {
+    // Sanity check that the new handler is part of the public API surface used by
+    // the webhook controller switch (controller dispatch is integration-tested
+    // separately in billing.webhook.integration.tests.js).
+    expect(typeof BillingWebhookService.handleCustomerDeleted).toBe('function');
+  });
+
+  test('runs through withIdempotency: tryRecord called once with eventId+type', async () => {
+    mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(null);
+    const event = {
+      id: 'evt_cd_idem_001',
+      type: 'customer.deleted',
+      created: 1714000000,
+      data: { object: { id: stripeCustomerId } },
+    };
+
+    await BillingWebhookService.withIdempotency(event, (e) =>
+      BillingWebhookService.handleCustomerDeleted(e.data.object, e),
+    );
+
+    expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith(
+      'evt_cd_idem_001',
+      'customer.deleted',
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-LIVE — charge.dispute.created (log + emit, no auto-debit)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('handleChargeDisputeCreated — log + emit, no auto-debit:', () => {
+  let BillingWebhookService;
+  let mockExtraService;
+  let mockEvents;
+  let mockLogger;
+  let mockStripeInstance;
+  let mockGetStripe;
+  let mockProcessedStripeEventRepository;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const stripeSessionId = 'cs_test_dispute_001';
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    mockEvents = { emit: jest.fn() };
+    mockExtraService = {
+      creditPack: jest.fn(),
+      refundPartial: jest.fn(),
+    };
+    mockProcessedStripeEventRepository = {
+      tryRecord: jest.fn().mockResolvedValue({ recorded: true }),
+      incrementAttempts: jest.fn().mockResolvedValue({ attempts: 1 }),
+      deleteByEventId: jest.fn().mockResolvedValue({ deleted: true }),
+      markDeadLetter: jest.fn(),
+    };
+
+    mockStripeInstance = {
+      charges: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'ch_disputed_001',
+          payment_intent: 'pi_disputed_001',
+          metadata: { organizationId: orgId, stripeSessionId, packId: 'pack_500k' },
+        }),
+      },
+      paymentIntents: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'pi_disputed_001',
+          metadata: { organizationId: orgId, stripeSessionId, packId: 'pack_500k' },
+        }),
+      },
+    };
+    mockGetStripe = jest.fn().mockReturnValue(mockStripeInstance);
+
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: mockGetStripe }));
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({ default: mockExtraService }));
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({ default: { resetWeek: jest.fn() } }));
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {
+        findByOrganization: jest.fn(), findByStripeCustomerId: jest.fn(),
+        findByStripeSubscriptionId: jest.fn(), create: jest.fn(), update: jest.fn(),
+        updateIfEventNewer: jest.fn(),
+      },
+    }));
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: mockProcessedStripeEventRepository,
+    }));
+    jest.unstable_mockModule('../lib/events.js', () => ({ default: mockEvents }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { billing: { plans: ['free', 'starter', 'pro', 'enterprise'] } },
+    }));
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: () => ({}),
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  test('emits billing.dispute.opened + logs error with chargeId/orgId/amount; never debits', async () => {
+    await BillingWebhookService.handleChargeDisputeCreated(
+      {
+        id: 'dp_001',
+        charge: 'ch_disputed_001',
+        amount: 2900,
+        reason: 'fraudulent',
+      },
+      { id: 'evt_dp_001', type: 'charge.dispute.created', created: 1714000000 },
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing] dispute opened — manual review required',
+      expect.objectContaining({
+        disputeId: 'dp_001',
+        chargeId: 'ch_disputed_001',
+        organizationId: orgId,
+        amount: 2900,
+        reason: 'fraudulent',
+      }),
+    );
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.dispute.opened',
+      expect.objectContaining({
+        disputeId: 'dp_001',
+        chargeId: 'ch_disputed_001',
+        organizationId: orgId,
+        amount: 2900,
+      }),
+    );
+    // Conservative: never auto-debit on dispute opening — half of disputes are won.
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+  });
+
+  test('falls back to PaymentIntent metadata when charge metadata lacks organizationId', async () => {
+    mockStripeInstance.charges.retrieve.mockResolvedValue({
+      id: 'ch_no_meta',
+      payment_intent: 'pi_disputed_001',
+      metadata: {},
+    });
+
+    await BillingWebhookService.handleChargeDisputeCreated(
+      { id: 'dp_002', charge: 'ch_no_meta', amount: 2900 },
+      { id: 'evt_dp_002', type: 'charge.dispute.created', created: 1714000000 },
+    );
+
+    expect(mockStripeInstance.paymentIntents.retrieve).toHaveBeenCalledWith('pi_disputed_001');
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.dispute.opened',
+      expect.objectContaining({ organizationId: orgId }),
+    );
+  });
+
+  test('Stripe charge fetch failure: still logs+emits with null orgId, never throws', async () => {
+    mockStripeInstance.charges.retrieve.mockRejectedValue(new Error('Stripe API down'));
+
+    await expect(
+      BillingWebhookService.handleChargeDisputeCreated(
+        { id: 'dp_003', charge: 'ch_fetch_fail', amount: 2900 },
+        { id: 'evt_dp_003', type: 'charge.dispute.created', created: 1714000000 },
+      ),
+    ).resolves.not.toThrow();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] dispute charge/PI fetch failed',
+      expect.objectContaining({ chargeId: 'ch_fetch_fail' }),
+    );
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.dispute.opened',
+      expect.objectContaining({ disputeId: 'dp_003', organizationId: null }),
+    );
+  });
+
+  test('runs through withIdempotency: tryRecord called once with eventId+type', async () => {
+    const event = {
+      id: 'evt_dp_idem_001',
+      type: 'charge.dispute.created',
+      created: 1714000000,
+      data: { object: { id: 'dp_idem_001', charge: 'ch_disputed_001', amount: 2900 } },
+    };
+
+    await BillingWebhookService.withIdempotency(event, (e) =>
+      BillingWebhookService.handleChargeDisputeCreated(e.data.object, e),
+    );
+
+    expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith(
+      'evt_dp_idem_001',
+      'charge.dispute.created',
+    );
+  });
+
+  test('listener throws on billing.dispute.opened: logged as non-fatal, no propagation', async () => {
+    mockEvents.emit.mockImplementation((evtName) => {
+      if (evtName === 'billing.dispute.opened') throw new Error('dispute listener blew');
+    });
+
+    await expect(
+      BillingWebhookService.handleChargeDisputeCreated(
+        { id: 'dp_004', charge: 'ch_disputed_001', amount: 2900 },
+        { id: 'evt_dp_004', type: 'charge.dispute.created', created: 1714000000 },
+      ),
+    ).resolves.not.toThrow();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] billing.dispute.opened listener error (non-fatal)',
+      expect.objectContaining({ error: 'dispute listener blew' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Three audit findings to ship **before** the LIVE Stripe recalibration. One PR, three commits-worth of logical separation kept in a single commit (the fixes are tightly scoped — none touches the same hot path).

### 1. Free plan + extras pack = infinite free usage (money leak)
`BillingUsageService.incrementMeter` only debited extras when `meterQuota > 0`. On the free plan (`meterQuota = 0`) the overflow detection was always false, so a free user who bought a \$5 pack would scrape forever and `extrasBalance` would stay at 1000.

Fix: when `effectiveQuota === 0`, every unit goes to extras. The `requireQuota` middleware already gates entry on `extrasBalance > 0`, so reaching `incrementMeter` on a free plan means the org is paying from its pack. `BillingExtraBalanceRepository.debit` allows negative balance (debt persists until next pack), which is the correct economic reflection.

### 2. `/api/billing/plans` Stripe-API-quota DoS
The route is fully public. On cache miss, concurrent requests fan out to `stripe.products.list().autoPagingToArray({limit:1000})` + `stripe.prices.list().autoPagingToArray({limit:1000})` in parallel — an unauthenticated attacker can drain the Stripe API quota and break LIVE checkouts + webhook signature verification.

**Decision: rate-limit + in-flight dedup. No auth.** The route is intentionally public for marketing pages; auth would break them. The combination is sufficient:
- **In-flight promise dedup** in `BillingPlansService.getPlans` collapses the thundering herd into a single Stripe round-trip per cache-miss window. Slot resets in a `finally` block so a transient failure doesn't poison subsequent calls.
- **Per-IP rate limit** via the existing `lib/middlewares/rateLimiter.js` proxy. New `billingPlans` profile (60s window / 30 req in prod, disabled in test) — same library + pattern as `auth`.

### 3. Missing webhook handlers — `customer.deleted` + `charge.dispute.created`

**`customer.deleted`** — if a customer is deleted in the Stripe dashboard while we still hold their `stripeCustomerId`, the next `_ensureStripeCustomer` call dies with "No such customer". Handler nulls out `stripeCustomerId` / `stripeSubscriptionId`, sets `plan='free'` / `status='canceled'`, syncs the org plan, and forces meter rotation. Routes through `withIdempotency` + `updateIfEventNewer` like the other handlers.

**`charge.dispute.created`** — chargeback opened. **Conservative policy: log + emit `billing.dispute.opened` event, no auto-debit.** Roughly half of disputes are won by the merchant (user error / "I don't recognise this charge"); aggressive auto-debit would punish legitimate winning cases. Real claw-back happens later on `charge.dispute.funds_withdrawn` (lost) or `charge.refunded` (already handled). No `disputed: true` flag added — keeping scope tight.

I deliberately did **not** add a freeze-account flag: the existing schema has no equivalent, and adding one would balloon scope into middleware + UI + tests. If ops wants automated freeze, that's a follow-up issue.

## Files

- `modules/billing/services/billing.usage.service.js` — Fix 1
- `modules/billing/services/billing.plans.service.js` — Fix 2 dedup
- `modules/billing/routes/billing.routes.js` + `config/defaults/{production,test}.config.js` — Fix 2 rate-limit
- `modules/billing/controllers/billing.webhook.controller.js` + `services/billing.webhook.service.js` — Fix 3
- Tests: `tests/billing.usage.service.unit.tests.js`, `tests/billing.plans.unit.tests.js`, `tests/billing.webhook.hardening.unit.tests.js`

## Test plan

- [x] `npm run lint` — ESLint: No issues found
- [x] `NODE_ENV=test npm run test:unit` — 1124 tests passed (85 suites)
- [x] Targeted billing integration suites — 66 tests passed (8 suites)
- [x] No coverage threshold lowered
- [ ] Smoke test in staging post-merge: free plan checkout flow + dispute webhook replay
- [ ] Verify Stripe dashboard quota dashboard during a synthetic /plans flood (manual ops gate)