### PR TITLE
fix(billing): dead-letter mechanism + dispute.funds_withdrawn handler

### DIFF
--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -72,6 +72,11 @@ const handleWebhook = async (req, res) => {
           BillingWebhookService.handleChargeDisputeCreated(e.data.object, e),
         );
         break;
+      case 'charge.dispute.funds_withdrawn':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleChargeDisputeFundsWithdrawn(e.data.object, e),
+        );
+        break;
       default:
         break;
     }

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -14,13 +14,24 @@ const ProcessedStripeEvent = () => mongoose.model('ProcessedStripeEvent');
 
 /**
  * @function tryRecord
- * @description Atomically insert a new processed event document.
- *              If a document with the same eventId already exists (E11000 duplicate key),
- *              returns `{ recorded: false }` instead of throwing — idempotency by design.
- *              On success, returns `{ recorded: true }`.
+ * @description Atomically claim a Stripe event for processing using the unique index on eventId.
+ *              Returns 3-state semantics so withIdempotency can persist `attempts` across Stripe
+ *              redeliveries (the previous design deleted the doc on rollback, which reset attempts
+ *              and made the dead-letter branch unreachable):
+ *                - New doc inserted → `{ recorded: true, retry: false }` (first delivery)
+ *                - Existing doc, `deadLetter: true` → `{ recorded: false, reason: 'dead_letter' }`
+ *                  (we already gave up — return success to Stripe so it stops retrying)
+ *                - Existing doc, `attempts > 0 && !deadLetter` → `{ recorded: true, retry: true }`
+ *                  (a previous run failed and was kept on disk; allow re-entry so attempts persists)
+ *                - Existing doc, `attempts === 0 && !deadLetter` → `{ recorded: false,
+ *                  reason: 'already_processed' }` (handler succeeded last time; never increment on
+ *                  success, so attempts === 0 is the terminal-success signal)
+ *
+ *              No `pendingRetry` field is added — the (attempts, deadLetter) pair already encodes
+ *              the four states unambiguously.
  * @param {string} eventId - Stripe event ID (unique idempotency key).
  * @param {string} type - Stripe event type (e.g. 'checkout.session.completed').
- * @returns {Promise<{recorded: boolean}>}
+ * @returns {Promise<{recorded: boolean, retry?: boolean, reason?: string}>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const tryRecord = async (eventId, type) => {
@@ -33,12 +44,27 @@ const tryRecord = async (eventId, type) => {
 
   try {
     await ProcessedStripeEvent().create({ eventId, type, processedAt: new Date() });
-    return { recorded: true };
+    return { recorded: true, retry: false };
   } catch (err) {
-    if (isDuplicateKeyError(err)) {
-      return { recorded: false };
+    if (!isDuplicateKeyError(err)) {
+      throw err;
     }
-    throw err;
+    // Existing doc — inspect state to decide whether to allow re-entry.
+    const existing = await ProcessedStripeEvent().findOne({ eventId }).lean();
+    if (!existing) {
+      // Race window: doc was deleted between insert-fail and lookup. Treat as already_processed
+      // (TTL or admin cleanup) — safest is to skip and keep Stripe quiet.
+      return { recorded: false, reason: 'already_processed' };
+    }
+    if (existing.deadLetter) {
+      return { recorded: false, reason: 'dead_letter' };
+    }
+    if ((existing.attempts ?? 0) > 0) {
+      // Pending retry — previous run failed, attempts persisted. Allow handler re-entry.
+      return { recorded: true, retry: true };
+    }
+    // attempts === 0 && !deadLetter → handler succeeded on first delivery (we never increment on success).
+    return { recorded: false, reason: 'already_processed' };
   }
 };
 

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -78,32 +78,45 @@ const syncOrganizationPlan = async (organizationId, plan) => {
 /**
  * @description Wrap a webhook handler with idempotency using ProcessedStripeEvent.
  *
- * Atomic-claim semantics (closes TOCTOU race):
+ * Atomic-claim semantics (closes TOCTOU race) + persistent retry counter:
  * 1. tryRecord atomically inserts the event record BEFORE running the handler.
- *    The unique index on eventId means only the first concurrent delivery succeeds;
- *    all others get E11000 → { recorded: false } → skip.
- * 2. If the handler throws, deleteByEventId rolls back the claim so Stripe can retry.
- * 3. On handler success the record stays permanently — subsequent Stripe retries are
- *    skipped via tryRecord returning { recorded: false }.
+ *    The unique index on eventId means only the first concurrent delivery succeeds.
+ * 2. tryRecord uses 3-state semantics so attempts persists across Stripe redeliveries:
+ *      - First delivery → { recorded: true, retry: false }              → handler runs
+ *      - In-flight retry (attempts > 0, !deadLetter) → { recorded: true, retry: true } → handler runs again
+ *      - Already succeeded (attempts === 0) → { recorded: false, reason: 'already_processed' } → skip
+ *      - Dead-letter (deadLetter: true)     → { recorded: false, reason: 'dead_letter' }       → skip
+ * 3. On handler exception we DO NOT delete the doc (the previous design did, which reset
+ *    attempts to 0 on every Stripe redelivery and made BILLING_WEBHOOK_MAX_ATTEMPTS unreachable).
+ *    Instead we increment attempts, then either:
+ *      - attempts >= MAX → markDeadLetter, log critical, return success to Stripe (no throw)
+ *      - attempts <  MAX → throw → Stripe gets 5xx → redelivers ~24h later → tryRecord returns
+ *        { recorded: true, retry: true } → handler runs again, attempts persists.
+ * 4. On handler success the record stays with attempts === 0 (we never increment on success),
+ *    which is the terminal-success signal for tryRecord on subsequent redeliveries.
  *
  * @param {Object} event - Full Stripe event object (must have event.id and event.type).
- * @param {Function} handler - Async function (event) => result called when event is new.
- * @returns {Promise<Object>} Handler result or skip sentinel { skipped: true, reason: 'duplicate_event' }.
+ * @param {Function} handler - Async function (event) => result called when event is new or retrying.
+ * @returns {Promise<Object>} Handler result, or skip sentinel
+ *          { skipped: true, reason: 'duplicate_event_or_dead_letter' }, or
+ *          dead-letter sentinel { deadLettered: true, eventId, eventType, attempts }.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const withIdempotency = async (event, handler) => {
   const eventId = event.id;
   const eventType = event.type;
 
-  // Atomically claim the event — only the first delivery wins
-  const { recorded } = await ProcessedStripeEventRepository.tryRecord(eventId, eventType);
-  if (!recorded) {
-    return { skipped: true, reason: 'duplicate_event' };
+  // Atomically claim or re-enter — see tryRecord for 3-state semantics.
+  const claim = await ProcessedStripeEventRepository.tryRecord(eventId, eventType);
+  if (!claim.recorded) {
+    return { skipped: true, reason: 'duplicate_event_or_dead_letter', detail: claim.reason };
   }
   try {
     return await handler(event);
   } catch (err) {
     // Increment attempt counter and record error details before deciding fate.
+    // We MUST NOT delete the doc on failure — attempts must persist across Stripe redeliveries
+    // for BILLING_WEBHOOK_MAX_ATTEMPTS to be reachable.
     let attempts = 1;
     try {
       const updated = await ProcessedStripeEventRepository.incrementAttempts(eventId, err?.message ?? String(err));
@@ -113,26 +126,19 @@ const withIdempotency = async (event, handler) => {
     }
 
     if (attempts >= BILLING_WEBHOOK_MAX_ATTEMPTS) {
-      // Dead-letter: keep claim permanently so Stripe stops retrying after 3-day window.
+      // Dead-letter: keep claim permanently with deadLetter=true so subsequent redeliveries skip.
       try {
         await ProcessedStripeEventRepository.markDeadLetter(eventId);
       } catch (dlErr) {
         logger.error('[billing] webhook markDeadLetter failed', { eventId, eventType, error: dlErr?.message });
       }
       logger.error('[billing] webhook dead-letter', { eventId, eventType, attempts, error: err?.message ?? String(err) });
-      // Return success to Stripe so it stops retrying
+      // Return success to Stripe so it stops retrying.
       return { deadLettered: true, eventId, eventType, attempts };
     }
 
-    // Rollback claim so Stripe can retry on a fresh delivery.
-    // Swallow rollback errors so the original handler error is always propagated.
-    await ProcessedStripeEventRepository.deleteByEventId(event.id).catch((rollbackErr) => {
-      logger.error('[billing.webhook] rollback deleteByEventId failed — event may be stuck', {
-        eventId: event.id,
-        error: rollbackErr?.message ?? String(rollbackErr),
-        stack: rollbackErr?.stack,
-      });
-    });
+    // Below MAX: keep the doc (attempts persists), throw so Stripe retries on next delivery.
+    // The next delivery will hit tryRecord → { recorded: true, retry: true } and re-enter here.
     throw err;
   }
 };
@@ -714,6 +720,177 @@ const handleChargeDisputeCreated = async (dispute, event) => {
   }
 };
 
+/**
+ * @description Handle charge.dispute.funds_withdrawn event — debit ledger (dispute lost).
+ *       Triggered by Stripe when funds are actually withdrawn from the merchant bank account
+ *       because the dispute was lost (or accepted). At this point the customer kept their
+ *       meter units but Stripe has reclaimed the cash, so we MUST debit the ledger or we
+ *       lose money.
+ *
+ *       Resolution path mirrors handleChargeRefunded:
+ *         1. Retrieve the charge by `dispute.charge`.
+ *         2. Read organizationId / stripeSessionId / packId from charge.metadata.
+ *         3. If stripeSessionId is unresolved (absent or SENTINEL_PENDING), backfill via the
+ *            PaymentIntent (charge.metadata is a one-time snapshot taken at charge creation).
+ *         4. Debit the ledger via BillingExtraService.refundPartial with a stable refId
+ *            'dispute_<dispute.id>' — refundPartial's own idempotency on the refId guarantees
+ *            this is a no-op on Stripe redelivery, even outside the per-family event guard
+ *            (disputes do not fit the subscription/invoice ordering families, so we rely on
+ *            the ledger-layer idempotency exclusively).
+ *
+ *       When organizationId / charge / pack cannot be resolved, emits
+ *       'billing.refund.unresolved' for ops + logs a critical alert (mirrors handleChargeRefunded).
+ * @param {Object} dispute - Stripe dispute object (data.object of charge.dispute.funds_withdrawn).
+ * @param {Object} event - Full Stripe event (for traceability).
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleChargeDisputeFundsWithdrawn = async (dispute, event) => {
+  const chargeId = dispute?.charge;
+  const disputeId = dispute?.id;
+  const amount = dispute?.amount ?? 0;
+
+  if (!chargeId || !disputeId || amount <= 0) {
+    logger.error('[billing.webhook] dispute.funds_withdrawn missing required fields', {
+      disputeId,
+      chargeId,
+      amount,
+      eventId: event?.id,
+    });
+    try {
+      billingEvents.emit('billing.refund.unresolved', { reason: 'dispute_missing_fields', disputeId, chargeId, amount });
+    } catch (evtErr) {
+      logger.error('[billing.webhook] billing.refund.unresolved listener error (non-fatal)', {
+        error: evtErr?.message ?? String(evtErr),
+        stack: evtErr?.stack,
+      });
+    }
+    return;
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    logger.error('[billing.webhook] dispute.funds_withdrawn — Stripe client unavailable, cannot resolve charge', {
+      disputeId,
+      chargeId,
+    });
+    return;
+  }
+
+  let organizationId = null;
+  let stripeSessionId = null;
+  let packId = null;
+  let paymentIntentId = null;
+
+  try {
+    const charge = await stripe.charges.retrieve(chargeId);
+    const meta = charge?.metadata ?? {};
+    organizationId = meta.organizationId ?? null;
+    stripeSessionId = meta.stripeSessionId ?? null;
+    packId = meta.packId ?? null;
+    paymentIntentId = charge?.payment_intent ?? null;
+  } catch (err) {
+    logger.error('[billing.webhook] dispute.funds_withdrawn charge fetch failed', {
+      chargeId,
+      disputeId,
+      error: err?.message ?? String(err),
+      stack: err?.stack,
+    });
+    // Surface to ops; do NOT throw — withIdempotency would dead-letter after 5 retries on a
+    // permanently-broken Stripe lookup, but Stripe transient failures should still go through
+    // the retry machinery, so we re-throw to let it count.
+    throw err;
+  }
+
+  // Backfill via PaymentIntent when charge metadata is missing or carries the sentinel.
+  if ((isUnresolved(stripeSessionId) || !organizationId || !packId) && paymentIntentId) {
+    try {
+      const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+      const piMeta = paymentIntent?.metadata ?? {};
+      if (isUnresolved(stripeSessionId)) stripeSessionId = piMeta.stripeSessionId ?? stripeSessionId;
+      if (!packId) packId = piMeta.packId ?? null;
+      if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) {
+        const piOrgId = piMeta.organizationId;
+        if (piOrgId && mongoose.Types.ObjectId.isValid(piOrgId)) {
+          organizationId = piOrgId;
+        }
+      }
+    } catch (err) {
+      logger.error('[billing.webhook] dispute.funds_withdrawn PI fetch failed', {
+        paymentIntentId,
+        disputeId,
+        chargeId,
+        error: err?.message ?? String(err),
+        stack: err?.stack,
+      });
+      // PI fetch failure is non-fatal — we may still have what we need from charge.metadata.
+    }
+  }
+
+  // Could not resolve org / session — this charge is unrelated to billing extras (or metadata
+  // was never propagated). Emit alert for manual reconciliation, do NOT crash.
+  if (
+    !organizationId ||
+    !mongoose.Types.ObjectId.isValid(organizationId) ||
+    isUnresolved(stripeSessionId)
+  ) {
+    logger.error('[billing] dispute.funds_withdrawn unresolved — manual reconciliation required', {
+      disputeId,
+      chargeId,
+      paymentIntentId,
+      organizationId,
+      stripeSessionId,
+      amount,
+    });
+    try {
+      billingEvents.emit('billing.refund.unresolved', {
+        reason: 'dispute_unresolved',
+        disputeId,
+        chargeId,
+        paymentIntentId,
+        amount,
+      });
+    } catch (evtErr) {
+      logger.error('[billing.webhook] billing.refund.unresolved listener error (non-fatal)', {
+        error: evtErr?.message ?? String(evtErr),
+        stack: evtErr?.stack,
+      });
+    }
+    return;
+  }
+
+  // Stable refId per dispute — refundPartial's ledger idempotency makes redelivery a no-op.
+  // Disputes are independent of subscription/invoice cycles, so we deliberately skip the
+  // per-family event-newer guard and rely on ledger-layer refId idempotency exclusively.
+  const refId = `dispute_${disputeId}`;
+  await BillingExtraService.refundPartial(organizationId, stripeSessionId, amount, packId, refId);
+
+  // Critical alert — money has actually left the account.
+  logger.error('[billing] dispute lost — funds withdrawn, ledger debited', {
+    disputeId,
+    chargeId,
+    organizationId,
+    stripeSessionId,
+    amount,
+    eventId: event?.id,
+  });
+
+  try {
+    billingEvents.emit('billing.dispute.lost', {
+      disputeId,
+      chargeId,
+      organizationId,
+      stripeSessionId,
+      amount,
+    });
+  } catch (evtErr) {
+    logger.error('[billing.webhook] billing.dispute.lost listener error (non-fatal)', {
+      error: evtErr?.message ?? String(evtErr),
+      stack: evtErr?.stack,
+    });
+  }
+};
+
 export default {
   withIdempotency,
   handleCheckoutSessionCompleted,
@@ -726,4 +903,5 @@ export default {
   handleChargeRefunded,
   handleCustomerDeleted,
   handleChargeDisputeCreated,
+  handleChargeDisputeFundsWithdrawn,
 };

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -25,6 +25,9 @@ describe('Billing webhook controller unit tests:', () => {
       handleInvoicePaymentFailed: jest.fn().mockResolvedValue(),
       handleInvoicePaymentSucceeded: jest.fn().mockResolvedValue(),
       handleChargeRefunded: jest.fn().mockResolvedValue(),
+      handleCustomerDeleted: jest.fn().mockResolvedValue(),
+      handleChargeDisputeCreated: jest.fn().mockResolvedValue(),
+      handleChargeDisputeFundsWithdrawn: jest.fn().mockResolvedValue(),
     };
 
     jest.unstable_mockModule('../services/billing.webhook.service.js', () => ({
@@ -174,6 +177,28 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleInvoicePaymentFailed).toHaveBeenCalledWith({ id: 'inv_fail' }, eventData);
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('should handle charge.dispute.funds_withdrawn event', async () => {
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { stripe: { secretKey: 'sk_test_fw', webhookSecret: 'whsec_fw' } },
+    }));
+
+    const eventData = { type: 'charge.dispute.funds_withdrawn', data: { object: { id: 'dp_fw_1', charge: 'ch_1', amount: 2900 } } };
+    mockStripeInstance.webhooks.constructEvent.mockReturnValue(eventData);
+
+    const mod = await import('../controllers/billing.webhook.controller.js');
+    BillingWebhookController = mod.default;
+
+    const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw' };
+    await BillingWebhookController.handleWebhook(req, res);
+
+    expect(mockBillingWebhookService.handleChargeDisputeFundsWithdrawn).toHaveBeenCalledWith(
+      { id: 'dp_fw_1', charge: 'ch_1', amount: 2900 },
+      eventData,
+    );
     expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
@@ -23,6 +23,7 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
       create: jest.fn(),
       findOne: jest.fn(),
       deleteOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     jest.unstable_mockModule('mongoose', () => ({
@@ -40,35 +41,66 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
   });
 
   describe('tryRecord', () => {
-    test('should return { recorded: true } on first insert', async () => {
+    /** Helper: stub findOne().lean() to return the given existing doc. */
+    const stubExisting = (existing) => {
+      mockModel.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(existing) });
+    };
+
+    test('should return { recorded: true, retry: false } on first insert', async () => {
       mockModel.create.mockResolvedValue({ eventId: 'evt_abc', type: 'checkout.session.completed' });
 
       const result = await ProcessedStripeEventRepository.tryRecord('evt_abc', 'checkout.session.completed');
 
-      expect(result).toEqual({ recorded: true });
+      expect(result).toEqual({ recorded: true, retry: false });
       expect(mockModel.create).toHaveBeenCalledWith(
         expect.objectContaining({ eventId: 'evt_abc', type: 'checkout.session.completed' }),
       );
     });
 
-    test('should return { recorded: false } on duplicate eventId (E11000)', async () => {
+    test('duplicate + existing.deadLetter=true → { recorded: false, reason: dead_letter }', async () => {
       mockModel.create.mockRejectedValueOnce(makeE11000());
+      stubExisting({ eventId: 'evt_dl', attempts: 5, deadLetter: true });
 
-      const result = await ProcessedStripeEventRepository.tryRecord('evt_abc', 'checkout.session.completed');
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_dl', 'checkout.session.completed');
 
-      expect(result).toEqual({ recorded: false });
+      expect(result).toEqual({ recorded: false, reason: 'dead_letter' });
     });
 
-    test('same eventId twice — second returns { recorded: false }', async () => {
-      mockModel.create
-        .mockResolvedValueOnce({ eventId: 'evt_dup', type: 'charge.refunded' })
-        .mockRejectedValueOnce(makeE11000());
+    test('duplicate + attempts>0 + !deadLetter → { recorded: true, retry: true } (in-flight retry)', async () => {
+      mockModel.create.mockRejectedValueOnce(makeE11000());
+      stubExisting({ eventId: 'evt_retry', attempts: 2, deadLetter: false });
 
-      const first = await ProcessedStripeEventRepository.tryRecord('evt_dup', 'charge.refunded');
-      const second = await ProcessedStripeEventRepository.tryRecord('evt_dup', 'charge.refunded');
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_retry', 'charge.refunded');
 
-      expect(first).toEqual({ recorded: true });
-      expect(second).toEqual({ recorded: false });
+      expect(result).toEqual({ recorded: true, retry: true });
+    });
+
+    test('duplicate + attempts===0 + !deadLetter → { recorded: false, reason: already_processed } (terminal success)', async () => {
+      mockModel.create.mockRejectedValueOnce(makeE11000());
+      stubExisting({ eventId: 'evt_done', attempts: 0, deadLetter: false });
+
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_done', 'charge.refunded');
+
+      expect(result).toEqual({ recorded: false, reason: 'already_processed' });
+    });
+
+    test('duplicate + missing-attempts field treated as 0 → already_processed', async () => {
+      mockModel.create.mockRejectedValueOnce(makeE11000());
+      // Legacy doc with no attempts field at all
+      stubExisting({ eventId: 'evt_legacy', deadLetter: false });
+
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_legacy', 'charge.refunded');
+
+      expect(result).toEqual({ recorded: false, reason: 'already_processed' });
+    });
+
+    test('duplicate + lookup returns null (race window) → already_processed', async () => {
+      mockModel.create.mockRejectedValueOnce(makeE11000());
+      stubExisting(null);
+
+      const result = await ProcessedStripeEventRepository.tryRecord('evt_gone', 'charge.refunded');
+
+      expect(result).toEqual({ recorded: false, reason: 'already_processed' });
     });
 
     test('should throw for non-duplicate errors', async () => {

--- a/modules/billing/tests/billing.webhook.hardening.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.hardening.unit.tests.js
@@ -1615,4 +1615,151 @@ describe('handleChargeDisputeFundsWithdrawn — dispute lost, debit ledger:', ()
 
     expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
   });
+
+  test('missing-fields emit throws → listener error logged as non-fatal, no propagation', async () => {
+    mockEvents.emit.mockImplementationOnce((evtName) => {
+      if (evtName === 'billing.refund.unresolved') throw new Error('listener_blew_missing');
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_emit_miss', charge: null, amount: 2900 },
+      { id: 'evt_emit_miss', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] billing.refund.unresolved listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener_blew_missing' }),
+    );
+  });
+
+  test('Stripe client unavailable (getStripe → null) → log critical, return early without debit', async () => {
+    mockGetStripe.mockReturnValueOnce(null);
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_no_stripe', charge: 'ch_fw_001', amount: 2900 },
+      { id: 'evt_no_stripe', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockStripeInstance.charges.retrieve).not.toHaveBeenCalled();
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] dispute.funds_withdrawn — Stripe client unavailable, cannot resolve charge',
+      expect.objectContaining({ disputeId: 'dp_no_stripe', chargeId: 'ch_fw_001' }),
+    );
+  });
+
+  test('charge fetch failure → log error then re-throw (transient failures count toward dead-letter)', async () => {
+    mockStripeInstance.charges.retrieve.mockRejectedValueOnce(new Error('stripe_5xx'));
+
+    await expect(
+      BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+        { id: 'dp_charge_err', charge: 'ch_broken', amount: 2900 },
+        { id: 'evt_charge_err', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+      ),
+    ).rejects.toThrow('stripe_5xx');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] dispute.funds_withdrawn charge fetch failed',
+      expect.objectContaining({ chargeId: 'ch_broken', disputeId: 'dp_charge_err', error: 'stripe_5xx' }),
+    );
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+  });
+
+  test('PI fetch fails → log non-fatal, fall through with charge.metadata only (still resolves when sufficient)', async () => {
+    // charge has full metadata but session is the sentinel → triggers PI backfill, which throws.
+    mockStripeInstance.charges.retrieve.mockResolvedValueOnce({
+      id: 'ch_fw_pi_err',
+      payment_intent: 'pi_fw_pi_err',
+      metadata: { organizationId: orgId, stripeSessionId: '__pending__', packId },
+    });
+    mockStripeInstance.paymentIntents.retrieve.mockRejectedValueOnce(new Error('pi_fetch_5xx'));
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_pi_err', charge: 'ch_fw_pi_err', amount: 2900 },
+      { id: 'evt_pi_err', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] dispute.funds_withdrawn PI fetch failed',
+      expect.objectContaining({ paymentIntentId: 'pi_fw_pi_err', disputeId: 'dp_pi_err', error: 'pi_fetch_5xx' }),
+    );
+    // session still unresolved → unresolved branch fires, no debit.
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.refund.unresolved',
+      expect.objectContaining({ reason: 'dispute_unresolved', disputeId: 'dp_pi_err' }),
+    );
+  });
+
+  test('PI metadata backfills organizationId when charge has none (or invalid)', async () => {
+    mockStripeInstance.charges.retrieve.mockResolvedValueOnce({
+      id: 'ch_fw_org_backfill',
+      payment_intent: 'pi_fw_org_backfill',
+      metadata: { organizationId: 'not-a-valid-objectid', stripeSessionId: '__pending__', packId: undefined },
+    });
+    mockStripeInstance.paymentIntents.retrieve.mockResolvedValueOnce({
+      id: 'pi_fw_org_backfill',
+      metadata: { organizationId: orgId, stripeSessionId: 'cs_test_pi_real', packId },
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_org_backfill', charge: 'ch_fw_org_backfill', amount: 1500 },
+      { id: 'evt_org_backfill', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).toHaveBeenCalledWith(
+      orgId,
+      'cs_test_pi_real',
+      1500,
+      packId,
+      'dispute_dp_org_backfill',
+    );
+  });
+
+  test('unresolved emit throws → listener error logged, no propagation', async () => {
+    mockStripeInstance.charges.retrieve.mockResolvedValueOnce({
+      id: 'ch_unres_emit',
+      payment_intent: null,
+      metadata: {},
+    });
+    mockEvents.emit.mockImplementationOnce((evtName) => {
+      if (evtName === 'billing.refund.unresolved') throw new Error('listener_blew_unresolved');
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_unres_emit', charge: 'ch_unres_emit', amount: 2900 },
+      { id: 'evt_unres_emit', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] billing.refund.unresolved listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener_blew_unresolved' }),
+    );
+  });
+
+  test('billing.dispute.lost listener error → logged as non-fatal, debit still completes', async () => {
+    mockEvents.emit.mockImplementationOnce((evtName) => {
+      if (evtName === 'billing.dispute.lost') throw new Error('listener_blew_lost');
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_lost_emit', charge: 'ch_fw_001', amount: 2900 },
+      { id: 'evt_lost_emit', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    // Debit still happened (listener error must not interrupt the flow).
+    expect(mockExtraService.refundPartial).toHaveBeenCalledWith(
+      orgId,
+      stripeSessionId,
+      2900,
+      packId,
+      'dispute_dp_lost_emit',
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.webhook] billing.dispute.lost listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener_blew_lost' }),
+    );
+  });
 });

--- a/modules/billing/tests/billing.webhook.hardening.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.hardening.unit.tests.js
@@ -396,8 +396,8 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
     jest.restoreAllMocks();
   });
 
-  test('first failure (attempts=1 < 5): rollback called, error re-thrown', async () => {
-    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+  test('first failure (attempts=1 < 5): doc persists (no rollback), error re-thrown', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
     mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 1 });
     const handler = jest.fn().mockRejectedValue(new Error('transient'));
     const event = makeEvent();
@@ -405,19 +405,21 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
     await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('transient');
 
     expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledWith('evt_rl_001', 'transient');
-    expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_rl_001');
+    // Doc must NOT be deleted — attempts must persist across Stripe redeliveries
+    // so MAX_ATTEMPTS (5) is reachable. Deleting on rollback was the original bug.
+    expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
     expect(mockProcessedStripeEventRepository.markDeadLetter).not.toHaveBeenCalled();
   });
 
-  test('fifth failure (attempts=5 >= 5): dead-letter — no rollback, success sentinel returned, logger.error called', async () => {
-    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+  test('fifth failure (attempts=5 >= 5): dead-letter — markDeadLetter called, success sentinel returned, logger.error called', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: true });
     mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 5 });
     const handler = jest.fn().mockRejectedValue(new Error('persistent'));
     const event = makeEvent('evt_dead_001');
 
     const result = await BillingWebhookService.withIdempotency(event, handler);
 
-    // No rollback — dead-letter kept
+    // Doc kept; markDeadLetter sets the terminal flag.
     expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
     expect(mockProcessedStripeEventRepository.markDeadLetter).toHaveBeenCalledWith('evt_dead_001');
     expect(mockLogger.error).toHaveBeenCalledWith(
@@ -427,20 +429,20 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
     expect(result).toEqual(expect.objectContaining({ deadLettered: true, eventId: 'evt_dead_001', attempts: 5 }));
   });
 
-  test('attempts=4 < 5: rollback still runs (not yet dead-letter)', async () => {
-    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+  test('attempts=4 < 5: doc persists, no rollback, no dead-letter, error re-thrown', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: true });
     mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 4 });
     const handler = jest.fn().mockRejectedValue(new Error('still failing'));
     const event = makeEvent('evt_retry_04');
 
     await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('still failing');
 
-    expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_retry_04');
+    expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
     expect(mockProcessedStripeEventRepository.markDeadLetter).not.toHaveBeenCalled();
   });
 
-  test('incrementAttempts failure: original error still propagated, rollback attempted', async () => {
-    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+  test('incrementAttempts failure: original error propagated, doc not deleted', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
     mockProcessedStripeEventRepository.incrementAttempts.mockRejectedValue(new Error('counter DB down'));
     const handler = jest.fn().mockRejectedValue(new Error('handler error'));
     const event = makeEvent('evt_counter_fail');
@@ -451,10 +453,11 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
       '[billing] webhook attempts increment failed',
       expect.objectContaining({ eventId: 'evt_counter_fail' }),
     );
+    expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
   });
 
   test('markDeadLetter failure: logger.error called, success sentinel still returned', async () => {
-    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: true });
     mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 5 });
     mockProcessedStripeEventRepository.markDeadLetter.mockRejectedValue(new Error('DL DB down'));
     const handler = jest.fn().mockRejectedValue(new Error('persistent again'));
@@ -468,6 +471,42 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
     );
     // Still returns dead-letter sentinel (Stripe gets 200)
     expect(result.deadLettered).toBe(true);
+  });
+
+  test('successful first call: handler runs, no incrementAttempts (attempts stays 0)', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
+    const handler = jest.fn().mockResolvedValue({ ok: true });
+    const event = makeEvent('evt_success_001');
+
+    const result = await BillingWebhookService.withIdempotency(event, handler);
+
+    expect(result).toEqual({ ok: true });
+    // attempts stays 0 on success — that is the terminal-success signal for tryRecord.
+    expect(mockProcessedStripeEventRepository.incrementAttempts).not.toHaveBeenCalled();
+    expect(mockProcessedStripeEventRepository.markDeadLetter).not.toHaveBeenCalled();
+    expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
+  });
+
+  test('redelivery after success: tryRecord={recorded:false, reason:already_processed} → skip', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false, reason: 'already_processed' });
+    const handler = jest.fn();
+    const event = makeEvent('evt_already_processed');
+
+    const result = await BillingWebhookService.withIdempotency(event, handler);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'duplicate_event_or_dead_letter', detail: 'already_processed' });
+  });
+
+  test('redelivery after dead-letter: tryRecord={recorded:false, reason:dead_letter} → skip', async () => {
+    mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false, reason: 'dead_letter' });
+    const handler = jest.fn();
+    const event = makeEvent('evt_dl_replay');
+
+    const result = await BillingWebhookService.withIdempotency(event, handler);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'duplicate_event_or_dead_letter', detail: 'dead_letter' });
   });
 });
 
@@ -1383,5 +1422,197 @@ describe('handleChargeDisputeCreated — log + emit, no auto-debit:', () => {
       '[billing.webhook] billing.dispute.opened listener error (non-fatal)',
       expect.objectContaining({ error: 'dispute listener blew' }),
     );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pre-LIVE — charge.dispute.funds_withdrawn (dispute lost — debit ledger)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('handleChargeDisputeFundsWithdrawn — dispute lost, debit ledger:', () => {
+  let BillingWebhookService;
+  let mockExtraService;
+  let mockEvents;
+  let mockLogger;
+  let mockStripeInstance;
+  let mockGetStripe;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const stripeSessionId = 'cs_test_dispute_fw_001';
+  const packId = 'pack_500k';
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    mockEvents = { emit: jest.fn() };
+    mockExtraService = {
+      creditPack: jest.fn(),
+      refundPartial: jest.fn().mockResolvedValue({ doc: {}, applied: true, refundUnits: 100000 }),
+    };
+
+    mockStripeInstance = {
+      charges: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'ch_fw_001',
+          payment_intent: 'pi_fw_001',
+          metadata: { organizationId: orgId, stripeSessionId, packId },
+        }),
+      },
+      paymentIntents: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'pi_fw_001',
+          metadata: { organizationId: orgId, stripeSessionId, packId },
+        }),
+      },
+    };
+    mockGetStripe = jest.fn().mockReturnValue(mockStripeInstance);
+
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: mockGetStripe }));
+    jest.unstable_mockModule('../services/billing.extra.service.js', () => ({ default: mockExtraService }));
+    jest.unstable_mockModule('../services/billing.reset.service.js', () => ({ default: { resetWeek: jest.fn() } }));
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {
+        findByOrganization: jest.fn(), findByStripeCustomerId: jest.fn(),
+        findByStripeSubscriptionId: jest.fn(), create: jest.fn(), update: jest.fn(),
+        updateIfEventNewer: jest.fn(),
+      },
+    }));
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: {
+        tryRecord: jest.fn().mockResolvedValue({ recorded: true, retry: false }),
+        incrementAttempts: jest.fn(),
+        deleteByEventId: jest.fn(),
+        markDeadLetter: jest.fn(),
+      },
+    }));
+    jest.unstable_mockModule('../lib/events.js', () => ({ default: mockEvents }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { billing: { plans: ['free', 'starter', 'pro', 'enterprise'] } },
+    }));
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+        model: () => ({}),
+      },
+    }));
+
+    const mod = await import('../services/billing.webhook.service.js');
+    BillingWebhookService = mod.default;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  test('fully resolved: ledger debited via refundPartial(refId="dispute_<id>"), event emitted, log called', async () => {
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_fw_001', charge: 'ch_fw_001', amount: 2900 },
+      { id: 'evt_fw_001', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).toHaveBeenCalledWith(
+      orgId,
+      stripeSessionId,
+      2900,
+      packId,
+      'dispute_dp_fw_001',
+    );
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.dispute.lost',
+      expect.objectContaining({
+        disputeId: 'dp_fw_001',
+        chargeId: 'ch_fw_001',
+        organizationId: orgId,
+        stripeSessionId,
+        amount: 2900,
+      }),
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing] dispute lost — funds withdrawn, ledger debited',
+      expect.objectContaining({ disputeId: 'dp_fw_001', amount: 2900 }),
+    );
+  });
+
+  test('SENTINEL_PENDING in charge.metadata → backfill via PaymentIntent → debit succeeds', async () => {
+    mockStripeInstance.charges.retrieve.mockResolvedValueOnce({
+      id: 'ch_fw_002',
+      payment_intent: 'pi_fw_002',
+      metadata: { organizationId: orgId, stripeSessionId: '__pending__', packId: undefined },
+    });
+    mockStripeInstance.paymentIntents.retrieve.mockResolvedValueOnce({
+      id: 'pi_fw_002',
+      metadata: { organizationId: orgId, stripeSessionId: 'cs_test_real', packId },
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_fw_002', charge: 'ch_fw_002', amount: 1500 },
+      { id: 'evt_fw_002', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockStripeInstance.paymentIntents.retrieve).toHaveBeenCalledWith('pi_fw_002');
+    expect(mockExtraService.refundPartial).toHaveBeenCalledWith(
+      orgId,
+      'cs_test_real',
+      1500,
+      packId,
+      'dispute_dp_fw_002',
+    );
+  });
+
+  test('charge unrelated to billing (no org / no session) → emit billing.refund.unresolved, no debit, no crash', async () => {
+    mockStripeInstance.charges.retrieve.mockResolvedValueOnce({
+      id: 'ch_unrelated',
+      payment_intent: null,
+      metadata: {}, // no org/session/pack — not a billing extras charge
+    });
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_unrelated', charge: 'ch_unrelated', amount: 4500 },
+      { id: 'evt_unrelated', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.refund.unresolved',
+      expect.objectContaining({ reason: 'dispute_unresolved', disputeId: 'dp_unrelated' }),
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing] dispute.funds_withdrawn unresolved — manual reconciliation required',
+      expect.objectContaining({ disputeId: 'dp_unrelated' }),
+    );
+  });
+
+  test('idempotent re-delivery: refId is stable per dispute (downstream refundPartial enforces no-op)', async () => {
+    const dispute = { id: 'dp_idem', charge: 'ch_fw_001', amount: 2900 };
+    const evt = { id: 'evt_idem', type: 'charge.dispute.funds_withdrawn', created: 1714000000 };
+
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(dispute, evt);
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(dispute, evt);
+
+    expect(mockExtraService.refundPartial).toHaveBeenCalledTimes(2);
+    // Both calls use the SAME refId — refundPartial's ledger-layer idempotency makes the second a no-op.
+    expect(mockExtraService.refundPartial.mock.calls[0][4]).toBe('dispute_dp_idem');
+    expect(mockExtraService.refundPartial.mock.calls[1][4]).toBe('dispute_dp_idem');
+  });
+
+  test('missing required fields (no chargeId): emit billing.refund.unresolved with reason=dispute_missing_fields, no debit', async () => {
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_bad', charge: null, amount: 2900 },
+      { id: 'evt_bad', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.refund.unresolved',
+      expect.objectContaining({ reason: 'dispute_missing_fields' }),
+    );
+  });
+
+  test('zero amount: skipped via missing-fields branch, no debit', async () => {
+    await BillingWebhookService.handleChargeDisputeFundsWithdrawn(
+      { id: 'dp_zero', charge: 'ch_fw_001', amount: 0 },
+      { id: 'evt_zero', type: 'charge.dispute.funds_withdrawn', created: 1714000000 },
+    );
+
+    expect(mockExtraService.refundPartial).not.toHaveBeenCalled();
   });
 });

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -6,11 +6,15 @@ import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globa
 /**
  * Unit tests for webhook idempotency (withIdempotency guard)
  *
- * Contract (post #3573 fix — atomic-claim):
- * - tryRecord is called BEFORE the handler (atomic claim via unique index)
- * - If tryRecord returns { recorded: false } → skip (Stripe retry or concurrent delivery)
- * - If handler throws → deleteByEventId rollback → Stripe can retry
- * - On success → record stays permanently (subsequent Stripe retries skipped)
+ * Contract (post dead-letter-reachability fix):
+ * - tryRecord is called BEFORE the handler (atomic claim via unique index).
+ * - tryRecord uses 3-state semantics so attempts persists across Stripe redeliveries:
+ *     - First delivery        → { recorded: true,  retry: false }              → handler runs
+ *     - In-flight retry       → { recorded: true,  retry: true }               → handler runs again
+ *     - Already processed     → { recorded: false, reason: 'already_processed' } → skip
+ *     - Dead-lettered         → { recorded: false, reason: 'dead_letter' }      → skip
+ * - Handler throws → incrementAttempts; if attempts < MAX → throw (Stripe retries),
+ *   doc is NOT deleted (attempts persists). At MAX → markDeadLetter + return success sentinel.
  */
 describe('Billing webhook idempotency unit tests:', () => {
   let BillingWebhookService;
@@ -35,6 +39,8 @@ describe('Billing webhook idempotency unit tests:', () => {
       tryRecord: jest.fn(),
       wasProcessed: jest.fn(),
       deleteByEventId: jest.fn(),
+      incrementAttempts: jest.fn().mockResolvedValue({ attempts: 1 }),
+      markDeadLetter: jest.fn().mockResolvedValue({}),
     };
 
     jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
@@ -94,8 +100,8 @@ describe('Billing webhook idempotency unit tests:', () => {
     /**
      * Happy path: new event — tryRecord succeeds, handler runs, result returned.
      */
-    test('new event: tryRecord=true → handler runs → result returned', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+    test('new event: tryRecord={recorded:true,retry:false} → handler runs → result returned', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
       const handler = jest.fn().mockResolvedValue({ ok: true });
       const event = makeEvent();
 
@@ -110,35 +116,58 @@ describe('Billing webhook idempotency unit tests:', () => {
     });
 
     /**
-     * Stripe retry after success: tryRecord returns { recorded: false } (unique index hit)
-     * → handler not invoked → skip sentinel returned.
+     * In-flight retry: previous run failed, attempts persisted on disk.
+     * tryRecord returns { recorded: true, retry: true } → handler runs again.
      */
-    test('Stripe retry: tryRecord=false → handler not run → skip sentinel', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false });
+    test('in-flight retry: tryRecord={recorded:true,retry:true} → handler re-enters', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: true });
+      const handler = jest.fn().mockResolvedValue({ ok: true });
+      const event = makeEvent('evt_retry_001');
+
+      const result = await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(result).toEqual({ ok: true });
+    });
+
+    /**
+     * Stripe redelivery after success: tryRecord returns { recorded: false, reason: 'already_processed' }
+     * → handler not invoked → skip sentinel returned with detail.
+     */
+    test('Stripe redelivery after success: skip with detail=already_processed', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false, reason: 'already_processed' });
       const handler = jest.fn();
       const event = makeEvent();
 
       const result = await BillingWebhookService.withIdempotency(event, handler);
 
-      expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledWith(
-        'evt_test_001',
-        'checkout.session.completed',
-      );
       expect(handler).not.toHaveBeenCalled();
-      expect(result).toEqual({ skipped: true, reason: 'duplicate_event' });
+      expect(result).toEqual({ skipped: true, reason: 'duplicate_event_or_dead_letter', detail: 'already_processed' });
+    });
+
+    /**
+     * Stripe redelivery after dead-letter: skip and return success sentinel so Stripe stops retrying.
+     */
+    test('Stripe redelivery after dead-letter: skip with detail=dead_letter', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: false, reason: 'dead_letter' });
+      const handler = jest.fn();
+      const event = makeEvent('evt_dl_replay');
+
+      const result = await BillingWebhookService.withIdempotency(event, handler);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result).toEqual({ skipped: true, reason: 'duplicate_event_or_dead_letter', detail: 'dead_letter' });
     });
 
     /**
      * Concurrent delivery: two simultaneous Stripe deliveries — tryRecord is atomic.
      * First call wins (recorded: true) → handler runs once.
-     * Second call loses (recorded: false) → handler not run → skip.
-     *
-     * This is the TOCTOU fix: only ONE handler execution vs the old 2-execution race.
+     * Second call loses (recorded: false, already_processed) → handler not run → skip.
      */
     test('concurrent delivery: only the first claim runs the handler (TOCTOU fix)', async () => {
       mockProcessedStripeEventRepository.tryRecord
-        .mockResolvedValueOnce({ recorded: true }) // first delivery wins
-        .mockResolvedValueOnce({ recorded: false }); // second delivery loses
+        .mockResolvedValueOnce({ recorded: true, retry: false }) // first delivery wins
+        .mockResolvedValueOnce({ recorded: false, reason: 'already_processed' }); // second loses
       const handler = jest.fn().mockResolvedValue(undefined);
       const event = makeEvent('evt_concurrent', 'customer.subscription.updated');
 
@@ -147,19 +176,18 @@ describe('Billing webhook idempotency unit tests:', () => {
         BillingWebhookService.withIdempotency(event, handler),
       ]);
 
-      // Handler runs exactly ONCE (not twice as in the old TOCTOU bug)
       expect(handler).toHaveBeenCalledTimes(1);
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(2);
       expect(results.some((r) => r && r.skipped)).toBe(true);
     });
 
     /**
-     * Handler throws → deleteByEventId rollback → event stays unprocessed for Stripe to retry.
-     * wasProcessed is NOT called (old pre-check removed in favour of atomic-claim).
+     * Handler throws below MAX_ATTEMPTS → incrementAttempts called → error re-thrown
+     * → doc NOT deleted (attempts must persist across Stripe redeliveries for dead-letter to work).
      */
-    test('handler throws → deleteByEventId called (rollback) → error re-thrown', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
-      mockProcessedStripeEventRepository.deleteByEventId.mockResolvedValue({ deleted: true });
+    test('handler throws (attempts<MAX): incrementAttempts called, doc kept, error re-thrown', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
+      mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 1 });
       const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
       const event = makeEvent();
 
@@ -167,36 +195,23 @@ describe('Billing webhook idempotency unit tests:', () => {
         BillingWebhookService.withIdempotency(event, handler),
       ).rejects.toThrow('handler blew up');
 
-      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_test_001');
+      expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledWith(
+        'evt_test_001',
+        'handler blew up',
+      );
+      // Critical: doc must NOT be deleted — attempts must persist across redeliveries.
+      expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
     });
 
     /**
-     * Rollback itself fails (DB outage) — original handler error must still be thrown,
-     * not the rollback error. The swallowed rollback error is logged but never re-thrown.
+     * Retry across redeliveries: handler fails on delivery #1, succeeds on delivery #2.
+     * Doc persists between deliveries; tryRecord returns { recorded: true, retry: true } on #2.
      */
-    test('rollback fails → original handler error still propagated (not masked)', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
-      mockProcessedStripeEventRepository.deleteByEventId.mockRejectedValue(new Error('DB outage'));
-      const handler = jest.fn().mockRejectedValue(new Error('handler blew up'));
-      const event = makeEvent();
-
-      await expect(
-        BillingWebhookService.withIdempotency(event, handler),
-      ).rejects.toThrow('handler blew up');
-
-      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_test_001');
-    });
-
-    /**
-     * Retry after rollback: handler fails (rollback), then Stripe retries.
-     * On the second delivery tryRecord succeeds again (record was deleted) → handler runs.
-     */
-    test('retry after rollback: second delivery succeeds after first handler failure', async () => {
-      // First delivery: claim succeeds, handler throws, rollback runs
+    test('retry across redeliveries: second delivery succeeds without rollback', async () => {
       mockProcessedStripeEventRepository.tryRecord
-        .mockResolvedValueOnce({ recorded: true })
-        .mockResolvedValueOnce({ recorded: true }); // second delivery can claim again
-      mockProcessedStripeEventRepository.deleteByEventId.mockResolvedValue({ deleted: true });
+        .mockResolvedValueOnce({ recorded: true, retry: false })
+        .mockResolvedValueOnce({ recorded: true, retry: true });
+      mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 1 });
 
       const handler = jest.fn()
         .mockRejectedValueOnce(new Error('transient failure'))
@@ -204,14 +219,13 @@ describe('Billing webhook idempotency unit tests:', () => {
 
       const event = makeEvent('evt_retry_test');
 
-      // First delivery fails
+      // First delivery fails — attempts persists, no rollback.
       await expect(
         BillingWebhookService.withIdempotency(event, handler),
       ).rejects.toThrow('transient failure');
+      expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
 
-      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_retry_test');
-
-      // Second delivery (Stripe retry) succeeds
+      // Second delivery (Stripe retry) succeeds via retry: true re-entry.
       const result = await BillingWebhookService.withIdempotency(event, handler);
       expect(result).toEqual({ ok: true });
       expect(handler).toHaveBeenCalledTimes(2);
@@ -222,7 +236,7 @@ describe('Billing webhook idempotency unit tests:', () => {
      * wasProcessed must NOT be called (old contract removed).
      */
     test('tryRecord called exactly once; wasProcessed never called', async () => {
-      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true });
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
       const handler = jest.fn().mockResolvedValue(undefined);
       const event = makeEvent('evt_single_check');
 


### PR DESCRIPTION
## Summary

Two post-merge audit fixes on the billing module before LIVE.

### Fix 1 — Dead-letter mechanism unreachable (architectural bug)

Previous design deleted the `ProcessedStripeEvent` doc on handler exception, so `attempts` reset to 0 on every Stripe redelivery and the `attempts >= 5` dead-letter branch was never reachable. A permanently-broken handler would loop ~50× across Stripe's 3-day retry window, polluting logs and potentially writing partial state.

**Fix**: don't delete the doc on rollback. `attempts` persists across redeliveries.

`tryRecord` now returns 3-state semantics derived from existing fields (no new `pendingRetry` column — the `(attempts, deadLetter)` pair already encodes the four states unambiguously):

| state | tryRecord result | flow |
|---|---|---|
| new doc | `{ recorded: true, retry: false }` | handler runs |
| existing, `attempts > 0 && !deadLetter` | `{ recorded: true, retry: true }` | handler re-enters |
| existing, `attempts === 0 && !deadLetter` | `{ recorded: false, reason: 'already_processed' }` | skip (succeeded last time — handler never increments on success) |
| existing, `deadLetter: true` | `{ recorded: false, reason: 'dead_letter' }` | skip (terminal — return 200 to Stripe) |

`withIdempotency`: on exception, increment attempts; below MAX → throw (Stripe retries); at MAX → `markDeadLetter` + return success sentinel so Stripe stops.

### Fix 2 — Add `charge.dispute.funds_withdrawn` webhook handler

`charge.dispute.created` was handled (log + emit, no debit — conservative). But `charge.dispute.funds_withdrawn` (the event when Stripe actually pulls money from the bank because the dispute was lost) was unhandled — money-loss gap where the customer kept meter units.

New `handleChargeDisputeFundsWithdrawn`:
- Resolves org/session/pack via `charge.metadata`, falls back to PaymentIntent backfill on `SENTINEL_PENDING` (mirrors `handleChargeRefunded`).
- Debits via `BillingExtraService.refundPartial(orgId, sessionId, dispute.amount, packId, 'dispute_<id>')`.
- Stable `refId` per dispute → ledger-layer idempotency makes Stripe redeliveries no-ops.
- **No per-family event-newer guard** — disputes are independent of subscription/invoice cycles, so we deliberately rely on `refundPartial`'s ledger-layer idempotency on `refId` exclusively (combined with the persistent dead-letter machinery from Fix 1).
- Emits `billing.dispute.lost` on success, `billing.refund.unresolved` (`reason: 'dispute_unresolved'`) when org/session can't be resolved.
- Critical `logger.error` on the success path — money has actually left the account, ops must be notified.

## Test plan
- [x] `npm run lint` — clean
- [x] `NODE_ENV=test npm run test:unit` — 1137/1137 pass
- [x] `NODE_ENV=test npm run test:integration` — 335/335 pass
- [x] Updated repository tests for 3-state `tryRecord` (deadLetter / in-flight retry / already_processed / race-window)
- [x] Updated `withIdempotency` tests to assert no rollback on failure (doc must persist)
- [x] New tests for `handleChargeDisputeFundsWithdrawn`: fully-resolved debit, sentinel backfill, unrelated-charge unresolved emit, idempotent refId per dispute, missing-fields/zero-amount guards