### PR TITLE
feat(feature): read ERRORS.md in Phase 0 before coding

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -16,6 +16,7 @@ description: >
 
 ### 1. Identify target module
 
+- Read `ERRORS.md` for known bugs and non-obvious pitfalls to avoid before coding.
 - Which module? Default to **ONE** unless justified.
 - **If the module doesn't exist** → run `/create-module` to scaffold it first, then continue.
 


### PR DESCRIPTION
## Summary

- Adds a bullet to Phase 0 step 1 of the `/feature` skill to read `ERRORS.md` before coding
- Ensures known bugs and non-obvious pitfalls are surfaced at the earliest possible point in the feature implementation flow

## Changes

Additive only — inserts one bullet under `### 1. Identify target module` in `.claude/skills/feature/SKILL.md`. No existing behaviour is removed or altered.

Closes #3594.

## Test plan

- [ ] Confirm the new bullet appears first under Phase 0 step 1 in the skill
- [ ] Backwards compatible: no existing skill step removed or reordered