### PR TITLE
test(integration): config-aware billing equivalences + plan id (closes #3609)

### DIFF
--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1542,7 +1542,7 @@ describe('Auth integration tests:', () => {
       expect(result.body.data.billing).toBeDefined();
       expect(typeof result.body.data.billing.enabled).toBe('boolean');
       expect(typeof result.body.data.billing.meterMode).toBe('boolean');
-      expect(result.body.data.billing.equivalences).toBeNull();
+      expect(result.body.data.billing.equivalences).toEqual(config.billing?.equivalences ?? null);
     });
 
     test('should reflect billing.meterMode=true when enabled (authenticated)', async () => {

--- a/modules/billing/tests/billing.lifecycle.integration.tests.js
+++ b/modules/billing/tests/billing.lifecycle.integration.tests.js
@@ -70,19 +70,29 @@ describe('Billing meter lifecycle integration tests:', () => {
   });
 
   test('plan.changed webhook updates active week quota snapshot mid-week', async () => {
+    // Pick two distinct plan ids from the project's enum so the test runs on any downstream
+    // (upstream defaults expose no plans → fall back to legacy 'starter'/'pro').
+    const plans = Array.isArray(config.billing.plans) && config.billing.plans.length >= 2
+      ? config.billing.plans
+      : ['starter', 'pro'];
+    const initialPlan = plans[0];
+    const upgradePlan = plans[plans.length - 1];
+    const initialVersion = `${initialPlan}-v1`;
+    const upgradeVersion = `${upgradePlan}-v2`;
+
     config.billing.planDefinitions = [
-      { planId: 'starter', version: 'starter-v1', meterQuota: 100, ratios: { scrap: 1 } },
-      { planId: 'pro', version: 'pro-v2', meterQuota: 1000, ratios: { scrap: 1 } },
+      { planId: initialPlan, version: initialVersion, meterQuota: 100, ratios: { scrap: 1 } },
+      { planId: upgradePlan, version: upgradeVersion, meterQuota: 1000, ratios: { scrap: 1 } },
     ];
 
     const organizationId = new mongoose.Types.ObjectId();
     const weekKey = isoWeekKey(new Date());
-    await Organization.create({ _id: organizationId, name: 'Lifecycle Org', slug: 'lifecycle-org', plan: 'starter' });
+    await Organization.create({ _id: organizationId, name: 'Lifecycle Org', slug: 'lifecycle-org', plan: initialPlan });
     await Subscription.create({
       organization: organizationId,
       stripeCustomerId: 'cus_lifecycle',
       stripeSubscriptionId: 'sub_lifecycle',
-      plan: 'starter',
+      plan: initialPlan,
       status: 'active',
     });
     await BillingUsage.create({
@@ -92,7 +102,7 @@ describe('Billing meter lifecycle integration tests:', () => {
       counters: {},
       meterUsed: 25,
       meterQuota: 100,
-      planVersion: 'starter-v1',
+      planVersion: initialVersion,
       meterBreakdown: { scrap: 25 },
       consumedAttributionKeys: [],
     });
@@ -104,12 +114,12 @@ describe('Billing meter lifecycle integration tests:', () => {
         current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
         current_period_start: Math.floor(Date.now() / 1000) - 24 * 60 * 60,
         cancel_at_period_end: false,
-        items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        items: { data: [{ price: { metadata: { planId: upgradePlan } } }] },
       },
       {
         data: {
           previous_attributes: {
-            items: { data: [{ price: { metadata: { planId: 'starter' } } }] },
+            items: { data: [{ price: { metadata: { planId: initialPlan } } }] },
           },
         },
       },
@@ -117,7 +127,7 @@ describe('Billing meter lifecycle integration tests:', () => {
 
     const usage = await BillingUsage.findOne({ organizationId, weekKey }).lean();
     expect(usage.meterQuota).toBe(1000);
-    expect(usage.planVersion).toBe('pro-v2');
+    expect(usage.planVersion).toBe(upgradeVersion);
     expect(usage.meterUsed).toBe(25);
     expect(usage.meterBreakdown).toEqual({ scrap: 25 });
   });

--- a/modules/billing/tests/billing.lifecycle.integration.tests.js
+++ b/modules/billing/tests/billing.lifecycle.integration.tests.js
@@ -72,7 +72,7 @@ describe('Billing meter lifecycle integration tests:', () => {
   test('plan.changed webhook updates active week quota snapshot mid-week', async () => {
     // Pick two distinct plan ids from the project's enum so the test runs on any downstream
     // (upstream defaults expose no plans → fall back to legacy 'starter'/'pro').
-    const plans = Array.isArray(config.billing.plans) && config.billing.plans.length >= 2
+    const plans = Array.isArray(config.billing?.plans) && config.billing.plans.length >= 2
       ? config.billing.plans
       : ['starter', 'pro'];
     const initialPlan = plans[0];

--- a/modules/billing/tests/billing.lifecycle.integration.tests.js
+++ b/modules/billing/tests/billing.lifecycle.integration.tests.js
@@ -70,8 +70,9 @@ describe('Billing meter lifecycle integration tests:', () => {
   });
 
   test('plan.changed webhook updates active week quota snapshot mid-week', async () => {
-    // Pick two distinct plan ids from the project's enum so the test runs on any downstream
-    // (upstream defaults expose no plans → fall back to legacy 'starter'/'pro').
+    // Pick two distinct plan ids from the project's enum so the test runs on any downstream.
+    // Upstream defaults expose ['free','starter','pro','enterprise'] via planDefinitions;
+    // fallback to ['starter','pro'] only when plans array is absent or has fewer than 2 entries.
     const plans = Array.isArray(config.billing?.plans) && config.billing.plans.length >= 2
       ? config.billing.plans
       : ['starter', 'pro'];


### PR DESCRIPTION
## Summary
- `auth.integration` line 1545 — replaces `expect(...equivalences).toBeNull()` with `toEqual(config.billing?.equivalences ?? null)` so downstreams that define equivalences (e.g. trawl `/pricing`) no longer fail.
- `billing.lifecycle.integration` first test — derives the initial/upgrade plan ids from `config.billing.plans` (with legacy `'starter'`/`'pro'` fallback for upstream defaults) instead of hardcoding `'starter'`. The Subscription/Organization schema enum is locked at import time, so trawl's `['free','growth','pro']` enum was rejecting the literal `'starter'`.

## Why
The integration job split (commit `efbd7bcb`) made these two failures visible to downstreams. trawl_node currently carries a `DOWNSTREAM_PATCHES.md` override (PR comes-io/trawl_node#1128), which it can drop once this lands.

Refs `feedback_update_stack_theirs_wipes_patches.md` — second instance of the same pattern, durable fix is upstream.

## Test plan
- [x] `npm run test:integration` — 24 suites / 335 tests pass on upstream defaults (no `planDefinitions`, no `equivalences`)
- [x] ESLint clean on both touched files
- [ ] CI green
- [ ] CodeRabbit clean
- [ ] After merge: `/update-stack` propagation to trawl_node revert the DOWNSTREAM_PATCHES.md override

Closes #3609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated authentication config test to properly reflect configured billing equivalence values.
  * Enhanced billing lifecycle tests to support dynamic plan configurations and plan upgrade scenarios via configuration instead of hard-coded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->