### PR TITLE
feat(billing): stripe live blockers — TTL guard + idempotency + event coverage + admin route

### DIFF
--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -58,6 +58,59 @@ const adminRefundCharge = async (req, res) => {
   }
 };
 
+/**
+ * @desc Admin endpoint to override an organization's subscription plan.
+ *       Restricted to plan changes only — never touches Stripe-driven status fields.
+ *       Stripe remains source of truth for status / period / customer ids; this is
+ *       a manual ops escape hatch (e.g. comp a user during support, force a plan
+ *       during testing). The audit trail (adminUpdatedAt / adminUpdatedBy) is set
+ *       by the repo method.
+ *
+ *       NOTE: this DOES NOT call Stripe. The downstream Stripe subscription remains
+ *       on whatever plan the user is paying for. Use this only when the DB plan
+ *       must diverge from Stripe (rare ops scenarios). To change the actual Stripe
+ *       subscription, use the customer's Billing Portal or a separate Stripe API call.
+ *
+ * @param {Object} req - Express request object (req.body validated as AdminBumpPlanRequest)
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminBumpPlan = async (req, res) => {
+  try {
+    const { orgId, planId } = req.body;
+    const adminUserId = String(req.user?._id ?? '');
+
+    // Lazy imports — the repo module references mongoose.model('Subscription') at load time,
+    // and the logger module touches config.log.fileLogger which isn't always mocked. Unrelated
+    // unit tests that mock Stripe but don't load full schemas would crash on top-level imports.
+    const { default: SubscriptionRepository } = await import('../repositories/billing.subscription.repository.js');
+    const { default: logger } = await import('../../../lib/services/logger.js');
+
+    const existing = await SubscriptionRepository.findByOrganization(orgId);
+    if (!existing) {
+      return responses.error(res, 404, 'Not Found', 'Subscription not found for organization')(
+        new Error(`subscription not found for orgId=${orgId}`),
+      );
+    }
+
+    const updated = await SubscriptionRepository.adminUpdatePlanOnly(String(existing._id), planId, adminUserId);
+
+    logger.info('[billing.admin] plan bumped manually', {
+      orgId,
+      previousPlan: existing.plan,
+      newPlan: planId,
+      adminUserId,
+      subscriptionId: String(existing._id),
+    });
+
+    return responses.success(res, 'subscription plan bumped')(updated);
+  } catch (err) {
+    return responses.error(res, 500, 'Internal Server Error', 'Failed to bump plan')(err);
+  }
+};
+
 export default {
   adminRefundCharge,
+  adminBumpPlan,
 };

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -85,6 +85,7 @@ const adminBumpPlan = async (req, res) => {
     // and the logger module touches config.log.fileLogger which isn't always mocked. Unrelated
     // unit tests that mock Stripe but don't load full schemas would crash on top-level imports.
     const { default: SubscriptionRepository } = await import('../repositories/billing.subscription.repository.js');
+    const { default: OrganizationRepository } = await import('../../organizations/repositories/organizations.repository.js');
     const { default: logger } = await import('../../../lib/services/logger.js');
 
     const existing = await SubscriptionRepository.findByOrganization(orgId);
@@ -95,6 +96,12 @@ const adminBumpPlan = async (req, res) => {
     }
 
     const updated = await SubscriptionRepository.adminUpdatePlanOnly(String(existing._id), planId, adminUserId);
+
+    // Sync org plan so meter quotas / feature flags / access control reflect the bump
+    // immediately. Without this the new plan only applies to the subscription doc, but
+    // the organization's plan field — read by requirePlan / requireQuota — stays stale
+    // until the next Stripe webhook (which may revert to Stripe's value).
+    await OrganizationRepository.setPlan(orgId, planId);
 
     logger.info('[billing.admin] plan bumped manually', {
       orgId,

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -79,8 +79,24 @@ const adminRefundCharge = async (req, res) => {
 const adminBumpPlan = async (req, res) => {
   try {
     const { orgId, planId } = req.body;
-    const adminUserId = String(req.user?._id ?? '');
 
+    // Guard: req.user._id must be a valid ObjectId — the JWT middleware sets it, but a missing
+    // or malformed token could leave it undefined, causing a Mongoose CastError downstream.
+    const rawAdminId = req.user?._id;
+    if (!rawAdminId) {
+      return responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump plan')(
+        new Error('invalid argument: authenticated user id is missing'),
+      );
+    }
+    const adminUserId = String(rawAdminId);
+
+    // NOTE: this controller orchestrates directly against repo + logger to avoid adding a
+    // dedicated service method for a single admin escape hatch. This is an intentional
+    // exception to the service-layer convention: the operation is simple (find → update → sync),
+    // has no domain logic beyond what the repo already provides, and extracting it into
+    // billing.admin.service.js would add ceremony for no isolation benefit.
+    // Tracked for refactor in a future service-extraction pass if more admin operations join.
+    //
     // Lazy imports — the repo module references mongoose.model('Subscription') at load time,
     // and the logger module touches config.log.fileLogger which isn't always mocked. Unrelated
     // unit tests that mock Stripe but don't load full schemas would crash on top-level imports.
@@ -113,6 +129,10 @@ const adminBumpPlan = async (req, res) => {
 
     return responses.success(res, 'subscription plan bumped')(updated);
   } catch (err) {
+    // Surface schema/validation errors from Mongoose as 422 instead of letting them fall to 500.
+    if (err?.name === 'ValidationError' || err?.message?.startsWith('invalid argument')) {
+      return responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump plan')(err);
+    }
     return responses.error(res, 500, 'Internal Server Error', 'Failed to bump plan')(err);
   }
 };

--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -37,6 +37,11 @@ const handleWebhook = async (req, res) => {
           BillingWebhookService.handleCheckoutSessionCompleted(e),
         );
         break;
+      case 'customer.subscription.created':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleSubscriptionCreated(e.data.object, e),
+        );
+        break;
       case 'customer.subscription.updated':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleSubscriptionUpdated(e.data.object, e),
@@ -77,7 +82,13 @@ const handleWebhook = async (req, res) => {
           BillingWebhookService.handleChargeDisputeFundsWithdrawn(e.data.object, e),
         );
         break;
+      case 'charge.dispute.funds_reinstated':
+        await BillingWebhookService.withIdempotency(event, (e) =>
+          BillingWebhookService.handleChargeDisputeFundsReinstated(e.data.object, e),
+        );
+        break;
       default:
+        logger.info('[billing.webhook] unhandled event type', { type: event.type, id: event.id });
         break;
     }
     return res.status(200).json({ received: true });

--- a/modules/billing/models/billing.processedStripeEvent.model.mongoose.js
+++ b/modules/billing/models/billing.processedStripeEvent.model.mongoose.js
@@ -80,7 +80,7 @@ ProcessedStripeEventMongoose.index(
   { processedAt: 1 },
   {
     expireAfterSeconds: 30 * 24 * 60 * 60,
-    partialFilterExpression: { deadLetter: { $ne: true } },
+    partialFilterExpression: { deadLetter: { $eq: false } },
   },
 );
 

--- a/modules/billing/models/billing.processedStripeEvent.model.mongoose.js
+++ b/modules/billing/models/billing.processedStripeEvent.model.mongoose.js
@@ -68,9 +68,21 @@ const ProcessedStripeEventMongoose = new Schema(
 );
 
 /**
- * TTL index: automatically remove documents 30 days after processedAt
+ * TTL index: automatically remove documents 30 days after processedAt.
+ *
+ * Excludes dead-letter documents via partial filter: dead-lettered events are
+ * permanent rejections (Stripe was told to stop retrying via 200 response) and
+ * must NEVER be purged. If purged, a manual replay from the Stripe dashboard
+ * after 30 days would re-process the event as if new — causing potential
+ * double-credit on extras packs or double subscription resets.
  */
-ProcessedStripeEventMongoose.index({ processedAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60 });
+ProcessedStripeEventMongoose.index(
+  { processedAt: 1 },
+  {
+    expireAfterSeconds: 30 * 24 * 60 * 60,
+    partialFilterExpression: { deadLetter: { $ne: true } },
+  },
+);
 
 /**
  * Returns the hex string representation of the document ObjectId.

--- a/modules/billing/models/billing.subscription.model.mongoose.js
+++ b/modules/billing/models/billing.subscription.model.mongoose.js
@@ -104,6 +104,25 @@ const SubscriptionMongoose = new Schema(
       type: String,
       default: null,
     },
+
+    // ── Admin override audit trail ───────────────────────────────────────────
+    /**
+     * Timestamp of the last admin-initiated plan change (via adminUpdatePlanOnly).
+     * Distinct from updatedAt (touched by every webhook). Used by audit + ops UI to
+     * surface when a subscription's plan was overridden manually.
+     */
+    adminUpdatedAt: {
+      type: Date,
+      default: null,
+    },
+    /**
+     * ObjectId of the admin user who triggered the last plan override.
+     */
+    adminUpdatedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/modules/billing/models/billing.subscription.model.mongoose.js
+++ b/modules/billing/models/billing.subscription.model.mongoose.js
@@ -72,24 +72,6 @@ const SubscriptionMongoose = new Schema(
       type: Date,
       default: null,
     },
-    /**
-     * Stripe event.created timestamp (Unix seconds) of the last processed subscription event.
-     * Used to guard webhook handlers against out-of-order delivery — older events are skipped.
-     */
-    stripeEventCreatedAt: {
-      type: Number,
-      default: null,
-    },
-    /**
-     * Stripe event.id of the last processed subscription event.
-     * Tiebreaker for same-second events (lex string ordering on evt_ IDs).
-     * @deprecated use lastSubscriptionEventCreatedAt / lastInvoiceEventCreatedAt per-family fields.
-     */
-    stripeEventId: {
-      type: String,
-      default: null,
-    },
-
     // ── Per-family event ordering guards ─────────────────────────────────────
     // Separate trackers for 'subscription' vs 'invoice' event families prevent
     // same-second cross-family deliveries from cancelling each other's state.

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -29,6 +29,9 @@ const baseShape = {
   lastSubscriptionEventId: z.string().nullable().optional(),
   lastInvoiceEventCreatedAt: z.number().int().nullable().optional(),
   lastInvoiceEventId: z.string().nullable().optional(),
+  // Admin override audit trail
+  adminUpdatedAt: z.coerce.date().nullable().optional(),
+  adminUpdatedBy: z.string().regex(/^[a-f0-9]{24}$/i).nullable().optional(),
 };
 
 const Subscription = z.object({
@@ -99,9 +102,8 @@ const AdminRefundRequest = z
 
 const AdminBumpPlanRequest = z
   .object({
-    planId: z.string().trim().min(1, 'planId is required'),
-    meterQuota: z.number().int().nonnegative(),
-    ratios: z.record(z.string(), z.number().nonnegative()).optional(),
+    orgId: z.string().regex(/^[a-f0-9]{24}$/i, 'orgId must be a valid ObjectId'),
+    planId: z.enum(config.billing.plans),
   })
   .strict();
 

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -31,7 +31,7 @@ const baseShape = {
   lastInvoiceEventId: z.string().nullable().optional(),
   // Admin override audit trail
   adminUpdatedAt: z.coerce.date().nullable().optional(),
-  adminUpdatedBy: z.string().regex(/^[a-f0-9]{24}$/i).nullable().optional(),
+  adminUpdatedBy: z.string().regex(objectIdRegex).nullable().optional(),
 };
 
 const Subscription = z.object({

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -24,8 +24,6 @@ const baseShape = {
   currentPeriodStart: z.coerce.date().nullable().optional(),
   pastDueSince: z.coerce.date().nullable().optional(),
   lastResetAt: z.coerce.date().nullable().optional(),
-  stripeEventCreatedAt: z.number().int().nullable().optional(),
-  stripeEventId: z.string().nullable().optional(),
   // Per-family event ordering guards
   lastSubscriptionEventCreatedAt: z.number().int().nullable().optional(),
   lastSubscriptionEventId: z.string().nullable().optional(),

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -271,6 +271,41 @@ const updateIfEventNewer = (id, eventCreatedAt, eventId, fields, family = 'subsc
     .exec();
 };
 
+/**
+ * @function adminUpdatePlanOnly
+ * @description Restricted admin update — sets ONLY `plan` and `adminUpdatedAt`. Never touches
+ *              `status`, `stripeCustomerId`, `stripeSubscriptionId`, `currentPeriodStart`, or
+ *              the per-family event-ordering markers. Webhook handlers retain exclusive write
+ *              authority on those fields via `updateIfEventNewer`.
+ *
+ *              Why this restriction matters: a free `update()` call with `{ plan, status }` from
+ *              an admin path would overwrite Stripe-driven status (active/past_due/etc.) with
+ *              whatever the admin sent, breaking dunning + access control. Splitting the surface
+ *              forces admin overrides to plan-only territory.
+ *
+ * @param {string} id - Subscription ObjectId (string).
+ * @param {string} planId - The new plan identifier (must be in config.billing.plans enum).
+ * @param {string} adminUserId - The admin user ObjectId (string) who triggered the bump (for audit).
+ * @returns {Promise<Object|null>} Updated subscription doc, or null if id is invalid.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const adminUpdatePlanOnly = (id, planId, adminUserId) => {
+  if (!id || !mongoose.Types.ObjectId.isValid(id)) return null;
+  return Subscription.findByIdAndUpdate(
+    id,
+    {
+      $set: {
+        plan: planId,
+        adminUpdatedAt: new Date(),
+        adminUpdatedBy: adminUserId,
+      },
+    },
+    { returnDocument: 'after', runValidators: true },
+  )
+    .populate(defaultPopulate)
+    .exec();
+};
+
 export default {
   list,
   create,
@@ -286,4 +321,5 @@ export default {
   findStaleDunning,
   markUnpaid,
   updateIfEventNewer,
+  adminUpdatePlanOnly,
 };

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -291,13 +291,17 @@ const updateIfEventNewer = (id, eventCreatedAt, eventId, fields, family = 'subsc
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const adminUpdatePlanOnly = (id, planId, adminUserId) => {
   if (!id || !mongoose.Types.ObjectId.isValid(id)) return null;
+  // Validate adminUserId before persisting to adminUpdatedBy (ObjectId field).
+  // An empty string or non-ObjectId value triggers a Mongoose CastError at save time.
+  const safeAdminUserId =
+    adminUserId && mongoose.Types.ObjectId.isValid(adminUserId) ? adminUserId : null;
   return Subscription.findByIdAndUpdate(
     id,
     {
       $set: {
         plan: planId,
         adminUpdatedAt: new Date(),
-        adminUpdatedBy: adminUserId,
+        adminUpdatedBy: safeAdminUserId,
       },
     },
     { returnDocument: 'after', runValidators: true },

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -222,8 +222,6 @@ const markUnpaid = (id, threshold) => {
  *              The `family` parameter scopes the event-ordering guard to either the
  *              'subscription' family (customer.subscription.*) or the 'invoice' family
  *              (invoice.*).  Same-second cross-family deliveries no longer cancel each other.
- *              Falls back to legacy stripeEventCreatedAt/stripeEventId for back-compat when
- *              per-family fields are not yet populated (gradual migration — no down-time).
  *
  *              Returns null when the guard prevents the write (stale event).
  * @param {string} id - The subscription ObjectId (string).
@@ -262,9 +260,9 @@ const updateIfEventNewer = (id, eventCreatedAt, eventId, fields, family = 'subsc
         ...fields,
         [createdAtField]: eventCreatedAt,
         [eventIdField]: eventId,
-        // Keep legacy fields in sync for back-compat with existing queries / reports
-        stripeEventCreatedAt: eventCreatedAt,
-        stripeEventId: eventId,
+        // Legacy fields stripeEventCreatedAt/stripeEventId are no longer written.
+        // The migration in trawl_node $unset them post-deploy so docs converge to
+        // per-family markers only. Reading the legacy fields anywhere is dead surface.
       },
     },
     { returnDocument: 'after', runValidators: true },

--- a/modules/billing/routes/billing.admin.routes.js
+++ b/modules/billing/routes/billing.admin.routes.js
@@ -6,7 +6,7 @@ import passport from 'passport';
 import policy from '../../../lib/middlewares/policy.js';
 import model from '../../../lib/middlewares/model.js';
 import billingAdmin from '../controllers/billing.admin.controller.js';
-import { AdminRefundRequest } from '../models/billing.subscription.schema.js';
+import { AdminRefundRequest, AdminBumpPlanRequest } from '../models/billing.subscription.schema.js';
 
 /**
  * Routes
@@ -18,4 +18,9 @@ export default (app) => {
     .route('/api/admin/billing/refund')
     .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
     .post(model.isValid(AdminRefundRequest), billingAdmin.adminRefundCharge);
+
+  app
+    .route('/api/admin/billing/plans/bump')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .patch(model.isValid(AdminBumpPlanRequest), billingAdmin.adminBumpPlan);
 };

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -188,8 +188,8 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
   // A static `sub_checkout_${orgId}_${priceId}` key locks the user into a
   // single session for 24h: if they abandon the first attempt, retrying within
   // the day yields the same expired session URL, silently killing conversion.
-  // Same-tab double-clicks are prevented at the route level by the active-
-  // subscription guard above.
+  // Same-tab double-clicks are prevented in this function by the active-
+  // subscription guard above (both the DB check and the live Stripe lookup).
   const session = await stripe.checkout.sessions.create(checkoutParams);
 
   return session.url;

--- a/modules/billing/services/billing.service.js
+++ b/modules/billing/services/billing.service.js
@@ -184,10 +184,13 @@ const createCheckout = async (organization, priceId, successUrl, cancelUrl) => {
     checkoutParams.automatic_tax = { enabled: true };
     checkoutParams.customer_update = { address: 'auto', name: 'auto' };
   }
-  const session = await stripe.checkout.sessions.create(
-    checkoutParams,
-    { idempotencyKey: `sub_checkout_${String(organization._id)}_${priceId}` },
-  );
+  // No Stripe idempotency key here. Checkout sessions are ephemeral (24h TTL).
+  // A static `sub_checkout_${orgId}_${priceId}` key locks the user into a
+  // single session for 24h: if they abandon the first attempt, retrying within
+  // the day yields the same expired session URL, silently killing conversion.
+  // Same-tab double-clicks are prevented at the route level by the active-
+  // subscription guard above.
+  const session = await stripe.checkout.sessions.create(checkoutParams);
 
   return session.url;
 };

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -192,18 +192,32 @@ const handleCheckoutCompleted = async (session, event) => {
   }
 
   // Fetch real status from Stripe — never assume 'active' (could be 'trialing', 'incomplete', etc.)
-  let realStatus = 'active';
+  // On retrieval failure we abort: persisting 'active' on a failed fetch would silently
+  // misclassify trialing/incomplete subscriptions and bypass dunning. The next webhook
+  // (subscription.updated or invoice.payment_failed) will reconcile the correct status.
   const stripe = getStripe();
-  if (stripe) {
-    try {
-      const sub = await stripe.subscriptions.retrieve(stripeSubscriptionId);
-      realStatus = sub?.status ?? 'active';
-    } catch (err) {
-      logger.error('[billing.webhook] checkout.session.completed — subscription retrieve failed, falling back to active', {
+  if (!stripe) {
+    logger.error('[billing.webhook] checkout.session.completed — Stripe not configured, aborting', {
+      stripeSubscriptionId,
+    });
+    return;
+  }
+  let realStatus;
+  try {
+    const sub = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+    realStatus = sub?.status;
+    if (!realStatus) {
+      logger.error('[billing.webhook] checkout.session.completed — subscription has no status, aborting', {
         stripeSubscriptionId,
-        error: err?.message ?? String(err),
       });
+      return;
     }
+  } catch (err) {
+    logger.error('[billing.webhook] checkout.session.completed — subscription retrieve failed, aborting to avoid stale active assumption', {
+      stripeSubscriptionId,
+      error: err?.message ?? String(err),
+    });
+    return;
   }
 
   const existing = await SubscriptionRepository.findByOrganization(organizationId);
@@ -960,28 +974,64 @@ const handleChargeDisputeFundsWithdrawn = async (dispute, event) => {
  * @description Handle customer.subscription.created event — defensive upsert.
  *              In practice arrives just after checkout.session.completed which already
  *              creates the Subscription doc. This handler is a safety net + handles
- *              edge cases (subscription created via Stripe Dashboard/API outside checkout flow).
- *              Idempotent via updateIfEventNewer.
+ *              edge cases (subscription created via Stripe Dashboard/API outside checkout flow
+ *              (e.g. Payment Links, Stripe Dashboard manual subscriptions)).
+ *
+ *              When a DB doc already exists (normal checkout flow): uses updateIfEventNewer guard.
+ *              When no DB doc exists (Dashboard/Payment Link creation): resolves the organization
+ *              via stripeCustomerId and creates the subscription row so these edge-case
+ *              subscriptions are not silently dropped.
+ *
+ *              Idempotent via updateIfEventNewer (existing) or event marker seeding (new row).
  * @param {Object} subscription - Stripe subscription object
  * @param {Object} event - Full Stripe event for event-ordering guard
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleSubscriptionCreated = async (subscription, event) => {
-  const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
-  if (!existing) {
-    // Subscription not yet in DB (race with checkout.session.completed or external creation).
-    // Log and skip — checkout handler or next subscription.updated will reconcile.
-    logger.info('[billing.webhook] subscription.created arrived but DB doc not found yet — will reconcile via next event', {
-      stripeSubscriptionId: subscription.id,
-      eventId: event?.id,
-    });
-    return;
-  }
-
   const newPlan = resolvePlan(subscription);
   const rawPeriodStart = subscription.items?.data?.[0]?.current_period_start ?? subscription.current_period_start;
   const newPeriodStart = rawPeriodStart ? new Date(rawPeriodStart * 1000) : undefined;
+
+  const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
+  if (!existing) {
+    // No doc found via stripeSubscriptionId — could be a race with checkout.session.completed
+    // or a subscription created outside the checkout flow (Stripe Dashboard / Payment Links).
+    // Try to resolve the organization via stripeCustomerId and create the row.
+    const orgSub = subscription.customer
+      ? await SubscriptionRepository.findByStripeCustomerId(subscription.customer)
+      : null;
+
+    if (!orgSub) {
+      // Cannot resolve org — truly external subscription with no prior customer mapping.
+      // Log and skip; a later subscription.updated will reconcile when org is known.
+      logger.info('[billing.webhook] subscription.created — cannot resolve org, will reconcile via next event', {
+        stripeSubscriptionId: subscription.id,
+        stripeCustomerId: subscription.customer,
+        eventId: event?.id,
+      });
+      return;
+    }
+
+    const organizationId = String(orgSub.organization?._id || orgSub.organization);
+    logger.info('[billing.webhook] subscription.created — creating DB row for Dashboard/Payment Link subscription', {
+      stripeSubscriptionId: subscription.id,
+      organizationId,
+      eventId: event?.id,
+    });
+    await SubscriptionRepository.create({
+      organization: organizationId,
+      stripeCustomerId: subscription.customer,
+      stripeSubscriptionId: subscription.id,
+      plan: newPlan,
+      status: subscription.status,
+      lastSubscriptionEventCreatedAt: event.created,
+      lastSubscriptionEventId: event.id,
+      ...(newPeriodStart ? { currentPeriodStart: newPeriodStart } : {}),
+    });
+    await syncOrganizationPlan(organizationId, newPlan);
+    return;
+  }
 
   const fields = {
     plan: newPlan,
@@ -1027,7 +1077,20 @@ const handleChargeDisputeFundsReinstated = async (dispute, event) => {
   const disputeId = dispute?.id;
   const amount = dispute?.amount ?? 0;
 
-  logger.error('[billing.webhook] dispute.funds_reinstated received — manual ledger compensation required', {
+  // Validate required fields before logging/emitting — missing identifiers make ops investigation harder.
+  if (!disputeId || !chargeId) {
+    logger.error('[billing.webhook] dispute.funds_reinstated missing required fields — skipping emit', {
+      disputeId,
+      chargeId,
+      amount,
+      eventId: event?.id,
+    });
+    return;
+  }
+
+  // funds_reinstated is good news (dispute was won back) — log as warn, not error.
+  // The alert is for ops to manually credit the ledger (auto-credit deferred to Phase 1).
+  logger.warn('[billing.webhook] dispute.funds_reinstated received — manual ledger credit required', {
     disputeId,
     chargeId,
     amount,

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -156,16 +156,22 @@ const handleCheckoutSessionCompleted = async (event) => {
   if (session.mode === 'payment') {
     return handleCheckoutPaymentCompleted(session);
   }
-  return handleCheckoutCompleted(session);
+  return handleCheckoutCompleted(session, event);
 };
 
 /**
- * @description Handle checkout.session.completed for mode='subscription' — create or update subscription
+ * @description Handle checkout.session.completed for mode='subscription' — create or update subscription.
+ *              - Fetches real subscription status from Stripe (avoids hardcoding 'active' which is wrong
+ *                for trialing subscriptions).
+ *              - Uses updateIfEventNewer for existing rows so concurrent webhooks/admin updates don't race.
+ *              - On race with subscription.updated arriving first, that handler returns early because
+ *                the row doesn't exist yet, then checkout creates the row with markers seeded.
  * @param {Object} session - Stripe checkout session object
+ * @param {Object} event - Full Stripe event (for event-ordering guard)
  * @returns {Promise<void>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const handleCheckoutCompleted = async (session) => {
+const handleCheckoutCompleted = async (session, event) => {
   const { customer: stripeCustomerId, subscription: stripeSubscriptionId, metadata } = session;
   let organizationId = metadata?.organizationId;
   const plan = validatePlan(metadata?.plan) || 'free';
@@ -177,23 +183,60 @@ const handleCheckoutCompleted = async (session) => {
   }
 
   if (!organizationId || !mongoose.Types.ObjectId.isValid(organizationId)) return;
+  if (!stripeSubscriptionId) {
+    logger.warn('[billing.webhook] checkout.session.completed in mode=subscription without subscription id', {
+      sessionId: session?.id,
+      organizationId,
+    });
+    return;
+  }
+
+  // Fetch real status from Stripe — never assume 'active' (could be 'trialing', 'incomplete', etc.)
+  let realStatus = 'active';
+  const stripe = getStripe();
+  if (stripe) {
+    try {
+      const sub = await stripe.subscriptions.retrieve(stripeSubscriptionId);
+      realStatus = sub?.status ?? 'active';
+    } catch (err) {
+      logger.error('[billing.webhook] checkout.session.completed — subscription retrieve failed, falling back to active', {
+        stripeSubscriptionId,
+        error: err?.message ?? String(err),
+      });
+    }
+  }
 
   const existing = await SubscriptionRepository.findByOrganization(organizationId);
   if (existing) {
-    await SubscriptionRepository.update({
-      _id: existing._id,
+    // Existing row → use event-ordering guard. Prevents a stale checkout event arriving after
+    // a fresh subscription.updated from overwriting state.
+    const fields = {
       stripeCustomerId,
       stripeSubscriptionId,
       plan,
-      status: 'active',
-    });
+      status: realStatus,
+    };
+    const updated = await SubscriptionRepository.updateIfEventNewer(
+      String(existing._id),
+      event.created,
+      event.id,
+      fields,
+      'subscription',
+    );
+    if (!updated) {
+      logger.info('[billing.webhook] skipped stale checkout.session.completed', { eventId: event.id });
+      return;
+    }
   } else {
+    // New row → create with markers seeded so subsequent stale events are rejected.
     await SubscriptionRepository.create({
       organization: organizationId,
       stripeCustomerId,
       stripeSubscriptionId,
       plan,
-      status: 'active',
+      status: realStatus,
+      lastSubscriptionEventCreatedAt: event.created,
+      lastSubscriptionEventId: event.id,
     });
   }
 

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -274,8 +274,14 @@ const handleSubscriptionUpdated = async (subscription, event) => {
     ? new Date(rawPeriodStart * 1000)
     : undefined;
 
+  // Stripe `incomplete_expired` is a status (not a separate event type) — it fires when
+  // the initial payment fails and the subscription is auto-cancelled by Stripe after ~24h.
+  // Treat it as a downgrade-to-free + signal the org so they can retry.
+  const isIncompleteExpired = subscription.status === 'incomplete_expired';
+  const effectivePlan = isIncompleteExpired ? 'free' : newPlan;
+
   const fields = {
-    plan: newPlan,
+    plan: effectivePlan,
     status: subscription.status,
   };
   if (newPeriodStart) fields.currentPeriodStart = newPeriodStart;
@@ -287,7 +293,23 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   }
 
   const organizationId = String(existing.organization?._id || existing.organization);
-  await syncOrganizationPlan(organizationId, newPlan);
+  await syncOrganizationPlan(organizationId, effectivePlan);
+
+  if (isIncompleteExpired) {
+    logger.info('[billing.webhook] subscription incomplete_expired — downgraded to free', {
+      organizationId,
+      stripeSubscriptionId: subscription.id,
+      eventId: event?.id,
+    });
+    try {
+      billingEvents.emit('billing.subscription.expired', { organizationId, stripeSubscriptionId: subscription.id });
+    } catch (evtErr) {
+      logger.error('[billing.webhook] billing.subscription.expired listener error (non-fatal)', {
+        error: evtErr?.message ?? String(evtErr),
+        stack: evtErr?.stack,
+      });
+    }
+  }
 
   // Hoist previousPeriodStart so it is accessible both in the plan-change block
   // (anchor computation) and in the standalone period-start-change block below.
@@ -891,11 +913,106 @@ const handleChargeDisputeFundsWithdrawn = async (dispute, event) => {
   }
 };
 
+/**
+ * @description Handle customer.subscription.created event — defensive upsert.
+ *              In practice arrives just after checkout.session.completed which already
+ *              creates the Subscription doc. This handler is a safety net + handles
+ *              edge cases (subscription created via Stripe Dashboard/API outside checkout flow).
+ *              Idempotent via updateIfEventNewer.
+ * @param {Object} subscription - Stripe subscription object
+ * @param {Object} event - Full Stripe event for event-ordering guard
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleSubscriptionCreated = async (subscription, event) => {
+  const existing = await SubscriptionRepository.findByStripeSubscriptionId(subscription.id);
+  if (!existing) {
+    // Subscription not yet in DB (race with checkout.session.completed or external creation).
+    // Log and skip — checkout handler or next subscription.updated will reconcile.
+    logger.info('[billing.webhook] subscription.created arrived but DB doc not found yet — will reconcile via next event', {
+      stripeSubscriptionId: subscription.id,
+      eventId: event?.id,
+    });
+    return;
+  }
+
+  const newPlan = resolvePlan(subscription);
+  const rawPeriodStart = subscription.items?.data?.[0]?.current_period_start ?? subscription.current_period_start;
+  const newPeriodStart = rawPeriodStart ? new Date(rawPeriodStart * 1000) : undefined;
+
+  const fields = {
+    plan: newPlan,
+    status: subscription.status,
+  };
+  if (newPeriodStart) fields.currentPeriodStart = newPeriodStart;
+
+  const updated = await SubscriptionRepository.updateIfEventNewer(
+    String(existing._id),
+    event.created,
+    event.id,
+    fields,
+    'subscription',
+  );
+  if (!updated) {
+    logger.info('[billing.webhook] skipped stale subscription.created event', { eventId: event.id });
+    return;
+  }
+
+  const organizationId = String(existing.organization?._id || existing.organization);
+  await syncOrganizationPlan(organizationId, newPlan);
+};
+
+/**
+ * @description Handle charge.dispute.funds_reinstated event — fires when a previously-lost
+ *              dispute is later resolved in the merchant's favor (appeal won, evidence accepted).
+ *              The funds were debited via handleChargeDisputeFundsWithdrawn earlier; this handler
+ *              MUST credit them back to keep the extras ledger accurate.
+ *
+ *              Implementation note: auto-compensation requires a `creditCompensation` repo
+ *              method that adds an idempotent ledger entry (refId `dispute_reinstate_${disputeId}`).
+ *              That method does not exist yet (Phase 1 admin toolkit will add it). Until then,
+ *              this handler logs + emits a critical alert for manual ops resolution via the
+ *              admin endpoint. The runbook documents the manual flow.
+ *
+ * @param {Object} dispute - Stripe dispute object
+ * @param {Object} event - Full Stripe event
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const handleChargeDisputeFundsReinstated = async (dispute, event) => {
+  const chargeId = dispute?.charge;
+  const disputeId = dispute?.id;
+  const amount = dispute?.amount ?? 0;
+
+  logger.error('[billing.webhook] dispute.funds_reinstated received — manual ledger compensation required', {
+    disputeId,
+    chargeId,
+    amount,
+    eventId: event?.id,
+    note: 'Auto-credit deferred to Phase 1 admin endpoint. Use /api/admin/billing/credit (TBD) once available, or directly add a ledger entry via DB.',
+  });
+
+  try {
+    billingEvents.emit('billing.dispute.reinstated', {
+      disputeId,
+      chargeId,
+      amount,
+      eventId: event?.id,
+    });
+  } catch (evtErr) {
+    logger.error('[billing.webhook] billing.dispute.reinstated listener error (non-fatal)', {
+      error: evtErr?.message ?? String(evtErr),
+      stack: evtErr?.stack,
+    });
+  }
+};
+
 export default {
   withIdempotency,
   handleCheckoutSessionCompleted,
   handleCheckoutCompleted,
   handleCheckoutPaymentCompleted,
+  handleSubscriptionCreated,
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
@@ -904,4 +1021,5 @@ export default {
   handleCustomerDeleted,
   handleChargeDisputeCreated,
   handleChargeDisputeFundsWithdrawn,
+  handleChargeDisputeFundsReinstated,
 };

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -20,7 +20,7 @@ describe('Billing admin integration tests:', () => {
     const routes = new Map();
     const app = {
       route: jest.fn((path) => {
-        const entry = { all: [], get: [], post: [] };
+        const entry = { all: [], get: [], post: [], patch: [] };
         routes.set(path, entry);
         const routeBuilder = {
           all: (...handlers) => {
@@ -33,6 +33,10 @@ describe('Billing admin integration tests:', () => {
           },
           post: (...handlers) => {
             entry.post.push(...handlers);
+            return routeBuilder;
+          },
+          patch: (...handlers) => {
+            entry.patch.push(...handlers);
             return routeBuilder;
           },
         };
@@ -334,8 +338,8 @@ describe('Billing admin integration tests:', () => {
     expect(res.status).toHaveBeenCalledWith(422);
   });
 
-  test('/api/admin/billing/plans/bump route no longer registered (endpoint removed)', async () => {
+  test('/api/admin/billing/plans/bump route is registered (PATCH for adminBumpPlan)', async () => {
     const routes = await buildRoutes();
-    expect(routes.has('/api/admin/billing/plans/bump')).toBe(false);
+    expect(routes.has('/api/admin/billing/plans/bump')).toBe(true);
   });
 });

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -160,6 +160,31 @@ describe('Billing admin integration tests:', () => {
       },
     }));
 
+    // Lazy-imported by adminBumpPlan — must be mocked before the handler runs.
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {
+        findByOrganization: jest.fn().mockResolvedValue({
+          _id: '607f1f77bcf86cd799439033',
+          plan: 'free',
+          organization: '507f1f77bcf86cd799439011',
+        }),
+        adminUpdatePlanOnly: jest.fn().mockResolvedValue({
+          _id: '607f1f77bcf86cd799439033',
+          plan: 'pro',
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+      default: {
+        setPlan: jest.fn().mockResolvedValue({}),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
     billingAdminRoutes = (await import('../routes/billing.admin.routes.js')).default;
 
     const { app, routes } = createRouteRegistry();
@@ -338,8 +363,78 @@ describe('Billing admin integration tests:', () => {
     expect(res.status).toHaveBeenCalledWith(422);
   });
 
-  test('/api/admin/billing/plans/bump route is registered (PATCH for adminBumpPlan)', async () => {
+  test('/api/admin/billing/plans/bump route is registered as PATCH with auth + validation middleware', async () => {
     const routes = await buildRoutes();
-    expect(routes.has('/api/admin/billing/plans/bump')).toBe(true);
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    // Route must exist and expose a PATCH handler array (not just be registered)
+    expect(bumpRoute).toBeDefined();
+    expect(bumpRoute.patch).toBeDefined();
+    expect(bumpRoute.patch.length).toBeGreaterThan(0);
+    // The .all chain should contain the JWT + policy guards (2 middleware functions)
+    expect(bumpRoute.all.length).toBe(2);
+  });
+
+  test('admin can PATCH /api/admin/billing/plans/bump with valid body and gets 200', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.patch],
+      {
+        method: 'PATCH',
+        headers: { 'x-role': 'admin' },
+        body: { orgId: '507f1f77bcf86cd799439011', planId: 'pro' },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('non-admin user gets 403 on bump endpoint', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.patch],
+      {
+        method: 'PATCH',
+        headers: { 'x-role': 'user' },
+        body: { orgId: '507f1f77bcf86cd799439011', planId: 'pro' },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('invalid body for bump returns 422 from schema validation', async () => {
+    const routes = await buildRoutes();
+    const bumpRoute = routes.get('/api/admin/billing/plans/bump');
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await runHandlers(
+      [...bumpRoute.all, ...bumpRoute.patch],
+      {
+        method: 'PATCH',
+        headers: { 'x-role': 'admin' },
+        // orgId missing, planId is not a valid enum value
+        body: { planId: 'not-a-plan' },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(422);
   });
 });

--- a/modules/billing/tests/billing.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.checkout.unit.tests.js
@@ -233,20 +233,19 @@ describe('Billing service unit tests:', () => {
 
       expect(url).toBe('https://checkout.stripe.com/session_123');
       expect(mockStripeInstance.customers.create).not.toHaveBeenCalled();
-      expect(mockStripeInstance.checkout.sessions.create).toHaveBeenCalledWith(
-        {
-          customer: 'cus_existing',
-          mode: 'subscription',
-          line_items: [{ price: 'price_starter_m', quantity: 1 }],
-          success_url: 'http://ok',
-          cancel_url: 'http://cancel',
-          metadata: {
-            organizationId: orgId,
-            plan: 'starter',
-          },
+      // No idempotencyKey on checkout sessions — they're ephemeral (24h TTL),
+      // a static key locks abandoned-then-retried users into expired sessions.
+      expect(mockStripeInstance.checkout.sessions.create).toHaveBeenCalledWith({
+        customer: 'cus_existing',
+        mode: 'subscription',
+        line_items: [{ price: 'price_starter_m', quantity: 1 }],
+        success_url: 'http://ok',
+        cancel_url: 'http://cancel',
+        metadata: {
+          organizationId: orgId,
+          plan: 'starter',
         },
-        { idempotencyKey: `sub_checkout_${orgId}_price_starter_m` },
-      );
+      });
     });
 
     test('should NOT include automatic_tax when config.stripe.automaticTax is false', async () => {

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -203,3 +203,125 @@ describe('Admin refund controller unit tests:', () => {
     expect(mockResponses.success).toHaveBeenCalled();
   });
 });
+
+describe('adminBumpPlan controller unit tests:', () => {
+  let adminBumpPlan;
+  let mockSubscriptionRepository;
+  let mockOrganizationRepository;
+  let mockLogger;
+  let mockResponses;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const subId = '607f1f77bcf86cd799439022';
+  const adminId = '707f1f77bcf86cd799439033';
+
+  const makeRes = () => {
+    const res = { status: jest.fn(), json: jest.fn() };
+    res.status.mockReturnValue(res);
+    return res;
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn().mockResolvedValue({ _id: subId, plan: 'free', organization: orgId }),
+      adminUpdatePlanOnly: jest.fn().mockResolvedValue({ _id: subId, plan: 'pro' }),
+    };
+
+    mockOrganizationRepository = {
+      setPlan: jest.fn().mockResolvedValue({}),
+    };
+
+    mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    mockResponses = {
+      success: jest.fn(() => jest.fn()),
+      error: jest.fn(() => jest.fn()),
+    };
+
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+
+    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+      default: mockOrganizationRepository,
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: mockLogger,
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: mockResponses,
+    }));
+
+    // Stripe not needed for adminBumpPlan but imported at module level
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: jest.fn(() => null) }));
+
+    const mod = await import('../controllers/billing.admin.controller.js');
+    adminBumpPlan = mod.default.adminBumpPlan;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns 422 when req.user._id is missing', async () => {
+    const req = { body: { orgId, planId: 'pro' }, user: {} };
+    const res = makeRes();
+
+    await adminBumpPlan(req, res);
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to bump plan');
+    expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
+  });
+
+  test('returns 404 when no subscription found for org', async () => {
+    mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+    const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
+    const res = makeRes();
+
+    await adminBumpPlan(req, res);
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 404, 'Not Found', 'Subscription not found for organization');
+    expect(mockSubscriptionRepository.adminUpdatePlanOnly).not.toHaveBeenCalled();
+  });
+
+  test('returns 200 on happy path', async () => {
+    const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
+    const res = makeRes();
+
+    await adminBumpPlan(req, res);
+
+    expect(mockSubscriptionRepository.adminUpdatePlanOnly).toHaveBeenCalledWith(subId, 'pro', adminId);
+    expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
+    expect(mockResponses.success).toHaveBeenCalledWith(res, 'subscription plan bumped');
+  });
+
+  test('returns 422 on Mongoose ValidationError', async () => {
+    const validationErr = new Error('plan is invalid');
+    validationErr.name = 'ValidationError';
+    mockSubscriptionRepository.adminUpdatePlanOnly.mockRejectedValue(validationErr);
+    const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
+    const res = makeRes();
+
+    await adminBumpPlan(req, res);
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to bump plan');
+  });
+
+  test('returns 500 on unexpected error', async () => {
+    mockSubscriptionRepository.adminUpdatePlanOnly.mockRejectedValue(new Error('db timeout'));
+    const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
+    const res = makeRes();
+
+    await adminBumpPlan(req, res);
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 500, 'Internal Server Error', 'Failed to bump plan');
+  });
+});

--- a/modules/billing/tests/billing.service.unit.tests.js
+++ b/modules/billing/tests/billing.service.unit.tests.js
@@ -71,6 +71,16 @@ describe('Billing webhook service unit tests:', () => {
         Types: { ObjectId: { isValid: jest.fn().mockReturnValue(true) } },
       },
     }));
+
+    // Mock Stripe so handleCheckoutCompleted can call stripe.subscriptions.retrieve.
+    // Returns 'active' by default; override per-test as needed.
+    jest.unstable_mockModule('../lib/stripe.js', () => ({
+      default: jest.fn(() => ({
+        subscriptions: {
+          retrieve: jest.fn().mockResolvedValue({ status: 'active' }),
+        },
+      })),
+    }));
   });
 
   afterEach(() => {
@@ -103,7 +113,7 @@ describe('Billing webhook service unit tests:', () => {
           stripeCustomerId: 'cus_123',
           stripeSubscriptionId: 'sub_456',
           plan: 'pro',
-          // Status fetched from Stripe; falls back to 'active' when getStripe() returns null in tests.
+          // Status fetched from Stripe — mocked to 'active' in this test suite's beforeEach.
           status: 'active',
           lastSubscriptionEventCreatedAt: 1700000050,
           lastSubscriptionEventId: 'evt_checkout_1',

--- a/modules/billing/tests/billing.service.unit.tests.js
+++ b/modules/billing/tests/billing.service.unit.tests.js
@@ -78,6 +78,9 @@ describe('Billing webhook service unit tests:', () => {
   });
 
   describe('handleCheckoutCompleted', () => {
+    // Synthetic event passed to handleCheckoutCompleted (second arg) for event-ordering markers.
+    const makeCheckoutEvent = () => ({ id: 'evt_checkout_1', created: 1700000050, data: {} });
+
     test('should create new subscription when none exists', async () => {
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
       mockSubscriptionRepository.create.mockResolvedValue({});
@@ -85,42 +88,58 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'pro' },
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        makeCheckoutEvent(),
+      );
 
-      expect(mockSubscriptionRepository.create).toHaveBeenCalledWith({
-        organization: orgId,
-        stripeCustomerId: 'cus_123',
-        stripeSubscriptionId: 'sub_456',
-        plan: 'pro',
-        status: 'active',
-      });
+      expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: orgId,
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_456',
+          plan: 'pro',
+          // Status fetched from Stripe; falls back to 'active' when getStripe() returns null in tests.
+          status: 'active',
+          lastSubscriptionEventCreatedAt: 1700000050,
+          lastSubscriptionEventId: 'evt_checkout_1',
+        }),
+      );
       expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
     });
 
-    test('should update existing subscription on checkout', async () => {
+    test('should update existing subscription on checkout via updateIfEventNewer', async () => {
       mockSubscriptionRepository.findByOrganization.mockResolvedValue({ _id: subId });
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'starter' },
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'starter' },
+        },
+        makeCheckoutEvent(),
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith({
-        _id: subId,
-        stripeCustomerId: 'cus_123',
-        stripeSubscriptionId: 'sub_456',
-        plan: 'starter',
-        status: 'active',
-      });
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000050,
+        'evt_checkout_1',
+        expect.objectContaining({
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_456',
+          plan: 'starter',
+          status: 'active',
+        }),
+        'subscription',
+      );
     });
 
     test('should default plan to free when metadata plan is missing', async () => {
@@ -130,11 +149,14 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId },
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId },
+        },
+        makeCheckoutEvent(),
+      );
 
       expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({ plan: 'free' }),
@@ -147,11 +169,14 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_unknown',
-        subscription: 'sub_456',
-        metadata: {},
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_unknown',
+          subscription: 'sub_456',
+          metadata: {},
+        },
+        makeCheckoutEvent(),
+      );
 
       expect(mockSubscriptionRepository.findByStripeCustomerId).toHaveBeenCalledWith('cus_unknown');
       expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
@@ -165,11 +190,14 @@ describe('Billing webhook service unit tests:', () => {
       const mod = await import('../services/billing.webhook.service.js');
       BillingWebhookService = mod.default;
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: {},
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: {},
+        },
+        makeCheckoutEvent(),
+      );
 
       expect(mockSubscriptionRepository.findByStripeCustomerId).toHaveBeenCalledWith('cus_123');
       expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(

--- a/modules/billing/tests/billing.subscription.repository.per-family.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.per-family.unit.tests.js
@@ -58,9 +58,9 @@ describe('updateIfEventNewer — per-family guard:', () => {
     // Write targets the subscription-family field
     expect(update.$set.lastSubscriptionEventCreatedAt).toBe(100);
     expect(update.$set.lastSubscriptionEventId).toBe('evt_1');
-    // Legacy fields also updated for back-compat
-    expect(update.$set.stripeEventCreatedAt).toBe(100);
-    expect(update.$set.stripeEventId).toBe('evt_1');
+    // Legacy fields no longer written — migration $unset them
+    expect(update.$set.stripeEventCreatedAt).toBeUndefined();
+    expect(update.$set.stripeEventId).toBeUndefined();
     // Invoice-family fields not touched
     expect(update.$set.lastInvoiceEventCreatedAt).toBeUndefined();
   });

--- a/modules/billing/tests/billing.subscription.repository.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.unit.tests.js
@@ -321,4 +321,76 @@ describe('BillingSubscriptionRepository unit tests:', () => {
       expect(result).toEqual({ organization: orgId, lastResetAt: date });
     });
   });
+
+  // ── adminUpdatePlanOnly ────────────────────────────────────────────────────
+
+  describe('adminUpdatePlanOnly', () => {
+    const adminId = '707f1f77bcf86cd799439044';
+
+    test('updates plan + adminUpdatedAt + adminUpdatedBy when ids are valid', async () => {
+      const updated = { _id: subId, plan: 'pro', adminUpdatedBy: adminId };
+      const execMock = jest.fn().mockResolvedValue(updated);
+      const populateMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findByIdAndUpdate.mockReturnValue({ populate: populateMock });
+
+      const result = await BillingSubscriptionRepository.adminUpdatePlanOnly(subId, 'pro', adminId);
+
+      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        subId,
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            plan: 'pro',
+            adminUpdatedBy: adminId,
+          }),
+        }),
+        { returnDocument: 'after', runValidators: true },
+      );
+      expect(result).toEqual(updated);
+    });
+
+    test('returns null without querying when subscription id is invalid', async () => {
+      const result = await BillingSubscriptionRepository.adminUpdatePlanOnly('not-valid', 'pro', adminId);
+      expect(result).toBeNull();
+      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('returns null without querying when subscription id is falsy', async () => {
+      const result = await BillingSubscriptionRepository.adminUpdatePlanOnly(null, 'pro', adminId);
+      expect(result).toBeNull();
+      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('sets adminUpdatedBy to null when adminUserId is an invalid ObjectId', async () => {
+      const execMock = jest.fn().mockResolvedValue({ _id: subId, plan: 'pro', adminUpdatedBy: null });
+      const populateMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findByIdAndUpdate.mockReturnValue({ populate: populateMock });
+
+      await BillingSubscriptionRepository.adminUpdatePlanOnly(subId, 'pro', 'not-an-objectid');
+
+      const callArgs = mockModel.findByIdAndUpdate.mock.calls[0];
+      expect(callArgs[1].$set.adminUpdatedBy).toBeNull();
+    });
+
+    test('sets adminUpdatedBy to null when adminUserId is an empty string', async () => {
+      const execMock = jest.fn().mockResolvedValue({ _id: subId, plan: 'pro', adminUpdatedBy: null });
+      const populateMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findByIdAndUpdate.mockReturnValue({ populate: populateMock });
+
+      await BillingSubscriptionRepository.adminUpdatePlanOnly(subId, 'pro', '');
+
+      const callArgs = mockModel.findByIdAndUpdate.mock.calls[0];
+      expect(callArgs[1].$set.adminUpdatedBy).toBeNull();
+    });
+
+    test('sets adminUpdatedAt to a Date', async () => {
+      const execMock = jest.fn().mockResolvedValue({ _id: subId, plan: 'pro' });
+      const populateMock = jest.fn().mockReturnValue({ exec: execMock });
+      mockModel.findByIdAndUpdate.mockReturnValue({ populate: populateMock });
+
+      await BillingSubscriptionRepository.adminUpdatePlanOnly(subId, 'pro', adminId);
+
+      const callArgs = mockModel.findByIdAndUpdate.mock.calls[0];
+      expect(callArgs[1].$set.adminUpdatedAt).toBeInstanceOf(Date);
+    });
+  });
 });

--- a/modules/billing/tests/billing.subscription.repository.unit.tests.js
+++ b/modules/billing/tests/billing.subscription.repository.unit.tests.js
@@ -156,7 +156,7 @@ describe('BillingSubscriptionRepository unit tests:', () => {
   // ── updateIfEventNewer ────────────────────────────────────────────────────
 
   describe('updateIfEventNewer', () => {
-    test('updates when stripeEventCreatedAt is null (first event)', async () => {
+    test('updates when lastSubscriptionEventCreatedAt is null (first event)', async () => {
       const updated = { _id: subId, status: 'canceled', lastSubscriptionEventCreatedAt: 1000, lastSubscriptionEventId: 'evt_abc' };
       const populateMock = jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(updated) });
       mockModel.findOneAndUpdate.mockReturnValue({ populate: populateMock });
@@ -186,9 +186,6 @@ describe('BillingSubscriptionRepository unit tests:', () => {
             status: 'canceled',
             lastSubscriptionEventCreatedAt: 1000,
             lastSubscriptionEventId: 'evt_abc',
-            // Legacy fields kept in sync for back-compat
-            stripeEventCreatedAt: 1000,
-            stripeEventId: 'evt_abc',
           },
         },
         { returnDocument: 'after', runValidators: true },

--- a/modules/billing/tests/billing.unit.tests.js
+++ b/modules/billing/tests/billing.unit.tests.js
@@ -240,18 +240,18 @@ describe('Billing unit tests:', () => {
       expect(result.data.planVersion).toBe('v3');
     });
 
-    test('should accept stripeEventId as optional string', () => {
-      subscription.stripeEventId = 'evt_1AbCdEf';
+    test('should accept lastSubscriptionEventId as optional string', () => {
+      subscription.lastSubscriptionEventId = 'evt_1AbCdEf';
       const result = schema.Subscription.safeParse(subscription);
       expect(result.error).toBeFalsy();
-      expect(result.data.stripeEventId).toBe('evt_1AbCdEf');
+      expect(result.data.lastSubscriptionEventId).toBe('evt_1AbCdEf');
     });
 
-    test('should accept stripeEventId as null', () => {
-      subscription.stripeEventId = null;
+    test('should accept lastSubscriptionEventId as null', () => {
+      subscription.lastSubscriptionEventId = null;
       const result = schema.Subscription.safeParse(subscription);
       expect(result.error).toBeFalsy();
-      expect(result.data.stripeEventId).toBeNull();
+      expect(result.data.lastSubscriptionEventId).toBeNull();
     });
   });
 

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -422,6 +422,53 @@ describe('Billing webhook checkout unit tests:', () => {
       expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
     });
 
+    test('should abort without querying when Stripe is not configured (getStripe returns null)', async () => {
+      // The billing.webhook.checkout.unit.tests.js mocks stripe.js at module level.
+      // To test the getStripe()=null branch, we reload the module with a null-returning mock.
+      jest.resetModules();
+      jest.unstable_mockModule('../lib/stripe.js', () => ({ default: jest.fn(() => null) }));
+      jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+        default: mockSubscriptionRepository,
+      }));
+      jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+        default: { wasProcessed: jest.fn().mockResolvedValue(false), tryRecord: jest.fn().mockResolvedValue({ recorded: true }) },
+      }));
+      jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+        default: mockOrganizationRepository,
+      }));
+      jest.unstable_mockModule('../services/billing.extra.service.js', () => ({
+        default: { creditPack: jest.fn(), refundPartial: jest.fn() },
+      }));
+      jest.unstable_mockModule('../services/billing.reset.service.js', () => ({
+        default: { resetWeek: jest.fn() },
+      }));
+      jest.unstable_mockModule('../lib/events.js', () => ({ default: { emit: jest.fn() } }));
+      jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+        default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+      }));
+      jest.unstable_mockModule('../../../config/index.js', () => ({
+        default: { billing: { plans: ['free', 'starter', 'pro', 'enterprise'] } },
+      }));
+      jest.unstable_mockModule('mongoose', () => ({
+        default: { Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } }, model: () => ({}) },
+      }));
+
+      const mod2 = await import('../services/billing.webhook.service.js');
+      const svc2 = mod2.default;
+
+      await svc2.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
+    });
+
     test('should skip org sync when checkout event is stale (updateIfEventNewer returns null)', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -107,9 +107,11 @@ describe('Billing webhook checkout unit tests:', () => {
     test('mode=subscription routes to handleCheckoutCompleted (subscription update)', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
       await BillingWebhookService.handleCheckoutSessionCompleted({
+        id: 'evt_co_1',
+        created: 1700000010,
         data: {
           object: {
             id: stripeSessionId,
@@ -121,8 +123,12 @@ describe('Billing webhook checkout unit tests:', () => {
         },
       });
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000010,
+        'evt_co_1',
         expect.objectContaining({ plan: 'pro', status: 'active' }),
+        'subscription',
       );
       expect(mockExtraService.creditPack).not.toHaveBeenCalled();
     });
@@ -292,37 +298,51 @@ describe('Billing webhook checkout unit tests:', () => {
   });
 
   describe('handleCheckoutCompleted (mode=subscription)', () => {
-    test('should update existing subscription', async () => {
+    const checkoutEvent = { id: 'evt_co_2', created: 1700000020, data: {} };
+
+    test('should update existing subscription via updateIfEventNewer', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'pro' },
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, plan: 'pro', status: 'active' }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000020,
+        'evt_co_2',
+        expect.objectContaining({ plan: 'pro', status: 'active' }),
+        'subscription',
       );
     });
 
-    test('should create subscription when none exists', async () => {
+    test('should create subscription with seeded markers when none exists', async () => {
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
       mockSubscriptionRepository.create.mockResolvedValue({});
 
-      await BillingWebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'starter' },
-      });
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'starter' },
+        },
+        checkoutEvent,
+      );
 
       expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           organization: orgId,
           plan: 'starter',
           status: 'active',
+          lastSubscriptionEventCreatedAt: 1700000020,
+          lastSubscriptionEventId: 'evt_co_2',
         }),
       );
     });

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -45,6 +45,10 @@ describe('Billing webhook checkout unit tests:', () => {
       paymentIntents: {
         update: jest.fn().mockResolvedValue({}),
       },
+      subscriptions: {
+        // Default: return 'active' status so handleCheckoutCompleted proceeds normally in tests.
+        retrieve: jest.fn().mockResolvedValue({ status: 'active' }),
+      },
     };
 
     jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
@@ -345,6 +349,63 @@ describe('Billing webhook checkout unit tests:', () => {
           lastSubscriptionEventId: 'evt_co_2',
         }),
       );
+    });
+
+    test('should persist real status from Stripe (trialing, not active)', async () => {
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({ status: 'trialing' });
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
+
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000020,
+        'evt_co_2',
+        expect.objectContaining({ status: 'trialing' }),
+        'subscription',
+      );
+    });
+
+    test('should abort without persisting when stripe.subscriptions.retrieve throws', async () => {
+      mockStripeInstance.subscriptions.retrieve.mockRejectedValue(new Error('Stripe API error'));
+
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      // Should not persist anything — aborting to avoid stale 'active' assumption
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
+    });
+
+    test('should abort without persisting when stripe returns null status', async () => {
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({ status: null });
+
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -407,5 +407,37 @@ describe('Billing webhook checkout unit tests:', () => {
       expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
       expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
     });
+
+    test('should return early without querying when stripeSubscriptionId is missing', async () => {
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          // subscription omitted — e.g. mode=subscription but sub not created yet
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
+    });
+
+    test('should skip org sync when checkout event is stale (updateIfEventNewer returns null)', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+      await BillingWebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
+
+      // Event was stale — org plan should not be synced
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
   });
 });

--- a/modules/billing/tests/billing.webhook.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.integration.tests.js
@@ -84,32 +84,44 @@ describe('Billing webhook integration tests:', () => {
   });
 
   describe('handleCheckoutCompleted', () => {
-    test('should update existing subscription with valid metadata plan', async () => {
+    const checkoutEvent = { id: 'evt_int_co_1', created: 1700000030, data: {} };
+
+    test('should update existing subscription with valid metadata plan via updateIfEventNewer', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'pro' },
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'pro' },
+        },
+        checkoutEvent,
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: subId, plan: 'pro', status: 'active' }),
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000030,
+        'evt_int_co_1',
+        expect.objectContaining({ plan: 'pro', status: 'active' }),
+        'subscription',
       );
       expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
     });
 
-    test('should create subscription when none exists', async () => {
+    test('should create subscription when none exists with seeded markers', async () => {
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
       mockSubscriptionRepository.create.mockResolvedValue({});
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'starter' },
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'starter' },
+        },
+        checkoutEvent,
+      );
 
       expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -118,6 +130,8 @@ describe('Billing webhook integration tests:', () => {
           stripeSubscriptionId: 'sub_456',
           plan: 'starter',
           status: 'active',
+          lastSubscriptionEventCreatedAt: 1700000030,
+          lastSubscriptionEventId: 'evt_int_co_1',
         }),
       );
     });
@@ -125,32 +139,46 @@ describe('Billing webhook integration tests:', () => {
     test('should fall back to free when metadata plan is invalid (e.g. Stripe product ID)', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId, plan: 'prod_ABC123xyz' },
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId, plan: 'prod_ABC123xyz' },
+        },
+        checkoutEvent,
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000030,
+        'evt_int_co_1',
         expect.objectContaining({ plan: 'free' }),
+        'subscription',
       );
     });
 
     test('should fall back to free when metadata plan is missing', async () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { organizationId: orgId },
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { organizationId: orgId },
+        },
+        checkoutEvent,
+      );
 
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000030,
+        'evt_int_co_1',
         expect.objectContaining({ plan: 'free' }),
+        'subscription',
       );
     });
 
@@ -158,30 +186,40 @@ describe('Billing webhook integration tests:', () => {
       const existing = { _id: subId, organization: orgId };
       mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(existing);
       mockSubscriptionRepository.findByOrganization.mockResolvedValue(existing);
-      mockSubscriptionRepository.update.mockResolvedValue({});
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue({ _id: subId });
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: { plan: 'pro' },
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: { plan: 'pro' },
+        },
+        checkoutEvent,
+      );
 
       expect(mockSubscriptionRepository.findByStripeCustomerId).toHaveBeenCalledWith('cus_123');
-      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000030,
+        'evt_int_co_1',
         expect.objectContaining({ plan: 'pro', status: 'active' }),
+        'subscription',
       );
     });
 
     test('should return early when organizationId cannot be resolved', async () => {
       mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(null);
 
-      await WebhookService.handleCheckoutCompleted({
-        customer: 'cus_123',
-        subscription: 'sub_456',
-        metadata: {},
-      });
+      await WebhookService.handleCheckoutCompleted(
+        {
+          customer: 'cus_123',
+          subscription: 'sub_456',
+          metadata: {},
+        },
+        checkoutEvent,
+      );
 
-      expect(mockSubscriptionRepository.update).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.updateIfEventNewer).not.toHaveBeenCalled();
       expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
     });
   });
@@ -382,7 +420,7 @@ describe('Billing webhook integration tests:', () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
 
       // First call (t=10) succeeds
-      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce({ _id: subId, stripeEventCreatedAt: 10 });
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce({ _id: subId, lastSubscriptionEventCreatedAt: 10 });
       await WebhookService.handleSubscriptionUpdated(
         { id: 'sub_456', status: 'active', current_period_end: 9999999999, cancel_at_period_end: false, items: { data: [] } },
         { id: 'evt_1', created: 10, data: {} },
@@ -405,7 +443,7 @@ describe('Billing webhook integration tests:', () => {
       mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
 
       // First event at t=1000 succeeds
-      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce({ _id: subId, stripeEventCreatedAt: 1000, stripeEventId: 'evt_aaaa' });
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValueOnce({ _id: subId, lastSubscriptionEventCreatedAt: 1000, lastSubscriptionEventId: 'evt_aaaa' });
       await WebhookService.handleSubscriptionUpdated(
         { id: 'sub_456', status: 'active', current_period_end: 9999999999, cancel_at_period_end: false, items: { data: [] } },
         { id: 'evt_aaaa', created: 1000, data: {} },

--- a/modules/billing/tests/billing.webhook.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.integration.tests.js
@@ -75,6 +75,16 @@ describe('Billing webhook integration tests:', () => {
       default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
     }));
 
+    // Mock Stripe so handleCheckoutCompleted can call stripe.subscriptions.retrieve.
+    // Default: return 'active' so normal flow proceeds; override per-test as needed.
+    jest.unstable_mockModule('../lib/stripe.js', () => ({
+      default: jest.fn(() => ({
+        subscriptions: {
+          retrieve: jest.fn().mockResolvedValue({ status: 'active' }),
+        },
+      })),
+    }));
+
     const mod = await import('../services/billing.webhook.service.js');
     WebhookService = mod.default;
   });
@@ -411,6 +421,144 @@ describe('Billing webhook integration tests:', () => {
       await WebhookService.handleInvoicePaymentFailed({ subscription: 'sub_456' }, makeEvent({ created: 50 }));
 
       expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubscriptionCreated', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_created', created: 1700000050, data: {}, ...overrides });
+
+    test('should update existing subscription doc via updateIfEventNewer when found by stripeSubscriptionId', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+
+      await WebhookService.handleSubscriptionCreated(
+        {
+          id: 'sub_456',
+          customer: 'cus_123',
+          status: 'trialing',
+          items: { data: [{ current_period_start: 1700000000, price: { metadata: { planId: 'starter' } } }] },
+        },
+        makeEvent(),
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000050,
+        'evt_created',
+        expect.objectContaining({ plan: 'starter', status: 'trialing' }),
+        'subscription',
+      );
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'starter');
+    });
+
+    test('should skip org sync when event is stale', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
+
+      await WebhookService.handleSubscriptionCreated(
+        { id: 'sub_456', customer: 'cus_123', status: 'active', items: { data: [] } },
+        makeEvent({ created: 10 }),
+      );
+
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
+
+    test('should create DB row via stripeCustomerId fallback for Dashboard-created subscriptions', async () => {
+      const orgSub = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+      mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(orgSub);
+      mockSubscriptionRepository.create.mockResolvedValue({});
+
+      await WebhookService.handleSubscriptionCreated(
+        {
+          id: 'sub_dashboard_001',
+          customer: 'cus_123',
+          status: 'active',
+          items: { data: [{ current_period_start: 1700000000, price: { metadata: { planId: 'pro' } } }] },
+        },
+        makeEvent({ id: 'evt_dash_1', created: 1700000060 }),
+      );
+
+      expect(mockSubscriptionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: orgId,
+          stripeCustomerId: 'cus_123',
+          stripeSubscriptionId: 'sub_dashboard_001',
+          plan: 'pro',
+          status: 'active',
+          lastSubscriptionEventCreatedAt: 1700000060,
+          lastSubscriptionEventId: 'evt_dash_1',
+        }),
+      );
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
+    });
+
+    test('should log and skip when org cannot be resolved (no stripeCustomerId match)', async () => {
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+      mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(null);
+
+      await WebhookService.handleSubscriptionCreated(
+        { id: 'sub_external', customer: 'cus_unknown', status: 'active', items: { data: [] } },
+        makeEvent(),
+      );
+
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
+
+    test('should skip customer lookup when no customer field on subscription', async () => {
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+
+      await WebhookService.handleSubscriptionCreated(
+        { id: 'sub_nocust', status: 'active', items: { data: [] } },
+        makeEvent(),
+      );
+
+      expect(mockSubscriptionRepository.findByStripeCustomerId).not.toHaveBeenCalled();
+      expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleChargeDisputeFundsReinstated', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_reinstated', data: {}, ...overrides });
+
+    test('should emit billing.dispute.reinstated event on valid dispute', async () => {
+      const { default: billingEvents } = await import('../lib/events.js');
+
+      await WebhookService.handleChargeDisputeFundsReinstated(
+        { id: 'dp_123', charge: 'ch_456', amount: 5000 },
+        makeEvent(),
+      );
+
+      expect(billingEvents.emit).toHaveBeenCalledWith('billing.dispute.reinstated', {
+        disputeId: 'dp_123',
+        chargeId: 'ch_456',
+        amount: 5000,
+        eventId: 'evt_reinstated',
+      });
+    });
+
+    test('should skip emit when disputeId is missing', async () => {
+      const { default: billingEvents } = await import('../lib/events.js');
+
+      await WebhookService.handleChargeDisputeFundsReinstated(
+        { charge: 'ch_456', amount: 5000 },
+        makeEvent(),
+      );
+
+      expect(billingEvents.emit).not.toHaveBeenCalled();
+    });
+
+    test('should skip emit when chargeId is missing', async () => {
+      const { default: billingEvents } = await import('../lib/events.js');
+
+      await WebhookService.handleChargeDisputeFundsReinstated(
+        { id: 'dp_123', amount: 5000 },
+        makeEvent(),
+      );
+
+      expect(billingEvents.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/modules/billing/tests/billing.webhook.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.integration.tests.js
@@ -322,6 +322,48 @@ describe('Billing webhook integration tests:', () => {
     });
   });
 
+  describe('handleSubscriptionUpdated — incomplete_expired', () => {
+    const makeEvent = (overrides = {}) => ({ id: 'evt_ie', created: 1700000110, data: {}, ...overrides });
+
+    test('should downgrade plan to free and emit billing.subscription.expired on incomplete_expired', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      const { default: billingEvents } = await import('../lib/events.js');
+
+      await WebhookService.handleSubscriptionUpdated(
+        { id: 'sub_456', status: 'incomplete_expired', items: { data: [] } },
+        makeEvent(),
+      );
+
+      expect(mockSubscriptionRepository.updateIfEventNewer).toHaveBeenCalledWith(
+        subId,
+        1700000110,
+        'evt_ie',
+        expect.objectContaining({ plan: 'free', status: 'incomplete_expired' }),
+        'subscription',
+      );
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'free');
+      expect(billingEvents.emit).toHaveBeenCalledWith('billing.subscription.expired', {
+        organizationId: orgId,
+        stripeSubscriptionId: 'sub_456',
+      });
+    });
+
+    test('should not throw when billing.subscription.expired listener throws', async () => {
+      const existing = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(existing);
+      const { default: billingEvents } = await import('../lib/events.js');
+      billingEvents.emit.mockImplementationOnce(() => { throw new Error('listener_error'); });
+
+      await expect(
+        WebhookService.handleSubscriptionUpdated(
+          { id: 'sub_456', status: 'incomplete_expired', items: { data: [] } },
+          makeEvent(),
+        ),
+      ).resolves.not.toThrow();
+    });
+  });
+
   describe('handleSubscriptionDeleted', () => {
     const makeEvent = (overrides = {}) => ({ id: 'evt_deleted', created: 1700000200, ...overrides });
 
@@ -559,6 +601,18 @@ describe('Billing webhook integration tests:', () => {
       );
 
       expect(billingEvents.emit).not.toHaveBeenCalled();
+    });
+
+    test('should not throw when billing.dispute.reinstated listener throws (non-fatal)', async () => {
+      const { default: billingEvents } = await import('../lib/events.js');
+      billingEvents.emit.mockImplementationOnce(() => { throw new Error('listener_error'); });
+
+      await expect(
+        WebhookService.handleChargeDisputeFundsReinstated(
+          { id: 'dp_123', charge: 'ch_456', amount: 5000 },
+          makeEvent(),
+        ),
+      ).resolves.not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary

Pre-LIVE Stripe billing hardening for Trawl. **Étape 2** of the [Billing Prod-Ready Roadmap](https://github.com/pierreb-projects/infra/blob/main/.claude/skills/) (8 audit passes : 3 Sonnet + Opus + DeepSeek V4-pro × 2).

**Companion PR** : trawl_node migration cleanup will follow once this is deployed (drops legacy collections + \`\$unset\` deprecated fields). Ordering matters — see "Sequencing" below.

## What ships in this PR

### 🔴 Stripe correctness blockers
- **TTL partial filter** on \`ProcessedStripeEvent\` — dead-letter docs are now permanent (Stripe replay can't re-process them after 30d).
- **Drop static checkout idempotency key** — abandoned-then-retried checkouts no longer hit expired session URLs.
- **\`charge.dispute.funds_reinstated\` handler** — log + alert ops via \`billing.dispute.reinstated\` event (auto-credit deferred to Phase 1 admin endpoint).
- **\`customer.subscription.created\` handler** — defensive upsert for Dashboard-created subscriptions.
- **\`incomplete_expired\` status handling** — downgrade to free + emit \`billing.subscription.expired\`.
- **\`handleCheckoutCompleted\` refactor** — uses \`updateIfEventNewer\` (event-ordering guard) + fetches real status from Stripe (no more hardcoded \`'active'\` for trialing subs).
- **Log unhandled webhook events** — default case in dispatcher logs unknown event types.

### 🔴 Admin update race fix
- **\`adminUpdatePlanOnly()\`** repo method — restricted setter that touches ONLY \`plan\` + \`adminUpdatedAt\` + \`adminUpdatedBy\`. Reserves \`update()\` for webhook handlers. Prevents admin payload from overwriting Stripe-driven status.
- **\`adminUpdatedAt\` / \`adminUpdatedBy\`** fields added to Subscription for audit.

### 🔴 AdminBumpPlan route wired
- \`PATCH /api/admin/billing/plans/bump\` with body \`{ orgId, planId }\`, JWT + CASL guard.
- Resolves the orphaned policy declaration (subject was registered, route was missing).

### 🟡 Cleanup
- Drop legacy \`stripeEventCreatedAt\` / \`stripeEventId\` writes in \`updateIfEventNewer\` (per-family markers since V5 P1 are canonical). Migration in trawl_node will \`\$unset\` them post-deploy.
- Drop legacy fields from Mongoose model + Zod schema.
- Cleanup stale JSDoc reference.

## Sequencing critique

This PR **must merge + deploy on Trawl prod BEFORE** the trawl_node migration runs. The migration \`\$unset\` the legacy fields ; if a pod still has the old code (still writing them), the \`\$unset\` is silently re-applied at the next webhook → migration becomes no-op.

**Procédure** :
1. Merge cette PR → /update-stack propage à trawl_node
2. \`kubectl rollout status deployment/trawl-node -n pierreb-projects\` → \`successfully rolled out\`
3. \`kubectl exec deployment/trawl-node -- grep -c "stripeEventCreatedAt: eventCreatedAt" /app/node_modules/.../updateIfEventNewer\` → 0
4. ALORS lancer la migration trawl_node (PR Étape 2bis)

## Test plan

- [x] \`npm run test:unit -- --testPathPatterns=billing\` → 94 suites / 1217 tests green
- [x] ESLint clean
- [ ] CI green
- [ ] CodeRabbit clean (and/or DeepSeek critical-review approval)
- [ ] Manual: \`stripe trigger charge.dispute.funds_reinstated\` → 200 + ntfy (post-deploy staging)
- [ ] Manual: \`PATCH /api/admin/billing/plans/bump\` → 200 with admin JWT (post-deploy staging)

## References

- Roadmap: vault \`Projects/Devkit/Tech/Devkit — Tech — Billing Prod-Ready Roadmap.md\`
- 8 audit passes documented: 3 Sonnet (Stripe / data / ops) + 1 plan agent + DeepSeek V4-pro V1 + Opus + DeepSeek V4-pro V2
- All findings cross-checked against code (0 false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can manually override an organization's subscription plan via a new admin endpoint
  * Webhook handling added for subscription creation and charge-dispute fund reinstatement

* **Improvements**
  * Added admin audit fields to subscriptions to record who/when overrides occurred
  * Checkout flow adjusted (idempotency behavior and automatic tax handling)
  * TTL for processed webhook events now excludes dead-lettered entries

* **Tests**
  * Expanded unit and integration tests to cover new flows and event-ordering guards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->