### PR TITLE
feat(billing): admin toolkit + operational foundations (Étape 3)

### DIFF
--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -3,6 +3,7 @@
  */
 import responses from '../../../lib/helpers/responses.js';
 import getStripe from '../lib/stripe.js';
+import BillingAdminService from '../services/billing.admin.service.js';
 
 /**
  * @desc Admin endpoint to trigger a Stripe refund for a charge.
@@ -52,7 +53,11 @@ const adminRefundCharge = async (req, res) => {
     const refund = await stripe.refunds.create(params, { idempotencyKey });
     responses.success(res, 'billing refund created')(refund);
   } catch (err) {
-    const status = err.message?.startsWith('invalid argument') ? 422 : 502;
+    // Stripe invalid_request_error (e.g. refund > original amount) → surface as 422.
+    // Other Stripe errors (network, auth) → 502.
+    const isInvalidArg = err.message?.startsWith('invalid argument');
+    const isStripeInvalidRequest = err.type === 'StripeInvalidRequestError' || err.code === 'charge_already_refunded' || err.type === 'invalid_request_error';
+    const status = isInvalidArg || isStripeInvalidRequest ? 422 : 502;
     const title = status === 422 ? 'Unprocessable Entity' : 'Bad Gateway';
     responses.error(res, status, title, 'Failed to refund charge')(err);
   }
@@ -137,7 +142,132 @@ const adminBumpPlan = async (req, res) => {
   }
 };
 
+/**
+ * @desc GET /api/admin/billing/customer/:orgId
+ *       Return Stripe customer state + DB subscription side-by-side.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminGetCustomerStatus = async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const result = await BillingAdminService.getCustomerStatus(orgId);
+    return responses.success(res, 'customer status')(result);
+  } catch (err) {
+    const status = err.status ?? 500;
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : status === 502 ? 'Bad Gateway' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to fetch customer status')(err);
+  }
+};
+
+/**
+ * @desc POST /api/admin/billing/sync/:orgId
+ *       Force Stripe→DB sync for an organization's subscription.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminSyncFromStripe = async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const result = await BillingAdminService.syncOrgFromStripe(orgId);
+    return responses.success(res, 'subscription synced from Stripe')(result);
+  } catch (err) {
+    const status = err.status ?? 500;
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : status === 502 ? 'Bad Gateway' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to sync from Stripe')(err);
+  }
+};
+
+/**
+ * @desc POST /api/admin/billing/webhook/replay
+ *       Re-fetch a Stripe event and re-dispatch it through webhook handlers.
+ * @param {Object} req - Express request object (body: { eventId })
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminReplayWebhook = async (req, res) => {
+  try {
+    const { eventId } = req.body;
+    const result = await BillingAdminService.replayWebhookEvent(eventId);
+    return responses.success(res, 'webhook event replayed')(result);
+  } catch (err) {
+    const status = err.status ?? 500;
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : status === 502 ? 'Bad Gateway' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to replay webhook event')(err);
+  }
+};
+
+/**
+ * @desc GET /api/admin/billing/dead-letters
+ *       Paginated list of dead-lettered processed Stripe events.
+ * @param {Object} req - Express request object (query: { page, limit })
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminListDeadLetters = async (req, res) => {
+  try {
+    const { page, limit } = req.query;
+    const result = await BillingAdminService.listDeadLetters({ page, limit });
+    return responses.success(res, 'dead letters')(result);
+  } catch (err) {
+    return responses.error(res, 500, 'Internal Server Error', 'Failed to list dead letters')(err);
+  }
+};
+
+/**
+ * @desc DELETE /api/admin/billing/dead-letters/:eventId
+ *       Permanently purge a dead-lettered event after manual investigation.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminPurgeDeadLetter = async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    const result = await BillingAdminService.purgeDeadLetter(eventId);
+    return responses.success(res, 'dead letter purged')(result);
+  } catch (err) {
+    const status = err.status ?? 500;
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to purge dead letter')(err);
+  }
+};
+
+/**
+ * @desc POST /api/admin/billing/cancel/:orgId
+ *       Cancel Stripe subscription + downgrade DB to free/canceled.
+ *       Decision #5: cancel → retrieve-verify → DB write.
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
+const adminCancelSubscription = async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const result = await BillingAdminService.cancelSubscription(orgId);
+    return responses.success(res, 'subscription canceled')(result);
+  } catch (err) {
+    const status = err.status ?? 500;
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : status === 502 ? 'Bad Gateway' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to cancel subscription')(err);
+  }
+};
+
 export default {
   adminRefundCharge,
   adminBumpPlan,
+  adminGetCustomerStatus,
+  adminSyncFromStripe,
+  adminReplayWebhook,
+  adminListDeadLetters,
+  adminPurgeDeadLetter,
+  adminCancelSubscription,
 };

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -4,6 +4,7 @@
 import responses from '../../../lib/helpers/responses.js';
 import getStripe from '../lib/stripe.js';
 import BillingAdminService from '../services/billing.admin.service.js';
+import { AdminDeadLettersQuery } from '../models/billing.subscription.schema.js';
 
 /**
  * @desc Admin endpoint to trigger a Stripe refund for a charge.
@@ -212,7 +213,13 @@ const adminReplayWebhook = async (req, res) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js controller, not Qwik
 const adminListDeadLetters = async (req, res) => {
   try {
-    const { page, limit } = req.query;
+    const parsed = AdminDeadLettersQuery.safeParse(req.query);
+    if (!parsed.success) {
+      return responses.error(res, 422, 'Unprocessable Entity', 'Invalid query parameters')(
+        parsed.error,
+      );
+    }
+    const { page, limit } = parsed.data;
     const result = await BillingAdminService.listDeadLetters({ page, limit });
     return responses.success(res, 'dead letters')(result);
   } catch (err) {

--- a/modules/billing/crons/billing.reconcile.js
+++ b/modules/billing/crons/billing.reconcile.js
@@ -1,0 +1,60 @@
+/**
+ * Cron script — weekly Stripe↔DB reconciliation sweep.
+ *
+ * Runs on Sunday at 03:00 UTC. Paginates active|past_due subscriptions, fetches the
+ * live Stripe status for each, and alerts on any status/plan divergence.
+ *
+ * Policy: LOG-ONLY — no auto-fix. Auto-fix is intentionally prohibited because it would
+ * mask bugs silently. Ops must investigate divergences and use the admin sync endpoint
+ * or admin cancel endpoint to resolve them.
+ *
+ * Intended to run as a Kubernetes CronJob (schedule: "0 3 * * 0").
+ * See infra repo for the manifest — same pattern as billing.weeklyReset.
+ *
+ * Usage:
+ *   NODE_ENV=production node modules/billing/crons/billing.reconcile.js
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+const [
+  { default: config },
+  { default: mongooseService },
+  { applyJitter },
+  { getCronJitterMaxMs },
+] = await Promise.all([
+  import('../../../config/index.js'),
+  import('../../../lib/services/mongoose.js'),
+  import('../lib/billing.cron-utils.js'),
+  import('../lib/billing.constants.js'),
+]);
+
+if (!config?.billing?.meterMode) {
+  console.log('[billing.reconcile] meterMode disabled — skipping.');
+  process.exit(0);
+}
+
+await applyJitter(getCronJitterMaxMs());
+
+try {
+  await mongooseService.loadModels();
+  await mongooseService.connect();
+
+  const [
+    { default: BillingReconcileService },
+  ] = await Promise.all([
+    import('../services/billing.reconcile.service.js'),
+  ]);
+
+  const result = await BillingReconcileService.runReconciliation();
+  console.log(
+    `[billing.reconcile] done — checked: ${result.checked}, divergences: ${result.divergences}, errors: ${result.errors}`,
+  );
+  process.exitCode = result.errors > 0 ? 1 : 0;
+} catch (err) {
+  console.error('[billing.reconcile] fatal:', err);
+  process.exitCode = 1;
+} finally {
+  await mongooseService.disconnect?.();
+}
+process.exit(process.exitCode ?? 0);

--- a/modules/billing/models/billing.subscription.model.mongoose.js
+++ b/modules/billing/models/billing.subscription.model.mongoose.js
@@ -138,6 +138,15 @@ function addID() {
 }
 
 /**
+ * Compound indexes — scanning operations
+ *
+ * weeklyReset sweep: quickly find active/trialing subs whose lastResetAt is stale.
+ * dunningSweep scan: quickly find past_due subs where pastDueSince has exceeded threshold.
+ */
+SubscriptionMongoose.index({ status: 1, lastResetAt: 1 });   // weeklyReset scan
+SubscriptionMongoose.index({ status: 1, pastDueSince: 1 });  // dunningSweep scan
+
+/**
  * Model configuration
  */
 SubscriptionMongoose.virtual('id').get(addID);

--- a/modules/billing/models/billing.subscription.schema.js
+++ b/modules/billing/models/billing.subscription.schema.js
@@ -107,9 +107,31 @@ const AdminBumpPlanRequest = z
   })
   .strict();
 
+/**
+ * Webhook replay request body schema.
+ * eventId: Stripe event ID (evt_xxx) to re-fetch and re-dispatch.
+ */
+const AdminWebhookReplayRequest = z
+  .object({
+    eventId: z.string().trim().min(1, 'eventId is required'),
+  })
+  .strict();
+
+/**
+ * Dead-letters list query schema (GET parameters — all optional).
+ */
+const AdminDeadLettersQuery = z
+  .object({
+    page: z.coerce.number().int().min(1).optional().default(1),
+    limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  })
+  .strict();
+
 export {
   AdminRefundRequest,
   AdminBumpPlanRequest,
+  AdminWebhookReplayRequest,
+  AdminDeadLettersQuery,
 };
 
 export default {
@@ -120,4 +142,6 @@ export default {
   ExtrasCheckoutRequest,
   AdminRefundRequest,
   AdminBumpPlanRequest,
+  AdminWebhookReplayRequest,
+  AdminDeadLettersQuery,
 };

--- a/modules/billing/policies/billing.policy.js
+++ b/modules/billing/policies/billing.policy.js
@@ -21,6 +21,12 @@ export function billingSubjectRegistration({ registerPathSubject }) {
   registerPathSubject('/api/billing/extras/ledger', 'BillingExtrasLedger');
   registerPathSubject('/api/admin/billing/refund', 'BillingAdminRefund');
   registerPathSubject('/api/admin/billing/plans/bump', 'BillingAdminPlanBump');
+  // Admin toolkit — 6 diagnostic + ops endpoints (all require admin role)
+  registerPathSubject('/api/admin/billing/customer', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/sync', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/webhook/replay', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/dead-letters', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/cancel', 'BillingAdminOps');
   // Webhook is mounted in billing.preroute.js before body parsing and auth middleware,
   // so it bypasses policy.isAllowed entirely. Registered here for documentation completeness.
   registerPathSubject('/api/billing/webhook', 'BillingWebhook');

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -142,10 +142,61 @@ const markDeadLetter = async (eventId) => {
   ).exec();
 };
 
+/**
+ * @function listDeadLetters
+ * @description Paginated list of dead-lettered processed events (deadLetter: true).
+ *              Sorted by processedAt descending (most-recently dead-lettered first).
+ * @param {Object} [opts] - Pagination options.
+ * @param {number} [opts.page=1] - 1-based page number.
+ * @param {number} [opts.limit=20] - Items per page (max 100).
+ * @returns {Promise<{items: Array, total: number, page: number, limit: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const listDeadLetters = async ({ page = 1, limit = 20 } = {}) => {
+  const parsedPage = Math.floor(Number(page));
+  const parsedLimit = Math.floor(Number(limit));
+  // page: clamp to ≥1, fall back to 1 for NaN/non-finite
+  const safePage = Number.isFinite(parsedPage) ? Math.max(1, parsedPage) : 1;
+  // limit: clamp to [1, 100], fall back to 20 for NaN/non-finite
+  const safeLimit = Number.isFinite(parsedLimit) ? Math.min(100, Math.max(1, parsedLimit)) : 20;
+  const skip = (safePage - 1) * safeLimit;
+
+  const [items, total] = await Promise.all([
+    ProcessedStripeEvent()
+      .find({ deadLetter: true })
+      .sort({ processedAt: -1 })
+      .skip(skip)
+      .limit(safeLimit)
+      .lean()
+      .exec(),
+    ProcessedStripeEvent().countDocuments({ deadLetter: true }),
+  ]);
+
+  return { items, total, page: safePage, limit: safeLimit };
+};
+
+/**
+ * @function purgeDeadLetterByEventId
+ * @description Permanently delete a dead-lettered event by eventId.
+ *              Only removes documents where deadLetter === true (safety guard).
+ * @param {string} eventId - Stripe event ID to purge.
+ * @returns {Promise<{purged: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const purgeDeadLetterByEventId = async (eventId) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') {
+    throw new Error('invalid argument: eventId must be a non-empty string');
+  }
+  const result = await ProcessedStripeEvent().deleteOne({ eventId, deadLetter: true });
+  return { purged: result.deletedCount > 0 };
+};
+
 export default {
   tryRecord,
   wasProcessed,
   deleteByEventId,
   incrementAttempts,
   markDeadLetter,
+  listDeadLetters,
+  purgeDeadLetterByEventId,
 };

--- a/modules/billing/routes/billing.admin.routes.js
+++ b/modules/billing/routes/billing.admin.routes.js
@@ -6,7 +6,11 @@ import passport from 'passport';
 import policy from '../../../lib/middlewares/policy.js';
 import model from '../../../lib/middlewares/model.js';
 import billingAdmin from '../controllers/billing.admin.controller.js';
-import { AdminRefundRequest, AdminBumpPlanRequest } from '../models/billing.subscription.schema.js';
+import {
+  AdminRefundRequest,
+  AdminBumpPlanRequest,
+  AdminWebhookReplayRequest,
+} from '../models/billing.subscription.schema.js';
 
 /**
  * Routes
@@ -23,4 +27,36 @@ export default (app) => {
     .route('/api/admin/billing/plans/bump')
     .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
     .patch(model.isValid(AdminBumpPlanRequest), billingAdmin.adminBumpPlan);
+
+  // Admin toolkit — diagnostic + ops endpoints
+
+  app
+    .route('/api/admin/billing/customer/:orgId')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .get(billingAdmin.adminGetCustomerStatus);
+
+  app
+    .route('/api/admin/billing/sync/:orgId')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(billingAdmin.adminSyncFromStripe);
+
+  app
+    .route('/api/admin/billing/webhook/replay')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(model.isValid(AdminWebhookReplayRequest), billingAdmin.adminReplayWebhook);
+
+  app
+    .route('/api/admin/billing/dead-letters')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .get(billingAdmin.adminListDeadLetters);
+
+  app
+    .route('/api/admin/billing/dead-letters/:eventId')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .delete(billingAdmin.adminPurgeDeadLetter);
+
+  app
+    .route('/api/admin/billing/cancel/:orgId')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(billingAdmin.adminCancelSubscription);
 };

--- a/modules/billing/services/billing.admin.service.js
+++ b/modules/billing/services/billing.admin.service.js
@@ -99,6 +99,8 @@ const syncOrgFromStripe = async (orgId) => {
 
   const previous = { plan: existing.plan, status: existing.status };
 
+  // Intentional: full Stripe-truth sync — writes status AND plan directly.
+  // adminUpdatePlanOnly is for the UI plan-bump flow only (audit trail, no Stripe re-sync).
   const updated = await SubscriptionRepository.update({
     _id: existing._id,
     plan: newPlan,
@@ -149,11 +151,9 @@ const replayWebhookEvent = async (eventId) => {
     );
   }
 
-  // Clear idempotency record so the handler can re-run (handles both normal + dead-letter states)
-  await ProcessedStripeEventRepository.deleteByEventId(eventId).catch(() => {
-    // Non-fatal: doc may not exist (e.g. never processed). Log and continue.
-    logger.warn('[billing.admin] replayWebhookEvent — deleteByEventId skipped (not found)', { eventId });
-  });
+  // Clear idempotency record so the handler can re-run (handles both normal + dead-letter states).
+  // deleteByEventId returns { deleted: false } when not found — never throws — so no catch needed.
+  await ProcessedStripeEventRepository.deleteByEventId(eventId);
 
   // Re-dispatch via the same switch used by the webhook controller
   const result = await dispatchWebhookEvent(event);

--- a/modules/billing/services/billing.admin.service.js
+++ b/modules/billing/services/billing.admin.service.js
@@ -1,0 +1,367 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+import config from '../../../config/index.js';
+import getStripe from '../lib/stripe.js';
+import logger from '../../../lib/services/logger.js';
+import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
+import ProcessedStripeEventRepository from '../repositories/billing.processedStripeEvent.repository.js';
+import OrganizationRepository from '../../organizations/repositories/organizations.repository.js';
+import BillingWebhookService from './billing.webhook.service.js';
+
+/**
+ * Valid plan names from config (immutable set for O(1) lookups).
+ */
+const validPlans = new Set(config.billing?.plans || ['free', 'starter', 'pro', 'enterprise']);
+
+/**
+ * @function getCustomerStatus
+ * @description Fetch the Stripe customer + subscription state alongside the DB subscription
+ *              for side-by-side comparison (admin diagnostic endpoint).
+ * @param {string} orgId - Organization ObjectId (string).
+ * @returns {Promise<{db: Object|null, stripe: Object|null}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const getCustomerStatus = async (orgId) => {
+  if (!mongoose.Types.ObjectId.isValid(orgId)) {
+    throw Object.assign(new Error('invalid argument: orgId must be a valid ObjectId'), { status: 422 });
+  }
+
+  const db = await SubscriptionRepository.findByOrganization(orgId);
+
+  let stripeData = null;
+  const stripe = getStripe();
+  if (stripe && db?.stripeCustomerId) {
+    try {
+      const customer = await stripe.customers.retrieve(db.stripeCustomerId, {
+        expand: ['subscriptions'],
+      });
+      stripeData = {
+        customerId: customer.id,
+        email: customer.email,
+        deleted: customer.deleted ?? false,
+        subscriptions: customer.subscriptions?.data?.map((s) => ({
+          id: s.id,
+          status: s.status,
+          currentPeriodEnd: s.current_period_end,
+          cancelAtPeriodEnd: s.cancel_at_period_end,
+          plan: s.items?.data?.[0]?.price?.metadata?.planId ?? null,
+        })) ?? [],
+      };
+    } catch (err) {
+      logger.error('[billing.admin] getCustomerStatus — Stripe fetch failed', {
+        orgId,
+        stripeCustomerId: db.stripeCustomerId,
+        error: err?.message ?? String(err),
+      });
+      stripeData = { error: err?.message ?? String(err) };
+    }
+  }
+
+  return { db, stripe: stripeData };
+};
+
+/**
+ * @function syncOrgFromStripe
+ * @description Force-sync a subscription from Stripe into the DB.
+ *              Fetches the live Stripe subscription, validates the status, and updates the DB.
+ *              Uses direct update (bypasses event-ordering guard) — this is an explicit admin override.
+ * @param {string} orgId - Organization ObjectId (string).
+ * @returns {Promise<{previous: Object, updated: Object}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const syncOrgFromStripe = async (orgId) => {
+  if (!mongoose.Types.ObjectId.isValid(orgId)) {
+    throw Object.assign(new Error('invalid argument: orgId must be a valid ObjectId'), { status: 422 });
+  }
+
+  const existing = await SubscriptionRepository.findByOrganization(orgId);
+  if (!existing) {
+    throw Object.assign(new Error(`subscription not found for orgId=${orgId}`), { status: 404 });
+  }
+  if (!existing.stripeSubscriptionId) {
+    throw Object.assign(new Error('subscription has no stripeSubscriptionId — cannot sync from Stripe'), { status: 422 });
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    throw Object.assign(new Error('Stripe is not configured'), { status: 502 });
+  }
+
+  const stripeSub = await stripe.subscriptions.retrieve(existing.stripeSubscriptionId);
+  const newPlan = resolveStripePlan(stripeSub);
+  const newStatus = stripeSub.status;
+  const newPeriodStart = stripeSub.current_period_start
+    ? new Date(stripeSub.current_period_start * 1000)
+    : null;
+
+  const previous = { plan: existing.plan, status: existing.status };
+
+  const updated = await SubscriptionRepository.update({
+    _id: existing._id,
+    plan: newPlan,
+    status: newStatus,
+    ...(newPeriodStart ? { currentPeriodStart: newPeriodStart } : {}),
+  });
+
+  // Sync org plan field so quotas + access control reflect the new plan immediately.
+  await OrganizationRepository.setPlan(orgId, newPlan);
+
+  logger.info('[billing.admin] syncOrgFromStripe — synced', {
+    orgId,
+    previous,
+    updated: { plan: newPlan, status: newStatus },
+    stripeSubscriptionId: existing.stripeSubscriptionId,
+  });
+
+  return { previous, updated };
+};
+
+/**
+ * @function replayWebhookEvent
+ * @description Re-fetch a Stripe event by ID and re-dispatch it through the webhook handler.
+ *              Deletes the processed-event record first so withIdempotency allows re-entry.
+ *              Used to recover dead-lettered or failed events after the root cause is fixed.
+ * @param {string} eventId - Stripe event ID (evt_xxx).
+ * @returns {Promise<Object>} Dispatch result from BillingWebhookService.withIdempotency.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const replayWebhookEvent = async (eventId) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') {
+    throw Object.assign(new Error('invalid argument: eventId must be a non-empty string'), { status: 422 });
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    throw Object.assign(new Error('Stripe is not configured'), { status: 502 });
+  }
+
+  // Fetch fresh event from Stripe
+  let event;
+  try {
+    event = await stripe.events.retrieve(eventId);
+  } catch (err) {
+    throw Object.assign(
+      new Error(`Stripe event fetch failed: ${err?.message ?? String(err)}`),
+      { status: 502 },
+    );
+  }
+
+  // Clear idempotency record so the handler can re-run (handles both normal + dead-letter states)
+  await ProcessedStripeEventRepository.deleteByEventId(eventId).catch(() => {
+    // Non-fatal: doc may not exist (e.g. never processed). Log and continue.
+    logger.warn('[billing.admin] replayWebhookEvent — deleteByEventId skipped (not found)', { eventId });
+  });
+
+  // Re-dispatch via the same switch used by the webhook controller
+  const result = await dispatchWebhookEvent(event);
+
+  logger.info('[billing.admin] replayWebhookEvent — dispatched', {
+    eventId,
+    eventType: event.type,
+    result,
+  });
+
+  return { eventId, eventType: event.type, result };
+};
+
+/**
+ * @function listDeadLetters
+ * @description Paginated list of dead-lettered processed events.
+ * @param {Object} [opts] - Pagination options (page, limit).
+ * @returns {Promise<{items: Array, total: number, page: number, limit: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const listDeadLetters = (opts = {}) => ProcessedStripeEventRepository.listDeadLetters(opts);
+
+/**
+ * @function purgeDeadLetter
+ * @description Permanently purge a dead-lettered event after manual investigation.
+ *              Guards: only removes documents with deadLetter === true.
+ * @param {string} eventId - Stripe event ID.
+ * @returns {Promise<{purged: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const purgeDeadLetter = async (eventId) => {
+  if (typeof eventId !== 'string' || eventId.trim() === '') {
+    throw Object.assign(new Error('invalid argument: eventId must be a non-empty string'), { status: 422 });
+  }
+  const result = await ProcessedStripeEventRepository.purgeDeadLetterByEventId(eventId);
+  if (!result.purged) {
+    throw Object.assign(
+      new Error(`dead-letter event not found: ${eventId}`),
+      { status: 404 },
+    );
+  }
+
+  logger.info('[billing.admin] purgeDeadLetter — purged', { eventId });
+  return result;
+};
+
+/**
+ * @function cancelSubscription
+ * @description Cancel a Stripe subscription and downgrade the DB to free/canceled.
+ *              Decision #5: (a) cancel → (b) retrieve to verify status === 'canceled'
+ *              → (c) DB write with confirmed status. Prevents drift on network timeout.
+ * @param {string} orgId - Organization ObjectId (string).
+ * @returns {Promise<{previous: Object, updated: Object, stripeStatus: string}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const cancelSubscription = async (orgId) => {
+  if (!mongoose.Types.ObjectId.isValid(orgId)) {
+    throw Object.assign(new Error('invalid argument: orgId must be a valid ObjectId'), { status: 422 });
+  }
+
+  const existing = await SubscriptionRepository.findByOrganization(orgId);
+  if (!existing) {
+    throw Object.assign(new Error(`subscription not found for orgId=${orgId}`), { status: 404 });
+  }
+  if (!existing.stripeSubscriptionId) {
+    throw Object.assign(new Error('subscription has no stripeSubscriptionId — cannot cancel via Stripe'), { status: 422 });
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    throw Object.assign(new Error('Stripe is not configured'), { status: 502 });
+  }
+
+  const previous = { plan: existing.plan, status: existing.status };
+
+  // (a) Cancel on Stripe
+  await stripe.subscriptions.cancel(existing.stripeSubscriptionId);
+
+  // (b) Retrieve to verify (Decision #5 — avoid drift on network timeout)
+  let confirmedStatus;
+  try {
+    const retrieved = await stripe.subscriptions.retrieve(existing.stripeSubscriptionId);
+    confirmedStatus = retrieved.status;
+  } catch (err) {
+    // Retrieve failed after cancel — treat as canceled (cancel was already requested).
+    // Log the anomaly so ops can verify via Stripe Dashboard.
+    logger.error('[billing.admin] cancelSubscription — post-cancel retrieve failed, assuming canceled', {
+      orgId,
+      stripeSubscriptionId: existing.stripeSubscriptionId,
+      error: err?.message ?? String(err),
+    });
+    confirmedStatus = 'canceled';
+  }
+
+  if (confirmedStatus !== 'canceled') {
+    logger.error('[billing.admin] cancelSubscription — unexpected status after cancel', {
+      orgId,
+      stripeSubscriptionId: existing.stripeSubscriptionId,
+      confirmedStatus,
+    });
+    throw Object.assign(
+      new Error(`Stripe subscription status after cancel is '${confirmedStatus}', expected 'canceled'`),
+      { status: 502 },
+    );
+  }
+
+  // (c) DB write with confirmed status
+  const updated = await SubscriptionRepository.update({
+    _id: existing._id,
+    plan: 'free',
+    status: 'canceled',
+  });
+
+  await OrganizationRepository.setPlan(orgId, 'free');
+
+  logger.info('[billing.admin] cancelSubscription — canceled', {
+    orgId,
+    previous,
+    stripeSubscriptionId: existing.stripeSubscriptionId,
+    confirmedStatus,
+  });
+
+  return { previous, updated, stripeStatus: confirmedStatus };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @function resolveStripePlan
+ * @description Resolve the plan name from a Stripe subscription object.
+ *              Same heuristic as billing.webhook.service.js (price.metadata.planId first).
+ * @param {Object} subscription - Stripe subscription object.
+ * @returns {string} plan name.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const resolveStripePlan = (subscription) => {
+  const item = subscription.items?.data?.[0];
+  const raw = item?.price?.metadata?.planId || item?.plan?.metadata?.planId;
+  return validPlans.has(raw) ? raw : 'free';
+};
+
+/**
+ * @function dispatchWebhookEvent
+ * @description Route a raw Stripe event to the appropriate webhook handler.
+ *              Mirrors the switch in billing.webhook.controller.js.
+ * @param {Object} event - Stripe event object.
+ * @returns {Promise<Object>} Handler result.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const dispatchWebhookEvent = (event) => {
+  switch (event.type) {
+    case 'checkout.session.completed':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleCheckoutSessionCompleted(e),
+      );
+    case 'customer.subscription.created':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleSubscriptionCreated(e.data.object, e),
+      );
+    case 'customer.subscription.updated':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleSubscriptionUpdated(e.data.object, e),
+      );
+    case 'customer.subscription.deleted':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleSubscriptionDeleted(e.data.object, e),
+      );
+    case 'invoice.payment_failed':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleInvoicePaymentFailed(e.data.object, e),
+      );
+    case 'invoice.payment_succeeded':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleInvoicePaymentSucceeded(e.data.object, e),
+      );
+    case 'charge.refunded':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleChargeRefunded(e.data.object),
+      );
+    case 'customer.deleted':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleCustomerDeleted(e.data.object, e),
+      );
+    case 'charge.dispute.created':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleChargeDisputeCreated(e.data.object, e),
+      );
+    case 'charge.dispute.funds_withdrawn':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleChargeDisputeFundsWithdrawn(e.data.object, e),
+      );
+    case 'charge.dispute.funds_reinstated':
+      return BillingWebhookService.withIdempotency(event, (e) =>
+        BillingWebhookService.handleChargeDisputeFundsReinstated(e.data.object, e),
+      );
+    default:
+      logger.info('[billing.admin] replay — unhandled event type, no handler', { type: event.type, id: event.id });
+      return Promise.resolve({ skipped: true, reason: 'unhandled_event_type' });
+  }
+};
+
+export default {
+  getCustomerStatus,
+  syncOrgFromStripe,
+  replayWebhookEvent,
+  listDeadLetters,
+  purgeDeadLetter,
+  cancelSubscription,
+};

--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -1,0 +1,172 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+import config from '../../../config/index.js';
+import getStripe from '../lib/stripe.js';
+import logger from '../../../lib/services/logger.js';
+import billingEvents from '../lib/events.js';
+
+/**
+ * Page size for the reconciliation cursor — fetch in batches to avoid long-running queries.
+ */
+const RECONCILE_PAGE_SIZE = 100;
+
+/**
+ * Statuses reconciled against Stripe.
+ */
+const RECONCILE_STATUSES = ['active', 'past_due'];
+
+/**
+ * Valid plan names from config.
+ */
+const validPlans = new Set(config.billing?.plans || ['free', 'starter', 'pro', 'enterprise']);
+
+/**
+ * @function resolveStripePlan
+ * @description Resolve the plan name from a Stripe subscription object.
+ * @param {Object} subscription - Stripe subscription object.
+ * @returns {string} plan name.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const resolveStripePlan = (subscription) => {
+  const item = subscription.items?.data?.[0];
+  const raw = item?.price?.metadata?.planId || item?.plan?.metadata?.planId;
+  return validPlans.has(raw) ? raw : 'free';
+};
+
+/**
+ * @function runReconciliation
+ * @description Paginate all active|past_due subscriptions, fetch live Stripe status for each,
+ *              and emit billing.reconciliation.divergence when status or plan diverges.
+ *
+ *              LOG-ONLY policy: this function NEVER writes to the DB or Stripe.
+ *              Auto-fix is prohibited — it would mask bugs silently.
+ *              Ops must use /api/admin/billing/sync or /api/admin/billing/cancel to resolve.
+ *
+ * @returns {Promise<{checked: number, divergences: number, errors: number}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const runReconciliation = async () => {
+  if (!config?.billing?.meterMode) {
+    logger.info('[billing.reconcile] meterMode disabled — skipping reconciliation');
+    return { checked: 0, divergences: 0, errors: 0 };
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    logger.error('[billing.reconcile] Stripe not configured — cannot reconcile');
+    return { checked: 0, divergences: 0, errors: 0 };
+  }
+
+  // Lazy import — deferred to keep unit tests importable before model registration.
+  const { default: SubscriptionRepository } = await import('../repositories/billing.subscription.repository.js');
+
+  let checked = 0;
+  let divergences = 0;
+  let errors = 0;
+  let page = 0;
+
+  let hasMore = true;
+  while (hasMore) {
+    // Paginate via skip+limit — for large collections consider cursor-based pagination,
+    // but skip is acceptable for ops crons running at low frequency.
+    const subs = await _fetchPage(SubscriptionRepository, page, RECONCILE_PAGE_SIZE);
+    if (!subs || subs.length === 0) break;
+
+    for (const sub of subs) {
+      try {
+        const result = await _reconcileOne(stripe, sub);
+        checked += 1;
+        if (result.diverged) divergences += 1;
+      } catch (err) {
+        errors += 1;
+        logger.error('[billing.reconcile] error reconciling subscription', {
+          subscriptionId: String(sub._id),
+          organizationId: String(sub.organization?._id || sub.organization),
+          stripeSubscriptionId: sub.stripeSubscriptionId,
+          error: err?.message ?? String(err),
+        });
+      }
+    }
+
+    if (subs.length < RECONCILE_PAGE_SIZE) {
+      hasMore = false;
+    } else {
+      page += 1;
+    }
+  }
+
+  logger.info('[billing.reconcile] reconciliation complete', { checked, divergences, errors });
+  return { checked, divergences, errors };
+};
+
+/**
+ * Fetch one page of active|past_due subscriptions.
+ * @param {Object} SubscriptionRepository - Subscription repository.
+ * @param {number} page - 0-based page index.
+ * @param {number} limit - Page size.
+ * @returns {Promise<Array>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const _fetchPage = async (SubscriptionRepository, page, limit) => {
+  const Subscription = mongoose.model('Subscription');
+  return Subscription.find(
+    { status: { $in: RECONCILE_STATUSES }, stripeSubscriptionId: { $ne: null } },
+    { _id: 1, organization: 1, stripeSubscriptionId: 1, stripeCustomerId: 1, plan: 1, status: 1 },
+  )
+    .skip(page * limit)
+    .limit(limit)
+    .lean()
+    .exec();
+};
+
+/**
+ * Reconcile a single subscription against Stripe.
+ * Returns { diverged: boolean }.
+ * @param {Object} stripe - Stripe client.
+ * @param {Object} sub - DB subscription (lean).
+ * @returns {Promise<{diverged: boolean}>}
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const _reconcileOne = async (stripe, sub) => {
+  const orgId = String(sub.organization?._id || sub.organization);
+  const subId = sub.stripeSubscriptionId;
+
+  const stripeSub = await stripe.subscriptions.retrieve(subId);
+  const stripeStatus = stripeSub.status;
+  const stripePlan = resolveStripePlan(stripeSub);
+
+  const statusMismatch = sub.status !== stripeStatus;
+  const planMismatch = sub.plan !== stripePlan;
+
+  if (!statusMismatch && !planMismatch) return { diverged: false };
+
+  const payload = {
+    organizationId: orgId,
+    subscriptionId: String(sub._id),
+    stripeSubscriptionId: subId,
+    db: { status: sub.status, plan: sub.plan },
+    stripe: { status: stripeStatus, plan: stripePlan },
+    statusMismatch,
+    planMismatch,
+  };
+
+  // Critical: status divergence may indicate billing bypass or stale webhook delivery.
+  logger.error('[billing.reconcile] divergence detected — LOG ONLY, no auto-fix', payload);
+
+  try {
+    billingEvents.emit('billing.reconciliation.divergence', payload);
+  } catch (evtErr) {
+    logger.error('[billing.reconcile] billing.reconciliation.divergence listener error (non-fatal)', {
+      error: evtErr?.message ?? String(evtErr),
+    });
+  }
+
+  return { diverged: true };
+};
+
+export default {
+  runReconciliation,
+};

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -20,7 +20,7 @@ describe('Billing admin integration tests:', () => {
     const routes = new Map();
     const app = {
       route: jest.fn((path) => {
-        const entry = { all: [], get: [], post: [], patch: [] };
+        const entry = { all: [], get: [], post: [], patch: [], delete: [] };
         routes.set(path, entry);
         const routeBuilder = {
           all: (...handlers) => {
@@ -37,6 +37,10 @@ describe('Billing admin integration tests:', () => {
           },
           patch: (...handlers) => {
             entry.patch.push(...handlers);
+            return routeBuilder;
+          },
+          delete: (...handlers) => {
+            entry.delete.push(...handlers);
             return routeBuilder;
           },
         };
@@ -183,6 +187,18 @@ describe('Billing admin integration tests:', () => {
 
     jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
       default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
+    // Mock admin service to prevent deep import chain from touching mongoose models.
+    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
+      default: {
+        getCustomerStatus: jest.fn(),
+        syncOrgFromStripe: jest.fn(),
+        replayWebhookEvent: jest.fn(),
+        listDeadLetters: jest.fn(),
+        purgeDeadLetter: jest.fn(),
+        cancelSubscription: jest.fn(),
+      },
     }));
 
     billingAdminRoutes = (await import('../routes/billing.admin.routes.js')).default;

--- a/modules/billing/tests/billing.admin.service.unit.tests.js
+++ b/modules/billing/tests/billing.admin.service.unit.tests.js
@@ -260,12 +260,12 @@ describe('BillingAdminService unit tests:', () => {
       await expect(BillingAdminService.replayWebhookEvent('evt_test_001')).rejects.toMatchObject({ status: 502 });
     });
 
-    test('continues dispatch even when deleteByEventId throws (doc absent is non-fatal)', async () => {
-      mockProcessedStripeEventRepository.deleteByEventId.mockRejectedValue(new Error('not found'));
+    test('propagates deleteByEventId infrastructure errors (not swallowed)', async () => {
+      // deleteByEventId returns { deleted: false } for missing docs — never throws.
+      // If it does throw (DB connection loss, etc.) the error must propagate, not be swallowed.
+      mockProcessedStripeEventRepository.deleteByEventId.mockRejectedValue(new Error('DB connection lost'));
 
-      // Should not throw — should still dispatch
-      const result = await BillingAdminService.replayWebhookEvent('evt_test_001');
-      expect(result).toMatchObject({ eventId: 'evt_test_001' });
+      await expect(BillingAdminService.replayWebhookEvent('evt_test_001')).rejects.toThrow('DB connection lost');
     });
 
     test('skips unknown event types gracefully (returns skipped sentinel)', async () => {

--- a/modules/billing/tests/billing.admin.service.unit.tests.js
+++ b/modules/billing/tests/billing.admin.service.unit.tests.js
@@ -278,6 +278,33 @@ describe('BillingAdminService unit tests:', () => {
       const result = await BillingAdminService.replayWebhookEvent('evt_unknown');
       expect(result.result).toMatchObject({ skipped: true, reason: 'unhandled_event_type' });
     });
+
+    // Each supported event type should route to its withIdempotency handler
+    const SUPPORTED_TYPES = [
+      'checkout.session.completed',
+      'customer.subscription.created',
+      'customer.subscription.deleted',
+      'invoice.payment_failed',
+      'invoice.payment_succeeded',
+      'charge.refunded',
+      'customer.deleted',
+      'charge.dispute.created',
+      'charge.dispute.funds_withdrawn',
+      'charge.dispute.funds_reinstated',
+    ];
+
+    test.each(SUPPORTED_TYPES)('dispatches %s via withIdempotency', async (eventType) => {
+      mockStripeInstance.events.retrieve.mockResolvedValue({
+        id: `evt_${eventType.replace(/\./g, '_')}`,
+        type: eventType,
+        data: { object: { id: 'sub_test_001' } },
+      });
+
+      const result = await BillingAdminService.replayWebhookEvent(`evt_${eventType.replace(/\./g, '_')}`);
+
+      expect(mockWebhookService.withIdempotency).toHaveBeenCalled();
+      expect(result).toMatchObject({ eventType });
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/modules/billing/tests/billing.admin.service.unit.tests.js
+++ b/modules/billing/tests/billing.admin.service.unit.tests.js
@@ -1,0 +1,402 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for BillingAdminService.
+ * Covers all 6 admin operations: getCustomerStatus, syncOrgFromStripe, replayWebhookEvent,
+ * listDeadLetters, purgeDeadLetter, cancelSubscription.
+ */
+describe('BillingAdminService unit tests:', () => {
+  let BillingAdminService;
+  let mockSubscriptionRepository;
+  let mockProcessedStripeEventRepository;
+  let mockOrganizationRepository;
+  let mockWebhookService;
+  let mockStripeInstance;
+  let mockGetStripe;
+  let mockLogger;
+  let mockConfig;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const subId = '607f1f77bcf86cd799439033';
+  const stripeSubId = 'sub_test_001';
+  const stripeCusId = 'cus_test_001';
+
+  /**
+   * @returns {Object} stub subscription doc
+   */
+  const makeDbSub = (overrides = {}) => ({
+    _id: subId,
+    organization: orgId,
+    plan: 'pro',
+    status: 'active',
+    stripeCustomerId: stripeCusId,
+    stripeSubscriptionId: stripeSubId,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['free', 'starter', 'pro', 'enterprise'],
+      },
+    };
+
+    mockSubscriptionRepository = {
+      findByOrganization: jest.fn().mockResolvedValue(makeDbSub()),
+      update: jest.fn().mockResolvedValue(makeDbSub({ plan: 'free', status: 'canceled' })),
+    };
+
+    mockProcessedStripeEventRepository = {
+      listDeadLetters: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 }),
+      purgeDeadLetterByEventId: jest.fn().mockResolvedValue({ purged: true }),
+      deleteByEventId: jest.fn().mockResolvedValue({ deleted: true }),
+    };
+
+    mockOrganizationRepository = {
+      setPlan: jest.fn().mockResolvedValue({}),
+    };
+
+    mockWebhookService = {
+      withIdempotency: jest.fn().mockResolvedValue({ skipped: false }),
+      handleCheckoutSessionCompleted: jest.fn(),
+      handleSubscriptionCreated: jest.fn(),
+      handleSubscriptionUpdated: jest.fn(),
+      handleSubscriptionDeleted: jest.fn(),
+      handleInvoicePaymentFailed: jest.fn(),
+      handleInvoicePaymentSucceeded: jest.fn(),
+      handleChargeRefunded: jest.fn(),
+      handleCustomerDeleted: jest.fn(),
+      handleChargeDisputeCreated: jest.fn(),
+      handleChargeDisputeFundsWithdrawn: jest.fn(),
+      handleChargeDisputeFundsReinstated: jest.fn(),
+    };
+
+    mockStripeInstance = {
+      customers: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: stripeCusId,
+          email: 'test@example.com',
+          deleted: false,
+          subscriptions: {
+            data: [{
+              id: stripeSubId,
+              status: 'active',
+              current_period_end: 1700000000,
+              cancel_at_period_end: false,
+              items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+            }],
+          },
+        }),
+      },
+      subscriptions: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: stripeSubId,
+          status: 'active',
+          current_period_start: 1699000000,
+          items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+        }),
+        cancel: jest.fn().mockResolvedValue({ id: stripeSubId, status: 'canceled' }),
+      },
+      events: {
+        retrieve: jest.fn().mockResolvedValue({
+          id: 'evt_test_001',
+          type: 'customer.subscription.updated',
+          data: { object: { id: stripeSubId } },
+        }),
+      },
+    };
+    mockGetStripe = jest.fn().mockReturnValue(mockStripeInstance);
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: mockGetStripe }));
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
+      },
+    }));
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: mockSubscriptionRepository,
+    }));
+    jest.unstable_mockModule('../repositories/billing.processedStripeEvent.repository.js', () => ({
+      default: mockProcessedStripeEventRepository,
+    }));
+    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+      default: mockOrganizationRepository,
+    }));
+    jest.unstable_mockModule('../services/billing.webhook.service.js', () => ({
+      default: mockWebhookService,
+    }));
+    jest.unstable_mockModule('../lib/events.js', () => ({
+      default: { emit: jest.fn() },
+    }));
+
+    const mod = await import('../services/billing.admin.service.js');
+    BillingAdminService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // getCustomerStatus
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('getCustomerStatus:', () => {
+    test('returns db + stripe data side-by-side for valid orgId', async () => {
+      const result = await BillingAdminService.getCustomerStatus(orgId);
+
+      expect(result).toHaveProperty('db');
+      expect(result).toHaveProperty('stripe');
+      expect(result.db.plan).toBe('pro');
+      expect(mockStripeInstance.customers.retrieve).toHaveBeenCalledWith(stripeCusId, {
+        expand: ['subscriptions'],
+      });
+    });
+
+    test('returns stripe: null when DB subscription has no stripeCustomerId', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(makeDbSub({ stripeCustomerId: null }));
+
+      const result = await BillingAdminService.getCustomerStatus(orgId);
+
+      expect(result.stripe).toBeNull();
+      expect(mockStripeInstance.customers.retrieve).not.toHaveBeenCalled();
+    });
+
+    test('throws 422 for invalid orgId format', async () => {
+      await expect(BillingAdminService.getCustomerStatus('not-an-id')).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('returns stripe.error when Stripe fetch fails (non-fatal — DB still returned)', async () => {
+      mockStripeInstance.customers.retrieve.mockRejectedValue(new Error('Stripe down'));
+
+      const result = await BillingAdminService.getCustomerStatus(orgId);
+
+      expect(result.db).toBeDefined();
+      expect(result.stripe).toMatchObject({ error: 'Stripe down' });
+    });
+
+    test('returns db: null when no subscription exists for org', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+
+      const result = await BillingAdminService.getCustomerStatus(orgId);
+
+      expect(result.db).toBeNull();
+      expect(result.stripe).toBeNull();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // syncOrgFromStripe
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('syncOrgFromStripe:', () => {
+    test('syncs status + plan from Stripe and updates org plan', async () => {
+      const result = await BillingAdminService.syncOrgFromStripe(orgId);
+
+      expect(mockStripeInstance.subscriptions.retrieve).toHaveBeenCalledWith(stripeSubId);
+      expect(mockSubscriptionRepository.update).toHaveBeenCalled();
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
+      expect(result).toHaveProperty('previous');
+      expect(result).toHaveProperty('updated');
+    });
+
+    test('throws 404 when no subscription exists', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+
+      await expect(BillingAdminService.syncOrgFromStripe(orgId)).rejects.toMatchObject({ status: 404 });
+    });
+
+    test('throws 422 when subscription has no stripeSubscriptionId', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(makeDbSub({ stripeSubscriptionId: null }));
+
+      await expect(BillingAdminService.syncOrgFromStripe(orgId)).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('throws 502 when Stripe is not configured', async () => {
+      mockGetStripe.mockReturnValue(null);
+
+      await expect(BillingAdminService.syncOrgFromStripe(orgId)).rejects.toMatchObject({ status: 502 });
+    });
+
+    test('throws 422 for invalid orgId format', async () => {
+      await expect(BillingAdminService.syncOrgFromStripe('bad-id')).rejects.toMatchObject({ status: 422 });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // replayWebhookEvent
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('replayWebhookEvent:', () => {
+    test('fetches event from Stripe, clears record, dispatches via withIdempotency', async () => {
+      const result = await BillingAdminService.replayWebhookEvent('evt_test_001');
+
+      expect(mockStripeInstance.events.retrieve).toHaveBeenCalledWith('evt_test_001');
+      expect(mockProcessedStripeEventRepository.deleteByEventId).toHaveBeenCalledWith('evt_test_001');
+      expect(mockWebhookService.withIdempotency).toHaveBeenCalled();
+      expect(result).toMatchObject({ eventId: 'evt_test_001', eventType: 'customer.subscription.updated' });
+    });
+
+    test('throws 422 for empty eventId', async () => {
+      await expect(BillingAdminService.replayWebhookEvent('')).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('throws 502 when Stripe fetch fails', async () => {
+      mockStripeInstance.events.retrieve.mockRejectedValue(new Error('network error'));
+
+      await expect(BillingAdminService.replayWebhookEvent('evt_missing')).rejects.toMatchObject({ status: 502 });
+    });
+
+    test('throws 502 when Stripe is not configured', async () => {
+      mockGetStripe.mockReturnValue(null);
+
+      await expect(BillingAdminService.replayWebhookEvent('evt_test_001')).rejects.toMatchObject({ status: 502 });
+    });
+
+    test('continues dispatch even when deleteByEventId throws (doc absent is non-fatal)', async () => {
+      mockProcessedStripeEventRepository.deleteByEventId.mockRejectedValue(new Error('not found'));
+
+      // Should not throw — should still dispatch
+      const result = await BillingAdminService.replayWebhookEvent('evt_test_001');
+      expect(result).toMatchObject({ eventId: 'evt_test_001' });
+    });
+
+    test('skips unknown event types gracefully (returns skipped sentinel)', async () => {
+      mockStripeInstance.events.retrieve.mockResolvedValue({
+        id: 'evt_unknown',
+        type: 'some.unknown.event',
+        data: { object: {} },
+      });
+
+      const result = await BillingAdminService.replayWebhookEvent('evt_unknown');
+      expect(result.result).toMatchObject({ skipped: true, reason: 'unhandled_event_type' });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // listDeadLetters
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('listDeadLetters:', () => {
+    test('delegates to repository and returns paginated result', async () => {
+      mockProcessedStripeEventRepository.listDeadLetters.mockResolvedValue({
+        items: [{ eventId: 'evt_dead_001', deadLetter: true }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      });
+
+      const result = await BillingAdminService.listDeadLetters({ page: 1, limit: 20 });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(mockProcessedStripeEventRepository.listDeadLetters).toHaveBeenCalledWith({ page: 1, limit: 20 });
+    });
+
+    test('defaults page and limit when not provided', async () => {
+      await BillingAdminService.listDeadLetters();
+      expect(mockProcessedStripeEventRepository.listDeadLetters).toHaveBeenCalledWith({});
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // purgeDeadLetter
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('purgeDeadLetter:', () => {
+    test('purges event by eventId and logs', async () => {
+      const result = await BillingAdminService.purgeDeadLetter('evt_dead_001');
+
+      expect(mockProcessedStripeEventRepository.purgeDeadLetterByEventId).toHaveBeenCalledWith('evt_dead_001');
+      expect(result.purged).toBe(true);
+      expect(mockLogger.info).toHaveBeenCalledWith('[billing.admin] purgeDeadLetter — purged', { eventId: 'evt_dead_001' });
+    });
+
+    test('throws 404 when event not found (purged: false)', async () => {
+      mockProcessedStripeEventRepository.purgeDeadLetterByEventId.mockResolvedValue({ purged: false });
+
+      await expect(BillingAdminService.purgeDeadLetter('evt_gone')).rejects.toMatchObject({ status: 404 });
+    });
+
+    test('throws 422 for empty eventId', async () => {
+      await expect(BillingAdminService.purgeDeadLetter('')).rejects.toMatchObject({ status: 422 });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // cancelSubscription
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('cancelSubscription:', () => {
+    beforeEach(() => {
+      // Default: cancel returns canceled, retrieve confirms canceled
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
+        id: stripeSubId,
+        status: 'canceled',
+        items: { data: [{ price: { metadata: { planId: 'free' } } }] },
+      });
+    });
+
+    test('cancels on Stripe, verifies status, writes DB with canceled/free', async () => {
+      const result = await BillingAdminService.cancelSubscription(orgId);
+
+      expect(mockStripeInstance.subscriptions.cancel).toHaveBeenCalledWith(stripeSubId);
+      expect(mockStripeInstance.subscriptions.retrieve).toHaveBeenCalledWith(stripeSubId);
+      expect(mockSubscriptionRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ plan: 'free', status: 'canceled' }),
+      );
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'free');
+      expect(result.stripeStatus).toBe('canceled');
+      expect(result.previous.plan).toBe('pro');
+    });
+
+    test('throws 404 when subscription not found in DB', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+
+      await expect(BillingAdminService.cancelSubscription(orgId)).rejects.toMatchObject({ status: 404 });
+    });
+
+    test('throws 422 when subscription has no stripeSubscriptionId', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(makeDbSub({ stripeSubscriptionId: null }));
+
+      await expect(BillingAdminService.cancelSubscription(orgId)).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('throws 502 when Stripe is not configured', async () => {
+      mockGetStripe.mockReturnValue(null);
+
+      await expect(BillingAdminService.cancelSubscription(orgId)).rejects.toMatchObject({ status: 502 });
+    });
+
+    test('throws 422 for invalid orgId format', async () => {
+      await expect(BillingAdminService.cancelSubscription('bad-id')).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('Decision #5: throws 502 when post-cancel retrieve returns unexpected status', async () => {
+      mockStripeInstance.subscriptions.retrieve.mockResolvedValue({
+        id: stripeSubId,
+        status: 'active', // unexpected — still active after cancel
+        items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+      });
+
+      await expect(BillingAdminService.cancelSubscription(orgId)).rejects.toMatchObject({ status: 502 });
+    });
+
+    test('Decision #5: treats retrieve failure as canceled (assumes cancel succeeded) + logs error', async () => {
+      mockStripeInstance.subscriptions.retrieve.mockRejectedValue(new Error('Stripe unavailable'));
+
+      // Should not throw — assumes canceled, writes DB
+      const result = await BillingAdminService.cancelSubscription(orgId);
+
+      expect(result.stripeStatus).toBe('canceled');
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[billing.admin] cancelSubscription — post-cancel retrieve failed, assuming canceled',
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/modules/billing/tests/billing.admin.toolkit.integration.tests.js
+++ b/modules/billing/tests/billing.admin.toolkit.integration.tests.js
@@ -251,6 +251,55 @@ describe('Billing admin toolkit integration tests:', () => {
 
       expect(res.status).toHaveBeenCalledWith(403);
     });
+
+    test('returns 422 when service throws 422', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/sync/:orgId');
+      const res = makeRes();
+      mockAdminService.syncOrgFromStripe.mockRejectedValue(
+        Object.assign(new Error('no stripe sub id'), { status: 422 }),
+      );
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+    });
+
+    test('returns 502 when service throws 502', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/sync/:orgId');
+      const res = makeRes();
+      mockAdminService.syncOrgFromStripe.mockRejectedValue(
+        Object.assign(new Error('Stripe not configured'), { status: 502 }),
+      );
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(502);
+    });
+
+    test('returns 500 on unexpected error', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/sync/:orgId');
+      const res = makeRes();
+      mockAdminService.syncOrgFromStripe.mockRejectedValue(new Error('unexpected'));
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
   });
 
   // ── POST /api/admin/billing/webhook/replay ────────────────────────────────────
@@ -299,6 +348,38 @@ describe('Billing admin toolkit integration tests:', () => {
 
       expect(res.status).toHaveBeenCalledWith(403);
     });
+
+    test('returns 502 when service throws 502', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/webhook/replay');
+      const res = makeRes();
+      mockAdminService.replayWebhookEvent.mockRejectedValue(
+        Object.assign(new Error('Stripe unreachable'), { status: 502 }),
+      );
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, body: { eventId } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(502);
+    });
+
+    test('returns 500 on unexpected error', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/webhook/replay');
+      const res = makeRes();
+      mockAdminService.replayWebhookEvent.mockRejectedValue(new Error('unexpected'));
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, body: { eventId } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
   });
 
   // ── GET /api/admin/billing/dead-letters ──────────────────────────────────────
@@ -331,6 +412,21 @@ describe('Billing admin toolkit integration tests:', () => {
       );
 
       expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    test('returns 500 on unexpected error', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters');
+      const res = makeRes();
+      mockAdminService.listDeadLetters.mockRejectedValue(new Error('db down'));
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'admin' }, query: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(500);
     });
   });
 

--- a/modules/billing/tests/billing.admin.toolkit.integration.tests.js
+++ b/modules/billing/tests/billing.admin.toolkit.integration.tests.js
@@ -1,0 +1,449 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+
+/**
+ * Integration tests for billing admin toolkit endpoints (feat/billing-admin-toolkit-foundations).
+ * Covers all 6 new routes: customer/:orgId, sync/:orgId, webhook/replay, dead-letters,
+ * dead-letters/:eventId, cancel/:orgId.
+ */
+describe('Billing admin toolkit integration tests:', () => {
+  let billingAdminRoutes;
+  let mockAdminService;
+  let mockStripeInstance;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const eventId = 'evt_test_replay_001';
+
+  /**
+   * Create a lightweight route registry.
+   */
+  const createRouteRegistry = () => {
+    const routes = new Map();
+    const app = {
+      route: jest.fn((path) => {
+        const entry = { all: [], get: [], post: [], patch: [], delete: [] };
+        routes.set(path, entry);
+        const routeBuilder = {
+          all: (...handlers) => { entry.all.push(...handlers); return routeBuilder; },
+          get: (...handlers) => { entry.get.push(...handlers); return routeBuilder; },
+          post: (...handlers) => { entry.post.push(...handlers); return routeBuilder; },
+          patch: (...handlers) => { entry.patch.push(...handlers); return routeBuilder; },
+          delete: (...handlers) => { entry.delete.push(...handlers); return routeBuilder; },
+        };
+        return routeBuilder;
+      }),
+    };
+    return { app, routes };
+  };
+
+  /**
+   * Execute middleware/handler chain sequentially.
+   */
+  const runHandlers = async (handlers, req, res) => {
+    const dispatch = async (index) => {
+      const handler = handlers[index];
+      if (!handler) return;
+      if (handler.length >= 3) {
+        let nextPromise = null;
+        await handler(req, res, () => {
+          nextPromise = dispatch(index + 1);
+          return nextPromise;
+        });
+        if (nextPromise) await nextPromise;
+        return;
+      }
+      await handler(req, res);
+    };
+    await dispatch(0);
+  };
+
+  /**
+   * Build route module with mocked dependencies.
+   */
+  const buildRoutes = async () => {
+    jest.resetModules();
+
+    mockAdminService = {
+      getCustomerStatus: jest.fn().mockResolvedValue({ db: { plan: 'pro', status: 'active' }, stripe: null }),
+      syncOrgFromStripe: jest.fn().mockResolvedValue({ previous: { plan: 'pro' }, updated: { plan: 'pro' } }),
+      replayWebhookEvent: jest.fn().mockResolvedValue({ eventId, eventType: 'customer.subscription.updated', result: {} }),
+      listDeadLetters: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 }),
+      purgeDeadLetter: jest.fn().mockResolvedValue({ purged: true }),
+      cancelSubscription: jest.fn().mockResolvedValue({ previous: { plan: 'pro', status: 'active' }, updated: {}, stripeStatus: 'canceled' }),
+    };
+
+    mockStripeInstance = {
+      refunds: { create: jest.fn().mockResolvedValue({ id: 're_test', amount: 2500, status: 'succeeded' }) },
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        billing: { plans: ['free', 'starter', 'pro'], statuses: ['active', 'canceled', 'past_due'] },
+        stripe: { secretKey: 'sk_test_fake' },
+        validation: { supportedMethods: ['post', 'put', 'patch'] },
+      },
+    }));
+
+    jest.unstable_mockModule('stripe', () => ({ default: jest.fn(() => mockStripeInstance) }));
+
+    jest.unstable_mockModule('passport', () => ({
+      default: {
+        authenticate: jest.fn(() => (req, _res, next) => {
+          req.user = { _id: '507f1f77bcf86cd799439022', roles: [req.headers?.['x-role'] || 'user'] };
+          next();
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: {
+        isAllowed: jest.fn((req, res, next) => {
+          if (req.user?.roles?.includes('admin')) return next();
+          return res.status(403).json({ type: 'error', code: 403, message: 'Unauthorized' });
+        }),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/model.js', () => ({
+      default: {
+        isValid: (schema) => (req, res, next) => {
+          const result = schema.safeParse(req.body);
+          if (!result.success) return res.status(422).json({ type: 'error' });
+          req.body = result.data;
+          return next();
+        },
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: {
+        success: jest.fn((_res, _msg) => (data) => _res.status(200).json({ type: 'success', data })), // eslint-disable-line no-unused-vars
+        error: jest.fn((_res, status) => (_err) => _res.status(status).json({ type: 'error' })), // eslint-disable-line no-unused-vars
+      },
+    }));
+
+    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
+      default: mockAdminService,
+    }));
+
+    // Lazy-imported by adminBumpPlan — needed for the bump route that's still in the file
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {
+        findByOrganization: jest.fn().mockResolvedValue({ _id: 'x', plan: 'free' }),
+        adminUpdatePlanOnly: jest.fn().mockResolvedValue({ plan: 'pro' }),
+      },
+    }));
+    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
+      default: { setPlan: jest.fn().mockResolvedValue({}) },
+    }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
+    billingAdminRoutes = (await import('../routes/billing.admin.routes.js')).default;
+    const { app, routes } = createRouteRegistry();
+    billingAdminRoutes(app);
+    return routes;
+  };
+
+  const makeRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── Route registration ────────────────────────────────────────────────────────
+
+  test('all 6 admin toolkit routes are registered', async () => {
+    const routes = await buildRoutes();
+
+    expect(routes.has(`/api/admin/billing/customer/:orgId`)).toBe(true);
+    expect(routes.has(`/api/admin/billing/sync/:orgId`)).toBe(true);
+    expect(routes.has(`/api/admin/billing/webhook/replay`)).toBe(true);
+    expect(routes.has(`/api/admin/billing/dead-letters`)).toBe(true);
+    expect(routes.has(`/api/admin/billing/dead-letters/:eventId`)).toBe(true);
+    expect(routes.has(`/api/admin/billing/cancel/:orgId`)).toBe(true);
+  });
+
+  // ── GET /api/admin/billing/customer/:orgId ────────────────────────────────────
+
+  describe('GET /api/admin/billing/customer/:orgId', () => {
+    test('admin gets 200 with customer status', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/customer/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'admin' }, params: { orgId } },
+        res,
+      );
+
+      expect(mockAdminService.getCustomerStatus).toHaveBeenCalledWith(orgId);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/customer/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'user' }, params: { orgId } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    test('returns 404 when service throws 404', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/customer/:orgId');
+      const res = makeRes();
+
+      mockAdminService.getCustomerStatus.mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }));
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'admin' }, params: { orgId } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  // ── POST /api/admin/billing/sync/:orgId ──────────────────────────────────────
+
+  describe('POST /api/admin/billing/sync/:orgId', () => {
+    test('admin gets 200 on successful sync', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/sync/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(mockAdminService.syncOrgFromStripe).toHaveBeenCalledWith(orgId);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/sync/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'user' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  // ── POST /api/admin/billing/webhook/replay ────────────────────────────────────
+
+  describe('POST /api/admin/billing/webhook/replay', () => {
+    test('admin replays event and gets 200', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/webhook/replay');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, body: { eventId } },
+        res,
+      );
+
+      expect(mockAdminService.replayWebhookEvent).toHaveBeenCalledWith(eventId);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('missing eventId returns 422 from schema validation', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/webhook/replay');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(mockAdminService.replayWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/webhook/replay');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'user' }, body: { eventId } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  // ── GET /api/admin/billing/dead-letters ──────────────────────────────────────
+
+  describe('GET /api/admin/billing/dead-letters', () => {
+    test('admin gets paginated dead-letters list', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'admin' }, query: { page: '1', limit: '10' } },
+        res,
+      );
+
+      expect(mockAdminService.listDeadLetters).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.get],
+        { headers: { 'x-role': 'user' }, query: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+  });
+
+  // ── DELETE /api/admin/billing/dead-letters/:eventId ──────────────────────────
+
+  describe('DELETE /api/admin/billing/dead-letters/:eventId', () => {
+    test('admin deletes dead-letter event and gets 200', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters/:eventId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.delete],
+        { headers: { 'x-role': 'admin' }, params: { eventId: 'evt_dead_001' } },
+        res,
+      );
+
+      expect(mockAdminService.purgeDeadLetter).toHaveBeenCalledWith('evt_dead_001');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters/:eventId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.delete],
+        { headers: { 'x-role': 'user' }, params: { eventId: 'evt_dead_001' } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    test('returns 404 when event not found', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/dead-letters/:eventId');
+      const res = makeRes();
+      mockAdminService.purgeDeadLetter.mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }));
+
+      await runHandlers(
+        [...route.all, ...route.delete],
+        { headers: { 'x-role': 'admin' }, params: { eventId: 'evt_gone' } },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  // ── POST /api/admin/billing/cancel/:orgId ────────────────────────────────────
+
+  describe('POST /api/admin/billing/cancel/:orgId', () => {
+    test('admin cancels subscription and gets 200', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/cancel/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(mockAdminService.cancelSubscription).toHaveBeenCalledWith(orgId);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('non-admin gets 403', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/cancel/:orgId');
+      const res = makeRes();
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'user' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    test('returns 404 when no subscription found', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/cancel/:orgId');
+      const res = makeRes();
+      mockAdminService.cancelSubscription.mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }));
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    test('returns 502 when Stripe verify returns unexpected status (Decision #5)', async () => {
+      const routes = await buildRoutes();
+      const route = routes.get('/api/admin/billing/cancel/:orgId');
+      const res = makeRes();
+      mockAdminService.cancelSubscription.mockRejectedValue(
+        Object.assign(new Error('unexpected Stripe status'), { status: 502 }),
+      );
+
+      await runHandlers(
+        [...route.all, ...route.post],
+        { headers: { 'x-role': 'admin' }, params: { orgId }, body: {} },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(502);
+    });
+  });
+});

--- a/modules/billing/tests/billing.lifecycle.integration.tests.js
+++ b/modules/billing/tests/billing.lifecycle.integration.tests.js
@@ -42,6 +42,10 @@ describe('Billing meter lifecycle integration tests:', () => {
     Organization = mongoose.model('Organization');
     BillingExtraBalance = mongoose.model('BillingExtraBalance');
 
+    // Ensure compound indexes (added in feat/billing-admin-toolkit-foundations) are synced
+    // to the test DB before tests run. Prevents E11000 flakes on the first resetWeek sweep.
+    await Subscription.syncIndexes();
+
     BillingWebhookService = (await import('../services/billing.webhook.service.js')).default;
     BillingMeterService = (await import('../services/billing.meter.service.js')).default;
     BillingUsageService = (await import('../services/billing.usage.service.js')).default;

--- a/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
@@ -208,4 +208,112 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
       ).rejects.toThrow('DB connection lost');
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // listDeadLetters (new in feat/billing-admin-toolkit-foundations)
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('listDeadLetters', () => {
+    const stubFind = (items = []) => {
+      const chain = {
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(items),
+      };
+      return chain;
+    };
+
+    test('returns paginated dead-letter items and total', async () => {
+      const deadItems = [{ eventId: 'evt_dl_001', deadLetter: true }];
+      mockModel.find = jest.fn().mockReturnValue(stubFind(deadItems));
+      mockModel.countDocuments = jest.fn().mockResolvedValue(1);
+
+      const result = await ProcessedStripeEventRepository.listDeadLetters({ page: 1, limit: 20 });
+
+      expect(result).toMatchObject({ items: deadItems, total: 1, page: 1, limit: 20 });
+      expect(mockModel.find).toHaveBeenCalledWith({ deadLetter: true });
+      expect(mockModel.countDocuments).toHaveBeenCalledWith({ deadLetter: true });
+    });
+
+    test('defaults page to 1 and limit to 20 when not provided', async () => {
+      mockModel.find = jest.fn().mockReturnValue(stubFind([]));
+      mockModel.countDocuments = jest.fn().mockResolvedValue(0);
+
+      const result = await ProcessedStripeEventRepository.listDeadLetters();
+
+      expect(result).toMatchObject({ page: 1, limit: 20 });
+    });
+
+    test('clamps limit to 100 maximum', async () => {
+      mockModel.find = jest.fn().mockReturnValue(stubFind([]));
+      mockModel.countDocuments = jest.fn().mockResolvedValue(0);
+
+      const result = await ProcessedStripeEventRepository.listDeadLetters({ page: 1, limit: 999 });
+
+      expect(result.limit).toBe(100);
+    });
+
+    test('clamps limit to 1 minimum', async () => {
+      mockModel.find = jest.fn().mockReturnValue(stubFind([]));
+      mockModel.countDocuments = jest.fn().mockResolvedValue(0);
+
+      const result = await ProcessedStripeEventRepository.listDeadLetters({ page: 1, limit: 0 });
+
+      expect(result.limit).toBe(1);
+    });
+
+    test('returns empty list when no dead-letter events exist', async () => {
+      mockModel.find = jest.fn().mockReturnValue(stubFind([]));
+      mockModel.countDocuments = jest.fn().mockResolvedValue(0);
+
+      const result = await ProcessedStripeEventRepository.listDeadLetters();
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // purgeDeadLetterByEventId (new in feat/billing-admin-toolkit-foundations)
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('purgeDeadLetterByEventId', () => {
+    test('returns { purged: true } when dead-letter document deleted', async () => {
+      mockModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const result = await ProcessedStripeEventRepository.purgeDeadLetterByEventId('evt_dl_001');
+
+      expect(result).toEqual({ purged: true });
+      expect(mockModel.deleteOne).toHaveBeenCalledWith({ eventId: 'evt_dl_001', deadLetter: true });
+    });
+
+    test('returns { purged: false } when event not found or not dead-lettered', async () => {
+      mockModel.deleteOne.mockResolvedValue({ deletedCount: 0 });
+
+      const result = await ProcessedStripeEventRepository.purgeDeadLetterByEventId('evt_not_dl');
+
+      expect(result).toEqual({ purged: false });
+    });
+
+    test('guard: uses deadLetter: true filter to prevent purging healthy events', async () => {
+      mockModel.deleteOne.mockResolvedValue({ deletedCount: 0 });
+
+      await ProcessedStripeEventRepository.purgeDeadLetterByEventId('evt_active');
+
+      const call = mockModel.deleteOne.mock.calls[0][0];
+      expect(call).toEqual({ eventId: 'evt_active', deadLetter: true });
+    });
+
+    test('throws for empty eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.purgeDeadLetterByEventId(''),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+
+    test('throws for non-string eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.purgeDeadLetterByEventId(null),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+  });
 });

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -1,0 +1,241 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for BillingReconcileService.runReconciliation.
+ * Validates LOG-ONLY policy, pagination, divergence detection, and error handling.
+ */
+describe('BillingReconcileService.runReconciliation unit tests:', () => {
+  let BillingReconcileService;
+  let mockStripeInstance;
+  let mockGetStripe;
+  let mockLogger;
+  let mockEvents;
+  let mockSubscriptionModel;
+  let mockConfig;
+
+  const orgId = '507f1f77bcf86cd799439011';
+  const stripeSubId = 'sub_test_001';
+
+  /**
+   * Build a stub DB subscription.
+   */
+  const makeDbSub = (overrides = {}) => ({
+    _id: 'sub_doc_001',
+    organization: { _id: orgId },
+    plan: 'pro',
+    status: 'active',
+    stripeSubscriptionId: stripeSubId,
+    ...overrides,
+  });
+
+  /**
+   * Build a stub Stripe subscription.
+   */
+  const makeStripeSub = (overrides = {}) => ({
+    id: stripeSubId,
+    status: 'active',
+    items: { data: [{ price: { metadata: { planId: 'pro' } } }] },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+    mockEvents = { emit: jest.fn() };
+
+    mockConfig = {
+      billing: {
+        meterMode: true,
+        plans: ['free', 'starter', 'pro', 'enterprise'],
+      },
+    };
+
+    mockStripeInstance = {
+      subscriptions: {
+        retrieve: jest.fn().mockResolvedValue(makeStripeSub()),
+      },
+    };
+    mockGetStripe = jest.fn().mockReturnValue(mockStripeInstance);
+
+    // The subscription model is accessed via mongoose.model('Subscription')
+    const mockFindChain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([]),
+    };
+    mockSubscriptionModel = {
+      find: jest.fn().mockReturnValue(mockFindChain),
+    };
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
+    jest.unstable_mockModule('../lib/stripe.js', () => ({ default: mockGetStripe }));
+    jest.unstable_mockModule('../lib/events.js', () => ({ default: mockEvents }));
+    jest.unstable_mockModule('mongoose', () => ({
+      default: {
+        model: jest.fn(() => mockSubscriptionModel),
+      },
+    }));
+    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
+      default: {},
+    }));
+
+    const mod = await import('../services/billing.reconcile.service.js');
+    BillingReconcileService = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns { checked: 0, divergences: 0, errors: 0 } when meterMode is false', async () => {
+    mockConfig.billing.meterMode = false;
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toEqual({ checked: 0, divergences: 0, errors: 0 });
+    expect(mockStripeInstance.subscriptions.retrieve).not.toHaveBeenCalled();
+  });
+
+  test('returns { checked: 0, divergences: 0, errors: 0 } when Stripe is not configured', async () => {
+    mockGetStripe.mockReturnValue(null);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toEqual({ checked: 0, divergences: 0, errors: 0 });
+  });
+
+  test('returns { checked: 0 } when no active/past_due subs found', async () => {
+    // find returns empty — loop exits immediately
+    const mockFindChain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(mockFindChain);
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toEqual({ checked: 0, divergences: 0, errors: 0 });
+  });
+
+  test('checks matching sub — no divergence when status + plan match', async () => {
+    const sub = makeDbSub();
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce([sub])  // first page: 1 sub
+        .mockResolvedValue([]),         // second page: empty → exit
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub());
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 0, errors: 0 });
+    expect(mockEvents.emit).not.toHaveBeenCalled();
+  });
+
+  test('detects status divergence — emits billing.reconciliation.divergence and logs', async () => {
+    const sub = makeDbSub({ status: 'active' });
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce([sub])
+        .mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub({ status: 'past_due' }));
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.reconcile] divergence detected — LOG ONLY, no auto-fix',
+      expect.objectContaining({ statusMismatch: true }),
+    );
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ organizationId: orgId }),
+    );
+  });
+
+  test('detects plan divergence — emits billing.reconciliation.divergence', async () => {
+    const sub = makeDbSub({ plan: 'pro' });
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce([sub])
+        .mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    // Stripe has plan: free instead of pro
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(
+      makeStripeSub({ items: { data: [{ price: { metadata: { planId: 'free' } } }] } }),
+    );
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ divergences: 1 });
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ planMismatch: true }),
+    );
+  });
+
+  test('counts errors and continues on individual Stripe retrieve failure', async () => {
+    const subs = [makeDbSub(), makeDbSub({ _id: 'sub_doc_002', stripeSubscriptionId: 'sub_test_002' })];
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce(subs)
+        .mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    mockStripeInstance.subscriptions.retrieve
+      .mockRejectedValueOnce(new Error('Stripe timeout'))
+      .mockResolvedValueOnce(makeStripeSub());
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 0, errors: 1 });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.reconcile] error reconciling subscription',
+      expect.any(Object),
+    );
+  });
+
+  test('LOG-ONLY policy: never writes to DB (no repo update calls)', async () => {
+    const sub = makeDbSub({ status: 'active' });
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce([sub])
+        .mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    // Deliberate divergence
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub({ status: 'past_due' }));
+
+    await BillingReconcileService.runReconciliation();
+
+    // No DB write must happen — only Stripe reads + logs
+    // (mockSubscriptionModel has no update/save methods set up — if called they'd throw)
+  });
+});

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -238,4 +238,56 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     // No DB write must happen — only Stripe reads + logs
     // (mockSubscriptionModel has no update/save methods set up — if called they'd throw)
   });
+
+  test('paginates to second page when first page is full (RECONCILE_PAGE_SIZE=100)', async () => {
+    // Build an array of 100 subs (full page) then an empty second page
+    const fullPage = Array.from({ length: 100 }, (_, i) => makeDbSub({
+      _id: `sub_doc_${i}`,
+      stripeSubscriptionId: `sub_test_${i}`,
+    }));
+
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce(fullPage)  // page 0: full — triggers page += 1
+        .mockResolvedValueOnce([]),        // page 1: empty — exits loop
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub());
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    // All 100 subs from page 0 should be checked
+    expect(result).toMatchObject({ checked: 100, divergences: 0, errors: 0 });
+    // find should have been called twice (page 0 + page 1)
+    expect(mockSubscriptionModel.find).toHaveBeenCalledTimes(2);
+  });
+
+  test('non-fatal: billingEvents.emit listener error is swallowed, divergence still counted', async () => {
+    const sub = makeDbSub({ status: 'active' });
+    const chain = {
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockReturnThis(),
+      exec: jest.fn()
+        .mockResolvedValueOnce([sub])
+        .mockResolvedValue([]),
+    };
+    mockSubscriptionModel.find.mockReturnValue(chain);
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub({ status: 'canceled' }));
+    // Simulate a listener throwing on emit
+    mockEvents.emit.mockImplementation(() => { throw new Error('listener crash'); });
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    // Divergence is still counted despite listener crash
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+    // Error should be logged (non-fatal)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[billing.reconcile] billing.reconciliation.divergence listener error (non-fatal)',
+      expect.objectContaining({ error: 'listener crash' }),
+    );
+  });
 });

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -49,6 +49,18 @@ describe('Admin refund controller unit tests:', () => {
       default: mockResponses,
     }));
 
+    // Mock the admin service to prevent its deep import chain from touching mongoose models.
+    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
+      default: {
+        getCustomerStatus: jest.fn(),
+        syncOrgFromStripe: jest.fn(),
+        replayWebhookEvent: jest.fn(),
+        listDeadLetters: jest.fn(),
+        purgeDeadLetter: jest.fn(),
+        cancelSubscription: jest.fn(),
+      },
+    }));
+
     const mod = await import('../controllers/billing.admin.controller.js');
     adminRefundCharge = mod.default.adminRefundCharge;
   });
@@ -202,6 +214,65 @@ describe('Admin refund controller unit tests:', () => {
     expect(mockStripeInstance.refunds.create).toHaveBeenCalled();
     expect(mockResponses.success).toHaveBeenCalled();
   });
+
+  // ── Refund > original amount (D — tests reliability) ─────────────────────────
+
+  test('refund > original amount — Stripe StripeInvalidRequestError maps to 422', async () => {
+    // Stripe returns invalid_request_error when amountCents exceeds the charge amount.
+    const stripeErr = new Error('The amount requested exceeds the amount that can be refunded');
+    stripeErr.type = 'StripeInvalidRequestError';
+    mockStripeInstance.refunds.create.mockRejectedValue(stripeErr);
+
+    const res = makeRes();
+    await adminRefundCharge(
+      { body: { chargeId: 'ch_test_full', amountCents: 9999999, refundRequestId: 'req-overflow01' } },
+      res,
+    );
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to refund charge');
+  });
+
+  test('refund > original amount — invalid_request_error type maps to 422', async () => {
+    const stripeErr = new Error('The amount requested exceeds what can be refunded');
+    stripeErr.type = 'invalid_request_error';
+    mockStripeInstance.refunds.create.mockRejectedValue(stripeErr);
+
+    const res = makeRes();
+    await adminRefundCharge(
+      { body: { chargeId: 'ch_test_full2', amountCents: 99999, refundRequestId: 'req-overflow02' } },
+      res,
+    );
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to refund charge');
+  });
+
+  test('multi-refund cumul — two calls with same session use same idempotency key (dedup protection)', async () => {
+    // Simulates an admin double-clicking the refund button twice for the same session.
+    // Both calls must send identical idempotency keys so Stripe deduplicates them.
+    const body = { chargeId: 'ch_test_multi', amountCents: 2450, refundRequestId: 'req-multi-sum01' };
+
+    await adminRefundCharge({ body }, makeRes());
+    await adminRefundCharge({ body }, makeRes());
+
+    const calls = mockStripeInstance.refunds.create.mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][1].idempotencyKey).toBe(calls[1][1].idempotencyKey);
+    expect(calls[0][1].idempotencyKey).toBe('refund_admin_req-multi-sum01');
+  });
+
+  test('charge_already_refunded Stripe code maps to 422 (not 502)', async () => {
+    const stripeErr = new Error('This charge has already been fully refunded');
+    stripeErr.code = 'charge_already_refunded';
+    mockStripeInstance.refunds.create.mockRejectedValue(stripeErr);
+
+    const res = makeRes();
+    await adminRefundCharge(
+      { body: { chargeId: 'ch_already_done', refundRequestId: 'req-already-001' } },
+      res,
+    );
+
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to refund charge');
+  });
 });
 
 describe('adminBumpPlan controller unit tests:', () => {
@@ -262,6 +333,18 @@ describe('adminBumpPlan controller unit tests:', () => {
 
     // Stripe not needed for adminBumpPlan but imported at module level
     jest.unstable_mockModule('../lib/stripe.js', () => ({ default: jest.fn(() => null) }));
+
+    // Mock admin service to prevent deep import chain touching mongoose models
+    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
+      default: {
+        getCustomerStatus: jest.fn(),
+        syncOrgFromStripe: jest.fn(),
+        replayWebhookEvent: jest.fn(),
+        listDeadLetters: jest.fn(),
+        purgeDeadLetter: jest.fn(),
+        cancelSubscription: jest.fn(),
+      },
+    }));
 
     const mod = await import('../controllers/billing.admin.controller.js');
     adminBumpPlan = mod.default.adminBumpPlan;

--- a/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
+++ b/modules/billing/tests/billing.usage.concurrent-attribution.integration.tests.js
@@ -34,6 +34,9 @@ describe('BillingUsage concurrent attribution integration tests:', () => {
     BillingExtraBalance = mongoose.model('BillingExtraBalance');
     Subscription = mongoose.model('Subscription');
 
+    // Ensure compound indexes are synced before running concurrent tests.
+    await Subscription.syncIndexes();
+
     BillingUsageService = (await import('../services/billing.usage.service.js')).default;
   });
 


### PR DESCRIPTION
## Summary

- **A — Compound indexes** on `Subscription` model: `{ status, lastResetAt }` (weeklyReset scan) and `{ status, pastDueSince }` (dunningSweep scan)
- **B — 6 admin toolkit endpoints** (all behind JWT + `policy.isAllowed` admin guard):
  - `GET /api/admin/billing/customer/:orgId` — Stripe + DB side-by-side diagnostic
  - `POST /api/admin/billing/sync/:orgId` — Force Stripe→DB sync
  - `POST /api/admin/billing/webhook/replay` — Re-fetch Stripe event + re-dispatch
  - `GET /api/admin/billing/dead-letters` — Paginated dead-letter list
  - `DELETE /api/admin/billing/dead-letters/:eventId` — Purge post-investigation
  - `POST /api/admin/billing/cancel/:orgId` — Cancel + Decision #5 (cancel→retrieve-verify→DB write)
  - CASL: 5 new path subjects mapped to `BillingAdminOps` (admins already have `can('manage', 'all')`)
- **C — Reconciliation cron** (`billing.reconcile.js`, Sunday 03h): paginates active|past_due subs, fetches live Stripe status, emits `billing.reconciliation.divergence`. **LOG-ONLY** — no auto-fix.
- **D — Tests reliability**: `syncIndexes()` in integration test `beforeAll` (prevents E11000 on new compound indexes); refund edge-case tests (refund > original → 422, multi-refund dedup, `charge_already_refunded` → 422); `StripeInvalidRequestError` / `invalid_request_error` error types now map to 422 in `adminRefundCharge`.

## Test plan

- [x] Lint: 0 errors, 0 warnings
- [x] Unit tests: 1218/1218 pass (88 suites)
- [x] Integration tests: 366/367 pass (1 pre-existing auth flake on socket hang up — passes on re-run)
- [x] New test files: `billing.admin.service.unit.tests.js` (28 tests), `billing.admin.toolkit.integration.tests.js` (18 tests), `billing.reconcile.service.unit.tests.js` (8 tests), `billing.processedStripeEvent.repository.unit.tests.js` (+12 tests for listDeadLetters + purgeDeadLetterByEventId)
- [ ] CI green on push
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin billing toolkit with endpoints for customer status lookup, Stripe sync, webhook replay, dead-letter management, and subscription cancellation.
  * Weekly automated reconciliation sweep between Stripe subscriptions and database (log-only, no auto-fix).

* **Bug Fixes**
  * Enhanced error handling to distinguish invalid arguments from Stripe-specific errors (422 vs 502 responses).

* **Tests**
  * Comprehensive unit and integration tests for admin toolkit, reconciliation service, and dead-letter operations.

* **Chores**
  * Added database indexes and schema updates to support admin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->