### PR TITLE
feat(billing): hygiene polish — stack trace, req.id, $slice ledger, TTL archived, cache utils

### DIFF
--- a/modules/billing/controllers/billing.webhook.controller.js
+++ b/modules/billing/controllers/billing.webhook.controller.js
@@ -22,6 +22,9 @@ const handleWebhook = async (req, res) => {
 
   const sig = req.headers['stripe-signature'];
   const { webhookSecret } = config.stripe;
+  // req.id is injected by the global requestId middleware (lib/middlewares/requestId.js).
+  // Propagate it through to enable end-to-end traceability across webhook log lines.
+  const requestId = req.id;
 
   let event;
   try {
@@ -30,70 +33,83 @@ const handleWebhook = async (req, res) => {
     return responses.error(res, 400, 'Bad Request', 'Webhook signature verification failed')(err);
   }
 
+  logger.info('[billing.webhook] received', { type: event.type, id: event.id, requestId });
+
   try {
     switch (event.type) {
       case 'checkout.session.completed':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleCheckoutSessionCompleted(e),
+          { requestId },
         );
         break;
       case 'customer.subscription.created':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleSubscriptionCreated(e.data.object, e),
+          { requestId },
         );
         break;
       case 'customer.subscription.updated':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleSubscriptionUpdated(e.data.object, e),
+          { requestId },
         );
         break;
       case 'customer.subscription.deleted':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleSubscriptionDeleted(e.data.object, e),
+          { requestId },
         );
         break;
       case 'invoice.payment_failed':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleInvoicePaymentFailed(e.data.object, e),
+          { requestId },
         );
         break;
       case 'invoice.payment_succeeded':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleInvoicePaymentSucceeded(e.data.object, e),
+          { requestId },
         );
         break;
       case 'charge.refunded':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleChargeRefunded(e.data.object),
+          { requestId },
         );
         break;
       case 'customer.deleted':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleCustomerDeleted(e.data.object, e),
+          { requestId },
         );
         break;
       case 'charge.dispute.created':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleChargeDisputeCreated(e.data.object, e),
+          { requestId },
         );
         break;
       case 'charge.dispute.funds_withdrawn':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleChargeDisputeFundsWithdrawn(e.data.object, e),
+          { requestId },
         );
         break;
       case 'charge.dispute.funds_reinstated':
         await BillingWebhookService.withIdempotency(event, (e) =>
           BillingWebhookService.handleChargeDisputeFundsReinstated(e.data.object, e),
+          { requestId },
         );
         break;
       default:
-        logger.info('[billing.webhook] unhandled event type', { type: event.type, id: event.id });
+        logger.info('[billing.webhook] unhandled event type', { type: event.type, id: event.id, requestId });
         break;
     }
     return res.status(200).json({ received: true });
   } catch (err) {
-    logger.error('Stripe webhook handler error:', err);
+    logger.error('[billing.webhook] handler error', { error: err?.message ?? String(err), stack: err?.stack, requestId });
     return responses.error(res, 500, 'Internal Server Error', 'Webhook handler failed')(err);
   }
 };

--- a/modules/billing/lib/billing.constants.js
+++ b/modules/billing/lib/billing.constants.js
@@ -23,17 +23,10 @@ export const DEFAULT_GRACE_PERIOD_DAYS = 7;
 export const DEFAULT_DUNNING_THRESHOLD_DAYS = 14;
 
 /**
- * Floor charge per run. `runBaseUnits` is kept as a backward-compatible alias
- * for downstream projects that already adopted the earlier config name.
- */
-export const METER_RUN_BASE =
-  config?.billing?.meter?.runBase
-  ?? config?.billing?.meter?.runBaseUnits
-  ?? DEFAULT_METER_RUN_BASE;
-
-/**
  * @function getMeterRunBase
  * @description Resolve the configured base units charged when no costs are present.
+ *              Evaluated lazily on each call so test overrides and runtime config
+ *              changes are always reflected (avoids the stale module-scope const pattern).
  * @returns {number} Meter run base units.
  */
 export const getMeterRunBase = () =>

--- a/modules/billing/models/billing.usage.model.mongoose.js
+++ b/modules/billing/models/billing.usage.model.mongoose.js
@@ -138,6 +138,28 @@ UsageMongoose.index(
 UsageMongoose.index({ organizationId: 1, weekKey: 1 }, { unique: true, sparse: true });
 
 /**
+ * TTL index: automatically purge archived usage documents after 1 year.
+ *
+ * Conditional on archivedAt being set (non-null) — active (non-archived) documents
+ * are excluded from this TTL via partialFilterExpression, so only past periods are
+ * eligible for purge. The 1-year retention keeps the audit trail long enough for
+ * billing reconciliation while preventing unbounded collection growth.
+ *
+ * Notes:
+ *   - The TTL daemon runs once per minute; actual deletion may lag by up to ~1min.
+ *   - Verify this index with: db.billingusages.getIndexes() — look for expireAfterSeconds.
+ *   - archivedAt is set by archiveOtherWeeks() in the usage repository when the
+ *     weekly reset sweep moves old weeks to the archive state.
+ */
+UsageMongoose.index(
+  { archivedAt: 1 },
+  {
+    expireAfterSeconds: 365 * 24 * 60 * 60,
+    partialFilterExpression: { archivedAt: { $type: 'date' } },
+  },
+);
+
+/**
  * Returns the hex string representation of the document ObjectId.
  * @returns {string} Hex string of the ObjectId.
  */

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -288,13 +288,14 @@ const listLedgerPage = async (orgId, skip, limit) => {
       $project: {
         _id: 0,
         cachedBalance: 1,
-        total: { $size: '$ledger' },
-        // Sort descending by `at` then slice the requested page
+        total: { $size: { $ifNull: ['$ledger', []] } },
+        // Sort descending by `at` then slice the requested page.
+        // $ifNull guards against missing/null ledger field on legacy docs.
         ledgerPage: {
           $slice: [
             {
               $sortArray: {
-                input: '$ledger',
+                input: { $ifNull: ['$ledger', []] },
                 sortBy: { at: -1 },
               },
             },

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -258,6 +258,59 @@ const getBalance = async (orgId) => {
 };
 
 /**
+ * @function listLedgerPage
+ * @description Return a paginated slice of the ledger array for an organization using
+ *              MongoDB aggregation `$slice` — only the requested page is transferred over the
+ *              wire, avoiding full-document fetches for large ledgers (1000+ entries).
+ *
+ *              Entries are sorted descending by `at` (newest first) at the aggregation layer.
+ *              The aggregation pipeline is:
+ *                1. $match   — find the org's document
+ *                2. $project — sort + slice the ledger, plus cachedBalance and _id=0
+ *
+ *              Returns null when no document exists for the org yet (balance = 0).
+ *
+ * @param {string} orgId - The organization ObjectId (string).
+ * @param {number} skip - Number of entries to skip (0-based).
+ * @param {number} limit - Maximum number of entries to return.
+ * @returns {Promise<{ledgerPage: Object[], total: number, cachedBalance: number}|null>}
+ *   null when the org has no ExtraBalance document.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const listLedgerPage = async (orgId, skip, limit) => {
+  if (!isValidOrgId(orgId)) return null;
+  if (!Number.isFinite(skip) || skip < 0) throw new TypeError('skip must be a non-negative number');
+  if (!Number.isFinite(limit) || limit <= 0) throw new TypeError('limit must be a positive number');
+
+  const results = await BillingExtraBalance().aggregate([
+    { $match: { organization: new mongoose.Types.ObjectId(orgId) } },
+    {
+      $project: {
+        _id: 0,
+        cachedBalance: 1,
+        total: { $size: '$ledger' },
+        // Sort descending by `at` then slice the requested page
+        ledgerPage: {
+          $slice: [
+            {
+              $sortArray: {
+                input: '$ledger',
+                sortBy: { at: -1 },
+              },
+            },
+            skip,
+            limit,
+          ],
+        },
+      },
+    },
+  ]).exec();
+
+  if (!results || results.length === 0) return null;
+  return results[0];
+};
+
+/**
  * @function findOrgsWithExpiringTopups
  * @description Return the distinct organizationIds that have at least one topup ledger entry
  *              with `expiresAt < now` for which no matching expiration entry (`kind: 'expiration'`
@@ -308,5 +361,6 @@ export default {
   addExpirationEntries,
   refundPartial,
   getBalance,
+  listLedgerPage,
   findOrgsWithExpiringTopups,
 };

--- a/modules/billing/repositories/billing.processedStripeEvent.repository.js
+++ b/modules/billing/repositories/billing.processedStripeEvent.repository.js
@@ -104,20 +104,37 @@ const deleteByEventId = async (eventId) => {
  * @function incrementAttempts
  * @description Atomically increment the attempts counter and record the last error details
  *              on the processed event document. Used by withIdempotency to track retry depth.
+ *              Stores the full stack trace when available (err.stack), falling back to the
+ *              message string — provides full context for ops investigation of dead-letters.
  * @param {string} eventId - Stripe event ID.
- * @param {string} errorMessage - Error message from the last failed handler execution.
+ * @param {string|Error} errorOrMessage - Error object (preferred) or message string from the
+ *   last failed handler execution. When an Error is passed, err.stack is persisted; otherwise
+ *   the string value is stored as-is.
  * @returns {Promise<Object|null>} Updated document or null if not found.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
-const incrementAttempts = async (eventId, errorMessage) => {
+const incrementAttempts = async (eventId, errorOrMessage) => {
   if (typeof eventId !== 'string' || eventId.trim() === '') {
     throw new Error('invalid argument: eventId must be a non-empty string');
+  }
+  // Persist stack trace when available — provides full context for ops investigation.
+  // Falls back gracefully for non-Error throws (string, plain object, etc.).
+  // JSON.stringify for plain objects avoids the uninformative "[object Object]" fallback.
+  let lastError;
+  if (errorOrMessage instanceof Error) {
+    lastError = errorOrMessage.stack || errorOrMessage.message || String(errorOrMessage);
+  } else if (errorOrMessage === null || errorOrMessage === undefined) {
+    lastError = '';
+  } else if (typeof errorOrMessage === 'object') {
+    try { lastError = JSON.stringify(errorOrMessage); } catch { lastError = String(errorOrMessage); }
+  } else {
+    lastError = String(errorOrMessage);
   }
   return ProcessedStripeEvent().findOneAndUpdate(
     { eventId },
     {
       $inc: { attempts: 1 },
-      $set: { lastError: String(errorMessage ?? ''), lastErrorAt: new Date() },
+      $set: { lastError, lastErrorAt: new Date() },
     },
     { returnDocument: 'after' },
   ).exec();

--- a/modules/billing/services/billing.extra.service.js
+++ b/modules/billing/services/billing.extra.service.js
@@ -216,6 +216,10 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents, packId
  * @description Return a paginated slice of the ledger for an organization.
  *              Entries are returned in reverse chronological order (newest first).
  *
+ *              Uses MongoDB aggregation `$slice` via the repository so only the
+ *              requested page is transferred over the wire — avoids loading the full
+ *              ledger array into memory on large accounts (1000+ entries).
+ *
  * @param {string} orgId - The organization ObjectId (string).
  * @param {Object} [options={}] - Pagination options.
  * @param {number} [options.page=1] - 1-based page number.
@@ -224,17 +228,18 @@ const refundPartial = async (orgId, stripeSessionId, amountRefundedCents, packId
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const listLedger = async (orgId, { page = 1, limit = 20 } = {}) => {
-  const doc = await BillingExtraBalanceRepository.getOrCreate(orgId);
-  if (!doc) return { entries: [], total: 0, balance: 0 };
-  const ledger = doc.ledger ?? [];
-  const total = ledger.length;
+  const safePage = Math.max(1, Math.floor(Number(page)) || 1);
+  const safeLimit = Math.max(1, Math.floor(Number(limit)) || 20);
+  const skip = (safePage - 1) * safeLimit;
 
-  // Sort descending by at date
-  const sorted = [...ledger].sort((a, b) => new Date(b.at) - new Date(a.at));
-  const start = (page - 1) * limit;
-  const entries = sorted.slice(start, start + limit);
+  const result = await BillingExtraBalanceRepository.listLedgerPage(orgId, skip, safeLimit);
+  if (!result) return { entries: [], total: 0, balance: 0 };
 
-  return { entries, total, balance: doc.cachedBalance ?? 0 };
+  return {
+    entries: result.ledgerPage ?? [],
+    total: result.total ?? 0,
+    balance: result.cachedBalance ?? 0,
+  };
 };
 
 export default {

--- a/modules/billing/services/billing.meter.service.js
+++ b/modules/billing/services/billing.meter.service.js
@@ -9,10 +9,7 @@ import {
   getMeterRunBase,
   getDollarsToUnitRatio,
   getMaxUnitsPerOperation,
-  METER_RUN_BASE,
 } from '../lib/billing.constants.js';
-
-export { METER_RUN_BASE };
 
 /**
  * @function unitsFromCosts
@@ -237,5 +234,5 @@ export default {
   unitsFromCosts,
   attribute,
   capBreakdown,
-  METER_RUN_BASE,
+  getMeterRunBase,
 };

--- a/modules/billing/services/billing.plans.service.js
+++ b/modules/billing/services/billing.plans.service.js
@@ -64,8 +64,14 @@ const fetchPlansFromStripe = async (stripe) => {
     pricesByProduct[price.product].push(price);
   }
 
+  // Build reverse-lookup: priceId → [planId, ...] to detect price ID reuse across plans.
+  // A Stripe price ID mapped to multiple plans is a configuration error that causes silent
+  // billing misrouting — warn explicitly with both plan IDs + the duplicate price ID.
+  const priceIdToPlanIds = {};
+
   const plans = products.map((product) => {
     const productPrices = pricesByProduct[product.id] || [];
+    const planId = product.metadata?.planId || product.id;
 
     let monthlyPrice = 0;
     let annualPrice = 0;
@@ -82,10 +88,15 @@ const fetchPlansFromStripe = async (stripe) => {
         annualPrice = amount / 100;
         stripePriceAnnual = price.id;
       }
+      // Track price-to-plan mapping for duplicate detection
+      if (price.id) {
+        if (!priceIdToPlanIds[price.id]) priceIdToPlanIds[price.id] = [];
+        priceIdToPlanIds[price.id].push(planId);
+      }
     }
 
     return {
-      planId: product.metadata?.planId || product.id,
+      planId,
       name: product.name,
       monthlyPrice,
       annualPrice,
@@ -93,6 +104,17 @@ const fetchPlansFromStripe = async (stripe) => {
       stripePriceAnnual,
     };
   });
+
+  // Emit explicit warn for any Stripe price ID mapped to more than one plan.
+  // This is a Stripe account configuration error that causes silent billing misrouting.
+  for (const [priceId, planIds] of Object.entries(priceIdToPlanIds)) {
+    if (planIds.length > 1) {
+      logger.warn('[billing.plans] duplicate Stripe price ID mapped to multiple plans — config error', {
+        priceId,
+        planIds,
+      });
+    }
+  }
 
   return plans.sort((a, b) => a.monthlyPrice - b.monthlyPrice);
 };
@@ -164,6 +186,25 @@ const getPlans = async () => {
   return inFlightFetch;
 };
 
+/**
+ * @desc Reset the in-memory plan cache.
+ *
+ * Exposed for test isolation: each test that exercises different Stripe configurations
+ * should call `clearPlansCache()` in `beforeEach`/`afterEach` to prevent stale module-scope
+ * state from leaking between test files (ESM module cache is per-worker but shared across
+ * tests in the same worker file when `jest.resetModules()` is not in use).
+ *
+ * NOT intended for production use — the cache is self-refreshing via stale-while-revalidate.
+ */
+const clearPlansCache = () => {
+  cachedPlans = null;
+  cacheTimestamp = 0;
+  stalePlans = null;
+  staleTimestamp = 0;
+  inFlightFetch = null;
+};
+
 export default {
   getPlans,
+  clearPlansCache,
 };

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -97,20 +97,25 @@ const syncOrganizationPlan = async (organizationId, plan) => {
  *
  * @param {Object} event - Full Stripe event object (must have event.id and event.type).
  * @param {Function} handler - Async function (event) => result called when event is new or retrying.
+ * @param {Object} [ctx={}] - Optional context passed from the controller layer.
+ * @param {string} [ctx.requestId] - Express request ID for end-to-end traceability across log lines.
  * @returns {Promise<Object>} Handler result, or skip sentinel
  *          { skipped: true, reason: 'duplicate_event_or_dead_letter' }, or
  *          dead-letter sentinel { deadLettered: true, eventId, eventType, attempts }.
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const withIdempotency = async (event, handler) => {
+const withIdempotency = async (event, handler, { requestId } = {}) => {
   const eventId = event.id;
   const eventType = event.type;
 
   // Atomically claim or re-enter — see tryRecord for 3-state semantics.
   const claim = await ProcessedStripeEventRepository.tryRecord(eventId, eventType);
   if (!claim.recorded) {
+    logger.info('[billing] webhook skipped', { eventId, eventType, reason: claim.reason, requestId });
     return { skipped: true, reason: 'duplicate_event_or_dead_letter', detail: claim.reason };
   }
+
+  logger.info('[billing] webhook handler entry', { eventId, eventType, retry: claim.retry ?? false, requestId });
   try {
     return await handler(event);
   } catch (err) {
@@ -119,10 +124,10 @@ const withIdempotency = async (event, handler) => {
     // for BILLING_WEBHOOK_MAX_ATTEMPTS to be reachable.
     let attempts = 1;
     try {
-      const updated = await ProcessedStripeEventRepository.incrementAttempts(eventId, err?.message ?? String(err));
+      const updated = await ProcessedStripeEventRepository.incrementAttempts(eventId, err);
       attempts = updated?.attempts ?? 1;
     } catch (counterErr) {
-      logger.error('[billing] webhook attempts increment failed', { eventId, eventType, error: counterErr?.message });
+      logger.error('[billing] webhook attempts increment failed', { eventId, eventType, error: counterErr?.message, requestId });
     }
 
     if (attempts >= BILLING_WEBHOOK_MAX_ATTEMPTS) {
@@ -130,15 +135,16 @@ const withIdempotency = async (event, handler) => {
       try {
         await ProcessedStripeEventRepository.markDeadLetter(eventId);
       } catch (dlErr) {
-        logger.error('[billing] webhook markDeadLetter failed', { eventId, eventType, error: dlErr?.message });
+        logger.error('[billing] webhook markDeadLetter failed', { eventId, eventType, error: dlErr?.message, requestId });
       }
-      logger.error('[billing] webhook dead-letter', { eventId, eventType, attempts, error: err?.message ?? String(err) });
+      logger.error('[billing] webhook dead-letter', { eventId, eventType, attempts, error: err?.message ?? String(err), stack: err?.stack, requestId });
       // Return success to Stripe so it stops retrying.
       return { deadLettered: true, eventId, eventType, attempts };
     }
 
     // Below MAX: keep the doc (attempts persists), throw so Stripe retries on next delivery.
     // The next delivery will hit tryRecord → { recorded: true, retry: true } and re-enter here.
+    logger.error('[billing] webhook handler failed, will retry', { eventId, eventType, attempts, error: err?.message ?? String(err), requestId });
     throw err;
   }
 };

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -203,6 +203,28 @@ describe('Billing webhook controller unit tests:', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
+  test('should propagate req.id as requestId into withIdempotency', async () => {
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { stripe: { secretKey: 'sk_test_rid', webhookSecret: 'whsec_rid' } },
+    }));
+
+    const eventData = { type: 'customer.subscription.updated', data: { object: { id: 'sub_rid' } } };
+    mockStripeInstance.webhooks.constructEvent.mockReturnValue(eventData);
+
+    const mod = await import('../controllers/billing.webhook.controller.js');
+    BillingWebhookController = mod.default;
+
+    const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw', id: 'req-trace-id-001' };
+    await BillingWebhookController.handleWebhook(req, res);
+
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(
+      eventData,
+      expect.any(Function),
+      expect.objectContaining({ requestId: 'req-trace-id-001' }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
   test('should return 200 for unknown event types', async () => {
     jest.unstable_mockModule('../../../config/index.js', () => ({
       default: { stripe: { secretKey: 'sk_test_6', webhookSecret: 'whsec_6' } },

--- a/modules/billing/tests/billing.controller.unit.tests.js
+++ b/modules/billing/tests/billing.controller.unit.tests.js
@@ -139,7 +139,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleSubscriptionUpdated).toHaveBeenCalledWith({ id: 'sub_123' }, eventData);
-    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function), expect.objectContaining({}));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -158,7 +158,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleSubscriptionDeleted).toHaveBeenCalledWith({ id: 'sub_del' }, eventData);
-    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function), expect.objectContaining({}));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -177,7 +177,7 @@ describe('Billing webhook controller unit tests:', () => {
     await BillingWebhookController.handleWebhook(req, res);
 
     expect(mockBillingWebhookService.handleInvoicePaymentFailed).toHaveBeenCalledWith({ id: 'inv_fail' }, eventData);
-    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function), expect.objectContaining({}));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -199,7 +199,7 @@ describe('Billing webhook controller unit tests:', () => {
       { id: 'dp_fw_1', charge: 'ch_1', amount: 2900 },
       eventData,
     );
-    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function));
+    expect(mockBillingWebhookService.withIdempotency).toHaveBeenCalledWith(eventData, expect.any(Function), expect.objectContaining({}));
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -237,7 +237,10 @@ describe('Billing webhook controller unit tests:', () => {
     const req = { headers: { 'stripe-signature': 'sig_ok' }, body: 'raw' };
     await BillingWebhookController.handleWebhook(req, res);
 
-    expect(loggerMod.default.error).toHaveBeenCalledWith('Stripe webhook handler error:', expect.any(Error));
+    expect(loggerMod.default.error).toHaveBeenCalledWith(
+      '[billing.webhook] handler error',
+      expect.objectContaining({ error: 'DB error' }),
+    );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
       type: 'error',

--- a/modules/billing/tests/billing.extra.service.unit.tests.js
+++ b/modules/billing/tests/billing.extra.service.unit.tests.js
@@ -46,6 +46,7 @@ describe('BillingExtraService unit tests:', () => {
       getOrCreate: jest.fn(),
       getBalance: jest.fn(),
       refundPartial: jest.fn(),
+      listLedgerPage: jest.fn(),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
@@ -186,49 +187,46 @@ describe('BillingExtraService unit tests:', () => {
   });
 
   describe('listLedger', () => {
-    test('should return empty result when getOrCreate returns null (malformed orgId)', async () => {
-      mockRepository.getOrCreate.mockResolvedValue(null);
+    test('should return empty result when listLedgerPage returns null (malformed orgId)', async () => {
+      mockRepository.listLedgerPage.mockResolvedValue(null);
 
       const result = await BillingExtraService.listLedger('bad-org-id');
       expect(result).toEqual({ entries: [], total: 0, balance: 0 });
     });
 
-    test('should return paginated ledger entries in reverse chronological order', async () => {
-      const t1 = new Date('2026-05-01T10:00:00Z');
-      const t2 = new Date('2026-05-02T10:00:00Z');
-      const doc = makeDoc({
+    test('should delegate pagination to repository with correct skip+limit', async () => {
+      mockRepository.listLedgerPage.mockResolvedValue({
+        ledgerPage: [{ kind: 'debit', amount: -100, at: new Date() }],
+        total: 1,
         cachedBalance: 900000,
-        ledger: [
-          { kind: 'topup', amount: 500000, at: t1 },
-          { kind: 'topup', amount: 500000, at: t2 },
-          { kind: 'debit', amount: -100000, at: new Date('2026-05-03T10:00:00Z') },
-        ],
       });
-      mockRepository.getOrCreate.mockResolvedValue(doc);
 
       const result = await BillingExtraService.listLedger(orgId, { page: 1, limit: 2 });
 
-      expect(result.total).toBe(3);
+      expect(mockRepository.listLedgerPage).toHaveBeenCalledWith(orgId, 0, 2);
+      expect(result.total).toBe(1);
       expect(result.balance).toBe(900000);
-      expect(result.entries).toHaveLength(2);
-      // Newest first
-      expect(result.entries[0].kind).toBe('debit');
+      expect(result.entries).toHaveLength(1);
     });
 
-    test('should return second page correctly', async () => {
-      const doc = makeDoc({
+    test('should compute correct skip for page 2', async () => {
+      mockRepository.listLedgerPage.mockResolvedValue({
+        ledgerPage: [{ kind: 'topup', amount: 100, at: new Date() }],
+        total: 3,
         cachedBalance: 0,
-        ledger: [
-          { kind: 'topup', amount: 100, at: new Date('2026-01-01') },
-          { kind: 'topup', amount: 100, at: new Date('2026-02-01') },
-          { kind: 'topup', amount: 100, at: new Date('2026-03-01') },
-        ],
       });
-      mockRepository.getOrCreate.mockResolvedValue(doc);
 
-      const result = await BillingExtraService.listLedger(orgId, { page: 2, limit: 2 });
+      await BillingExtraService.listLedger(orgId, { page: 2, limit: 2 });
 
-      expect(result.entries).toHaveLength(1);
+      // page=2, limit=2 → skip=2
+      expect(mockRepository.listLedgerPage).toHaveBeenCalledWith(orgId, 2, 2);
+    });
+
+    test('should return empty result when listLedgerPage returns null for valid org with no balance doc', async () => {
+      mockRepository.listLedgerPage.mockResolvedValue(null);
+
+      const result = await BillingExtraService.listLedger(orgId);
+      expect(result).toEqual({ entries: [], total: 0, balance: 0 });
     });
   });
 

--- a/modules/billing/tests/billing.extraBalance.listLedger.perf.integration.tests.js
+++ b/modules/billing/tests/billing.extraBalance.listLedger.perf.integration.tests.js
@@ -1,0 +1,107 @@
+/**
+ * Module dependencies.
+ */
+import mongoose from 'mongoose';
+import { describe, beforeAll, beforeEach, afterAll, test, expect } from '@jest/globals';
+
+import mongooseService from '../../../lib/services/mongoose.js';
+
+/**
+ * Performance integration tests for BillingExtraBalanceRepository.listLedgerPage.
+ *
+ * Asserts that `listLedger` fetches a page from a 1000-entry ledger in < 50ms
+ * when using the aggregation $slice path — confirming that only the requested
+ * page is transferred over the wire, not the full document.
+ */
+describe('BillingExtraBalanceRepository.listLedgerPage performance integration tests:', () => {
+  let BillingExtraBalanceRepository;
+  let BillingExtraBalance;
+
+  const orgId = new mongoose.Types.ObjectId();
+
+  beforeAll(async () => {
+    await mongooseService.loadModels();
+    await mongooseService.connect();
+    BillingExtraBalance = mongoose.model('BillingExtraBalance');
+    BillingExtraBalanceRepository = (await import('../repositories/billing.extraBalance.repository.js')).default;
+  });
+
+  beforeEach(async () => {
+    await BillingExtraBalance.deleteMany({ organization: orgId });
+  });
+
+  afterAll(async () => {
+    await mongooseService.disconnect();
+  });
+
+  test('listLedgerPage: fetching page 1 of a 1000-entry ledger takes < 50ms', async () => {
+    // Seed a document with 1000 ledger entries
+    const ledger = Array.from({ length: 1000 }, (_, i) => ({
+      kind: 'topup',
+      amount: 1000,
+      stripeSessionId: `cs_perf_${i}`,
+      at: new Date(Date.now() - i * 1000),
+    }));
+
+    await BillingExtraBalance.create({
+      organization: orgId,
+      ledger,
+      cachedBalance: 1000000,
+      cachedBalanceAt: new Date(),
+    });
+
+    const start = performance.now();
+    const result = await BillingExtraBalanceRepository.listLedgerPage(String(orgId), 0, 20);
+    const elapsed = performance.now() - start;
+
+    expect(result).not.toBeNull();
+    expect(result.total).toBe(1000);
+    expect(result.ledgerPage).toHaveLength(20);
+    expect(result.cachedBalance).toBe(1000000);
+
+    // Entries should be sorted descending by `at` (newest first)
+    const firstAt = new Date(result.ledgerPage[0].at).getTime();
+    const secondAt = new Date(result.ledgerPage[1].at).getTime();
+    expect(firstAt).toBeGreaterThanOrEqual(secondAt);
+
+    // Performance gate: < 50ms for a 1000-entry ledger page fetch
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  test('listLedgerPage: returns null for a valid but non-existent org', async () => {
+    const unknownOrgId = new mongoose.Types.ObjectId();
+    const result = await BillingExtraBalanceRepository.listLedgerPage(String(unknownOrgId), 0, 20);
+    expect(result).toBeNull();
+  });
+
+  test('listLedgerPage: returns null for an invalid orgId', async () => {
+    const result = await BillingExtraBalanceRepository.listLedgerPage('not-an-object-id', 0, 20);
+    expect(result).toBeNull();
+  });
+
+  test('listLedgerPage: page 2 returns the correct slice (skip=20, limit=20)', async () => {
+    const now = Date.now();
+    const ledger = Array.from({ length: 50 }, (_, i) => ({
+      kind: 'topup',
+      amount: i + 1,
+      stripeSessionId: `cs_page_${i}`,
+      at: new Date(now - i * 1000),
+    }));
+
+    await BillingExtraBalance.create({
+      organization: orgId,
+      ledger,
+      cachedBalance: 0,
+      cachedBalanceAt: new Date(),
+    });
+
+    const result = await BillingExtraBalanceRepository.listLedgerPage(String(orgId), 20, 20);
+
+    expect(result).not.toBeNull();
+    expect(result.total).toBe(50);
+    expect(result.ledgerPage).toHaveLength(20);
+    // Page 2 entries should be older than page 1 entries (entries 20-39 by descending date)
+    const pageFirstAt = new Date(result.ledgerPage[0].at).getTime();
+    expect(pageFirstAt).toBeLessThanOrEqual(now - 20 * 1000 + 100); // within tolerance
+  });
+});

--- a/modules/billing/tests/billing.meter.service.unit.tests.js
+++ b/modules/billing/tests/billing.meter.service.unit.tests.js
@@ -71,10 +71,11 @@ describe('BillingMeterService unit tests:', () => {
     jest.restoreAllMocks();
   });
 
-  describe('METER_RUN_BASE constant', () => {
-    test('should export METER_RUN_BASE from config', async () => {
+  describe('getMeterRunBase export', () => {
+    test('should export getMeterRunBase function returning configured value', async () => {
       const mod = await import('../services/billing.meter.service.js');
-      expect(mod.METER_RUN_BASE).toBe(1);
+      expect(typeof mod.default.getMeterRunBase).toBe('function');
+      expect(mod.default.getMeterRunBase()).toBe(1);
     });
   });
 

--- a/modules/billing/tests/billing.plans.unit.tests.js
+++ b/modules/billing/tests/billing.plans.unit.tests.js
@@ -399,4 +399,75 @@ describe('Billing plans service unit tests:', () => {
       expect(plan).toHaveProperty('monthlyPrice');
     }
   });
+
+  // ── clearPlansCache — test isolation helper ─────────────────────────────
+  test('clearPlansCache: resets in-memory cache so next call fetches from Stripe', async () => {
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+
+    // Populate cache
+    await BillingPlansService.getPlans();
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(1);
+
+    // clearPlansCache resets state
+    BillingPlansService.clearPlansCache();
+
+    // Next call must issue a fresh Stripe round-trip
+    await BillingPlansService.getPlans();
+    expect(mockStripeInstance.products.list).toHaveBeenCalledTimes(2);
+  });
+
+  test('clearPlansCache: is exported on the default facade', async () => {
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+
+    expect(typeof BillingPlansService.clearPlansCache).toBe('function');
+  });
+
+  // ── Duplicate Stripe price ID warn ─────────────────────────────────────
+  test('warns when the same Stripe price ID is mapped to multiple plans', async () => {
+    // Two products share price_dup_m — config error
+    mockStripeInstance.products.list.mockReturnValue(
+      mockListResult([
+        { id: 'prod_a', name: 'Plan A', metadata: { planId: 'plan_a' } },
+        { id: 'prod_b', name: 'Plan B', metadata: { planId: 'plan_b' } },
+      ]),
+    );
+    mockStripeInstance.prices.list.mockReturnValue(
+      mockListResult([
+        { product: 'prod_a', recurring: { interval: 'month' }, unit_amount: 900, id: 'price_dup_m' },
+        { product: 'prod_b', recurring: { interval: 'month' }, unit_amount: 2900, id: 'price_dup_m' },
+      ]),
+    );
+
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+    const loggerMod = await import('../../../lib/services/logger.js');
+    const mockLogger = loggerMod.default;
+
+    await BillingPlansService.getPlans();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[billing.plans] duplicate Stripe price ID mapped to multiple plans — config error',
+      expect.objectContaining({
+        priceId: 'price_dup_m',
+        planIds: expect.arrayContaining(['plan_a', 'plan_b']),
+      }),
+    );
+  });
+
+  test('does not warn when all price IDs are unique per plan', async () => {
+    // Default mock has unique price IDs per product — no warn expected
+    const mod = await import('../services/billing.plans.service.js');
+    BillingPlansService = mod.default;
+    const loggerMod = await import('../../../lib/services/logger.js');
+    const mockLogger = loggerMod.default;
+
+    await BillingPlansService.getPlans();
+
+    const warnCalls = mockLogger.warn.mock.calls.filter((args) =>
+      String(args[0]).includes('duplicate Stripe price ID'),
+    );
+    expect(warnCalls).toHaveLength(0);
+  });
 });

--- a/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
+++ b/modules/billing/tests/billing.processedStripeEvent.repository.unit.tests.js
@@ -210,6 +210,66 @@ describe('ProcessedStripeEventRepository unit tests:', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // incrementAttempts — stack trace capture
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('incrementAttempts', () => {
+    const stubUpdate = (doc) => ({
+      exec: jest.fn().mockResolvedValue(doc),
+    });
+
+    test('stores err.stack when an Error object is passed', async () => {
+      const doc = { eventId: 'evt_stack', attempts: 1, lastError: 'some stack trace', lastErrorAt: new Date() };
+      mockModel.findOneAndUpdate = jest.fn().mockReturnValue(stubUpdate(doc));
+
+      const err = new Error('handler blew up');
+      // Stack trace is set by V8 at creation time
+      await ProcessedStripeEventRepository.incrementAttempts('evt_stack', err);
+
+      const updateCall = mockModel.findOneAndUpdate.mock.calls[0];
+      const setPayload = updateCall[1].$set;
+      // Should persist the stack, not just the message
+      expect(setPayload.lastError).toBe(err.stack);
+      expect(setPayload.lastError).toContain('handler blew up');
+    });
+
+    test('falls back to String(errorOrMessage) when a plain string is passed', async () => {
+      const doc = { eventId: 'evt_str', attempts: 1, lastError: 'plain error string', lastErrorAt: new Date() };
+      mockModel.findOneAndUpdate = jest.fn().mockReturnValue(stubUpdate(doc));
+
+      await ProcessedStripeEventRepository.incrementAttempts('evt_str', 'plain error string');
+
+      const updateCall = mockModel.findOneAndUpdate.mock.calls[0];
+      expect(updateCall[1].$set.lastError).toBe('plain error string');
+    });
+
+    test('handles null/undefined gracefully (empty string fallback)', async () => {
+      const doc = { eventId: 'evt_null', attempts: 1, lastError: '', lastErrorAt: new Date() };
+      mockModel.findOneAndUpdate = jest.fn().mockReturnValue(stubUpdate(doc));
+
+      await ProcessedStripeEventRepository.incrementAttempts('evt_null', null);
+
+      const updateCall = mockModel.findOneAndUpdate.mock.calls[0];
+      expect(updateCall[1].$set.lastError).toBe('');
+    });
+
+    test('serializes plain object throws as JSON to avoid [object Object]', async () => {
+      const doc = { eventId: 'evt_obj', attempts: 1, lastError: '{"code":"DB_ERR"}', lastErrorAt: new Date() };
+      mockModel.findOneAndUpdate = jest.fn().mockReturnValue(stubUpdate(doc));
+
+      await ProcessedStripeEventRepository.incrementAttempts('evt_obj', { code: 'DB_ERR' });
+
+      const updateCall = mockModel.findOneAndUpdate.mock.calls[0];
+      expect(updateCall[1].$set.lastError).toBe('{"code":"DB_ERR"}');
+    });
+
+    test('throws for empty eventId', async () => {
+      await expect(
+        ProcessedStripeEventRepository.incrementAttempts('', new Error('x')),
+      ).rejects.toThrow('invalid argument: eventId must be a non-empty string');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // listDeadLetters (new in feat/billing-admin-toolkit-foundations)
   // ─────────────────────────────────────────────────────────────────────────────
   describe('listDeadLetters', () => {

--- a/modules/billing/tests/billing.webhook.hardening.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.hardening.unit.tests.js
@@ -405,6 +405,7 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
     await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('transient');
 
     // incrementAttempts receives the full Error object (for stack trace capture)
+    expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledTimes(1);
     const [eidArg, errArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
     expect(eidArg).toBe('evt_rl_001');
     expect(errArg).toBeInstanceOf(Error);

--- a/modules/billing/tests/billing.webhook.hardening.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.hardening.unit.tests.js
@@ -404,7 +404,11 @@ describe('withIdempotency — replay-storm dead-letter protection:', () => {
 
     await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('transient');
 
-    expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledWith('evt_rl_001', 'transient');
+    // incrementAttempts receives the full Error object (for stack trace capture)
+    const [eidArg, errArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
+    expect(eidArg).toBe('evt_rl_001');
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg.message).toBe('transient');
     // Doc must NOT be deleted — attempts must persist across Stripe redeliveries
     // so MAX_ATTEMPTS (5) is reachable. Deleting on rollback was the original bug.
     expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -196,6 +196,7 @@ describe('Billing webhook idempotency unit tests:', () => {
       ).rejects.toThrow('handler blew up');
 
       // incrementAttempts receives the full Error object (for stack trace capture)
+      expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledTimes(1);
       const [eidArg, errArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
       expect(eidArg).toBe('evt_test_001');
       expect(errArg).toBeInstanceOf(Error);
@@ -259,6 +260,7 @@ describe('Billing webhook idempotency unit tests:', () => {
       await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('handler exploded');
 
       // Should receive the Error object itself, not err.message
+      expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledTimes(1);
       const [, errorArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
       expect(errorArg).toBe(handlerError);
     });

--- a/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.idempotency.unit.tests.js
@@ -195,10 +195,11 @@ describe('Billing webhook idempotency unit tests:', () => {
         BillingWebhookService.withIdempotency(event, handler),
       ).rejects.toThrow('handler blew up');
 
-      expect(mockProcessedStripeEventRepository.incrementAttempts).toHaveBeenCalledWith(
-        'evt_test_001',
-        'handler blew up',
-      );
+      // incrementAttempts receives the full Error object (for stack trace capture)
+      const [eidArg, errArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
+      expect(eidArg).toBe('evt_test_001');
+      expect(errArg).toBeInstanceOf(Error);
+      expect(errArg.message).toBe('handler blew up');
       // Critical: doc must NOT be deleted — attempts must persist across redeliveries.
       expect(mockProcessedStripeEventRepository.deleteByEventId).not.toHaveBeenCalled();
     });
@@ -244,6 +245,37 @@ describe('Billing webhook idempotency unit tests:', () => {
 
       expect(mockProcessedStripeEventRepository.tryRecord).toHaveBeenCalledTimes(1);
       expect(mockProcessedStripeEventRepository.wasProcessed).not.toHaveBeenCalled();
+    });
+
+    // ── req.id / requestId correlation ────────────────────────────────────
+
+    test('passes full Error to incrementAttempts (stack trace capture)', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
+      mockProcessedStripeEventRepository.incrementAttempts.mockResolvedValue({ attempts: 1 });
+      const handlerError = new Error('handler exploded');
+      const handler = jest.fn().mockRejectedValue(handlerError);
+      const event = makeEvent('evt_stack_trace');
+
+      await expect(BillingWebhookService.withIdempotency(event, handler)).rejects.toThrow('handler exploded');
+
+      // Should receive the Error object itself, not err.message
+      const [, errorArg] = mockProcessedStripeEventRepository.incrementAttempts.mock.calls[0];
+      expect(errorArg).toBe(handlerError);
+    });
+
+    test('requestId context is accepted without affecting handler result', async () => {
+      mockProcessedStripeEventRepository.tryRecord.mockResolvedValue({ recorded: true, retry: false });
+      const handler = jest.fn().mockResolvedValue({ ok: true });
+      const event = makeEvent('evt_with_req_id');
+
+      const result = await BillingWebhookService.withIdempotency(
+        event,
+        handler,
+        { requestId: 'test-request-id-abc' },
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(handler).toHaveBeenCalledWith(event);
     });
   });
 });


### PR DESCRIPTION
## Summary

Étape 5 — final polish layer for billing prod-ready (devkit Node only). Builds on Étapes 1–4 (#3611 #3612 #3613).

### A — Dead-letter observability + req.id correlation
- `incrementAttempts` now stores `err.stack` (full trace) rather than just `err.message`; JSON-serializes plain-object throws to avoid `[object Object]`
- `withIdempotency` accepts optional `ctx.requestId`; logs handler entry / skip / retry / dead-letter with the request ID for end-to-end traceability
- Webhook controller reads `req.id` (injected by global `requestId` middleware) and propagates it to all `withIdempotency` calls

### B — Performance hygiene
- `listLedger` refactored to use new `listLedgerPage()` repo method — MongoDB aggregation `$sortArray` + `$slice` transfers only the requested page over the wire instead of the full document
- Perf integration test asserts `< 50ms` on a 1000-entry ledger page fetch
- `BillingUsage`: TTL index on `archivedAt` (`expireAfterSeconds: 365 days`, `partialFilterExpression: { archivedAt: { $type: 'date' } }`) — auto-purge archived weekly periods after 1 year; active docs (archivedAt null/absent) are excluded

### C — Tier-3 nits
- Removed module-scope `METER_RUN_BASE` const (evaluated stale at load time); `getMeterRunBase()` function kept and re-exported from `billing.meter.service.js` for lazy evaluation
- Exported `clearPlansCache()` from `billing.plans.service.js` for test isolation (resets all module-scope cache state between test files)
- `fetchPlansFromStripe`: explicit `warn` log when a Stripe price ID is mapped to multiple plans — was previously silent (config error causing billing misrouting)

## Pre-push review

DeepSeek critical review verdict: **OK with nits** — 0 critical, 0 high. Two nits addressed:
- Removed redundant `$exists: true` from TTL `partialFilterExpression` (kept `$type: 'date'` which is sufficient)
- Improved `lastError` serialization for non-Error object throws (JSON.stringify fallback)

## Test plan

- [ ] All 1245 unit tests green (`npm run test:unit`)
- [ ] New perf integration test: `billing.extraBalance.listLedger.perf.integration.tests.js` — asserts `< 50ms` on 1000-entry ledger
- [ ] Existing webhook idempotency tests updated to verify full Error passed to `incrementAttempts`
- [ ] Plans service tests: `clearPlansCache` export + duplicate price warn assertions
- [ ] CI green incl. codecov