### PR TITLE
fix(billing): architecture compliance + quality fixes (Batch 3a)

### DIFF
--- a/modules/billing/RUNBOOKS.md
+++ b/modules/billing/RUNBOOKS.md
@@ -12,18 +12,23 @@ Operational runbooks for the billing module. Each runbook references real endpoi
 
 1. Confirm dispute in Stripe Dashboard → Radar → Disputes. Note the `charge_id` and `dispute_id`.
 2. Retrieve customer state to verify DB-side ledger matches Stripe:
-   ```
+
+   ```text
    GET /api/admin/billing/customer/:orgId
    ```
+
    Confirm `stripeStatus` matches `subscription.status` in DB.
 3. If the dispute is fraudulent (stolen card), cancel the subscription immediately:
-   ```
+
+   ```text
    POST /api/admin/billing/cancel/:orgId
    ```
+
 4. Gather evidence in Stripe Dashboard: usage records, signup email, ToS acceptance timestamp, IP logs.
 5. Submit evidence before day 7 via Stripe Dashboard → Dispute → Submit evidence.
 6. If dispute won (`charge.dispute.funds_reinstated` received): restore the customer's extras balance via:
-   ```
+
+   ```text
    POST /api/admin/billing/dispute/credit/:orgId
    Body: {
      "chargeId": "ch_xxx",
@@ -32,13 +37,16 @@ Operational runbooks for the billing module. Each runbook references real endpoi
      "refundRequestId": "<uuid>"
    }
    ```
+
    Example curl:
+
    ```bash
    curl -X POST https://api.trawl.me/api/admin/billing/dispute/credit/<orgId> \
      -H "Authorization: Bearer $ADMIN_JWT" \
      -H "Content-Type: application/json" \
      -d '{"chargeId":"ch_xxx","amountCents":2000,"reason":"dispute won — Stripe reinstated funds","refundRequestId":"<uuid>"}'
    ```
+
    Confirm credit applied: `GET /api/admin/billing/customer/:orgId` — check ledger for an `adjustment` entry with `refId: dispute-credit-<uuid>`.
 7. If dispute lost: extras balance debited by `charge.dispute.funds_withdrawn` is not refunded — log in incident tracker.
 
@@ -51,25 +59,31 @@ Operational runbooks for the billing module. Each runbook references real endpoi
 **Steps**:
 
 1. List all dead-letter events:
-   ```
+
+   ```text
    GET /api/admin/billing/dead-letters
    ```
+
    Response includes `eventId`, `type`, `createdAt`, `lastError` for each.
 
 2. For each suspicious event, attempt replay (re-fetches event from Stripe API, re-dispatches through the webhook pipeline):
-   ```
+
+   ```text
    POST /api/admin/billing/webhook/replay
    Body: { "eventId": "evt_xxx" }
    ```
+
    On success: the event is re-processed and the `deadLetter` flag cleared automatically.
 
 3. If replay succeeds but state is still inconsistent (e.g. subscription not updated), force a DB sync from Stripe:
-   ```
+
+   ```text
    POST /api/admin/billing/sync/:orgId
    ```
 
 4. If the event is stale/unrecoverable (e.g. the subscription no longer exists in Stripe), purge it:
-   ```
+
+   ```text
    DELETE /api/admin/billing/dead-letters/:eventId
    ```
 
@@ -84,24 +98,30 @@ Operational runbooks for the billing module. Each runbook references real endpoi
 **Steps**:
 
 1. Identify the divergence from the weekly reconciliation log:
-   ```
+
+   ```bash
    kubectl logs -n pierreb-projects job/billing-reconcile-<timestamp>
    ```
+
    Look for lines containing `divergence detected` — they include `orgId`, `stripeStatus`, `dbStatus`, `stripePlan`, `dbPlan`.
 
 2. Get the full customer state for the affected org:
-   ```
+
+   ```text
    GET /api/admin/billing/customer/:orgId
    ```
+
    Compare `stripeSnapshot` (live from Stripe API) vs `dbSnapshot` (local DB) fields.
 
 3. If Stripe is authoritative (e.g. subscription renewed but DB missed the webhook), sync Stripe → DB:
-   ```
+
+   ```text
    POST /api/admin/billing/sync/:orgId
    ```
 
 4. If the plan needs manual correction (e.g. plan bump after payment confirmation):
-   ```
+
+   ```text
    PATCH /api/admin/billing/plans/bump
    Body: { "orgId": "...", "planId": "pro", "reason": "manual reconciliation post-mismatch" }
    ```

--- a/modules/billing/controllers/billing.admin.controller.js
+++ b/modules/billing/controllers/billing.admin.controller.js
@@ -86,61 +86,13 @@ const adminRefundCharge = async (req, res) => {
 const adminBumpPlan = async (req, res) => {
   try {
     const { orgId, planId } = req.body;
-
-    // Guard: req.user._id must be a valid ObjectId — the JWT middleware sets it, but a missing
-    // or malformed token could leave it undefined, causing a Mongoose CastError downstream.
-    const rawAdminId = req.user?._id;
-    if (!rawAdminId) {
-      return responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump plan')(
-        new Error('invalid argument: authenticated user id is missing'),
-      );
-    }
-    const adminUserId = String(rawAdminId);
-
-    // NOTE: this controller orchestrates directly against repo + logger to avoid adding a
-    // dedicated service method for a single admin escape hatch. This is an intentional
-    // exception to the service-layer convention: the operation is simple (find → update → sync),
-    // has no domain logic beyond what the repo already provides, and extracting it into
-    // billing.admin.service.js would add ceremony for no isolation benefit.
-    // Tracked for refactor in a future service-extraction pass if more admin operations join.
-    //
-    // Lazy imports — the repo module references mongoose.model('Subscription') at load time,
-    // and the logger module touches config.log.fileLogger which isn't always mocked. Unrelated
-    // unit tests that mock Stripe but don't load full schemas would crash on top-level imports.
-    const { default: SubscriptionRepository } = await import('../repositories/billing.subscription.repository.js');
-    const { default: OrganizationRepository } = await import('../../organizations/repositories/organizations.repository.js');
-    const { default: logger } = await import('../../../lib/services/logger.js');
-
-    const existing = await SubscriptionRepository.findByOrganization(orgId);
-    if (!existing) {
-      return responses.error(res, 404, 'Not Found', 'Subscription not found for organization')(
-        new Error(`subscription not found for orgId=${orgId}`),
-      );
-    }
-
-    const updated = await SubscriptionRepository.adminUpdatePlanOnly(String(existing._id), planId, adminUserId);
-
-    // Sync org plan so meter quotas / feature flags / access control reflect the bump
-    // immediately. Without this the new plan only applies to the subscription doc, but
-    // the organization's plan field — read by requirePlan / requireQuota — stays stale
-    // until the next Stripe webhook (which may revert to Stripe's value).
-    await OrganizationRepository.setPlan(orgId, planId);
-
-    logger.info('[billing.admin] plan bumped manually', {
-      orgId,
-      previousPlan: existing.plan,
-      newPlan: planId,
-      adminUserId,
-      subscriptionId: String(existing._id),
-    });
-
-    return responses.success(res, 'subscription plan bumped')(updated);
+    const adminUserId = String(req.user?._id ?? '');
+    const result = await BillingAdminService.bumpOrgPlan(orgId, planId, adminUserId);
+    return responses.success(res, 'subscription plan bumped')(result);
   } catch (err) {
-    // Surface schema/validation errors from Mongoose as 422 instead of letting them fall to 500.
-    if (err?.name === 'ValidationError' || err?.message?.startsWith('invalid argument')) {
-      return responses.error(res, 422, 'Unprocessable Entity', 'Failed to bump plan')(err);
-    }
-    return responses.error(res, 500, 'Internal Server Error', 'Failed to bump plan')(err);
+    const status = err.status ?? (err?.name === 'ValidationError' ? 422 : 500);
+    const title = status === 404 ? 'Not Found' : status === 422 ? 'Unprocessable Entity' : 'Internal Server Error';
+    return responses.error(res, status, title, 'Failed to bump plan')(err);
   }
 };
 

--- a/modules/billing/lib/billing.isoWeek.js
+++ b/modules/billing/lib/billing.isoWeek.js
@@ -21,7 +21,30 @@ export const isoWeekKey = (date) => {
  */
 export const currentWeekKey = () => isoWeekKey(new Date());
 
+/**
+ * @function weekStartDate
+ * @description Compute the UTC start of the ISO week from a YYYY-Www key.
+ *              Returns the Monday 00:00:00 UTC of that ISO week.
+ * @param {string} weekKey - ISO week key in YYYY-Www format.
+ * @returns {Date} Start of the ISO week (Monday 00:00:00 UTC).
+ */
+export const weekStartDate = (weekKey) => {
+  const [yearStr, weekStr] = weekKey.split('-W');
+  const year = Number(yearStr);
+  const week = Number(weekStr);
+  // Jan 4 is always in ISO week 1
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  // Go back to Monday of week 1
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - ((jan4.getUTCDay() || 7) - 1));
+  // Add (week - 1) * 7 days to reach the target week's Monday
+  const targetMonday = new Date(week1Monday);
+  targetMonday.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  return targetMonday;
+};
+
 export default {
   currentWeekKey,
   isoWeekKey,
+  weekStartDate,
 };

--- a/modules/billing/policies/billing.policy.js
+++ b/modules/billing/policies/billing.policy.js
@@ -21,13 +21,16 @@ export function billingSubjectRegistration({ registerPathSubject }) {
   registerPathSubject('/api/billing/extras/ledger', 'BillingExtrasLedger');
   registerPathSubject('/api/admin/billing/refund', 'BillingAdminRefund');
   registerPathSubject('/api/admin/billing/plans/bump', 'BillingAdminPlanBump');
-  // Admin toolkit — 6 diagnostic + ops endpoints (all require admin role)
-  registerPathSubject('/api/admin/billing/customer', 'BillingAdminOps');
-  registerPathSubject('/api/admin/billing/sync', 'BillingAdminOps');
+  // Admin toolkit — diagnostic + ops endpoints (all require admin role).
+  // Paths registered with Express param patterns so deriveSubjectType (exact-string match)
+  // resolves the correct subject type for parameterised routes like /:orgId and /:eventId.
+  registerPathSubject('/api/admin/billing/customer/:orgId', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/sync/:orgId', 'BillingAdminOps');
   registerPathSubject('/api/admin/billing/webhook/replay', 'BillingAdminOps');
   registerPathSubject('/api/admin/billing/dead-letters', 'BillingAdminOps');
-  registerPathSubject('/api/admin/billing/cancel', 'BillingAdminOps');
-  // Dispute credit — manual ledger credit after funds_reinstated (Batch 2)
+  registerPathSubject('/api/admin/billing/dead-letters/:eventId', 'BillingAdminOps');
+  registerPathSubject('/api/admin/billing/cancel/:orgId', 'BillingAdminOps');
+  // Dispute credit — manual ledger credit after funds_reinstated
   registerPathSubject('/api/admin/billing/dispute/credit/:orgId', 'BillingAdminOps');
   // Webhook is mounted in billing.preroute.js before body parsing and auth middleware,
   // so it bypasses policy.isAllowed entirely. Registered here for documentation completeness.

--- a/modules/billing/repositories/billing.extraBalance.repository.js
+++ b/modules/billing/repositories/billing.extraBalance.repository.js
@@ -430,7 +430,6 @@ const findOrgsWithExpiringTopups = async (now) => {
 
 /**
  * Fetch the full ledger array for an org.
- * Used by the reconcile service to compute actual extras debits in the current period.
  * Returns null when no document exists yet (org has never had extras).
  * @param {string} orgId - Organization ObjectId (string).
  * @returns {Promise<Object[]|null>} Ledger entries array or null.
@@ -445,6 +444,41 @@ const findLedgerByOrg = async (orgId) => {
   return doc?.ledger ?? null;
 };
 
+/**
+ * Sum absolute debit entries within a time window using a server-side aggregation.
+ * Avoids loading the full ledger into memory — O(1) payload regardless of ledger size.
+ *
+ * Used by the billing reconcile service to compute actualExtrasDebits for the current week.
+ *
+ * @param {string} orgId - Organization ObjectId (string).
+ * @param {Date} windowStart - Inclusive lower bound (entries with at >= windowStart).
+ * @param {Date} windowEnd - Exclusive upper bound (entries with at < windowEnd).
+ * @returns {Promise<number>} Sum of absolute debit amounts in the window, or 0.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
+const sumDebitsByWindow = async (orgId, windowStart, windowEnd) => {
+  if (!isValidOrgId(orgId)) return 0;
+
+  const [result] = await BillingExtraBalance().aggregate([
+    { $match: { organization: new mongoose.Types.ObjectId(orgId) } },
+    { $unwind: '$ledger' },
+    {
+      $match: {
+        'ledger.kind': 'debit',
+        'ledger.at': { $gte: windowStart, $lt: windowEnd },
+      },
+    },
+    {
+      $group: {
+        _id: null,
+        total: { $sum: { $abs: '$ledger.amount' } },
+      },
+    },
+  ]);
+
+  return result?.total ?? 0;
+};
+
 export default {
   getOrCreate,
   creditPack,
@@ -456,4 +490,5 @@ export default {
   listLedgerPage,
   findOrgsWithExpiringTopups,
   findLedgerByOrg,
+  sumDebitsByWindow,
 };

--- a/modules/billing/repositories/billing.subscription.repository.js
+++ b/modules/billing/repositories/billing.subscription.repository.js
@@ -321,9 +321,13 @@ const adminUpdatePlanOnly = (id, planId, adminUserId) => {
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js repository, not Qwik
 const findPageForReconciliation = (statuses, page, limit) =>
   Subscription.find(
-    { status: { $in: statuses }, stripeSubscriptionId: { $ne: null } },
+    {
+      status: { $in: statuses },
+      stripeSubscriptionId: { $exists: true, $ne: null },
+    },
     { _id: 1, organization: 1, stripeSubscriptionId: 1, stripeCustomerId: 1, plan: 1, status: 1, currentPeriodStart: 1 },
   )
+    .sort({ _id: 1 })
     .skip(page * limit)
     .limit(limit)
     .lean()

--- a/modules/billing/services/billing.admin.service.js
+++ b/modules/billing/services/billing.admin.service.js
@@ -319,6 +319,13 @@ const creditDisputeReinstated = async (chargeId, amountCents, reason, refundRequ
     throw Object.assign(new Error('invalid argument: reason must be at least 3 characters'), { status: 422 });
   }
 
+  // Guard: reject credits for non-existent orgs — mirrors the debit existence guard.
+  // A 24-hex match that references a ghost org would silently create a ledger doc for nobody.
+  const org = await OrganizationRepository.get(orgId);
+  if (!org) {
+    throw Object.assign(new Error(`organization not found: ${orgId}`), { status: 422 });
+  }
+
   // Idempotency key includes the refundRequestId to prevent double-click double-credit.
   const refId = `dispute-credit-${refundRequestId}`;
 
@@ -423,6 +430,50 @@ const dispatchWebhookEvent = (event) => {
   }
 };
 
+/**
+ * @function bumpOrgPlan
+ * @description Override an organization's subscription plan (admin ops escape hatch).
+ *              Does NOT call Stripe — the downstream Stripe subscription remains on whatever
+ *              plan the user is paying for. Use only when the DB plan must diverge from Stripe
+ *              (rare ops scenarios such as comping a user during support or forcing a plan for testing).
+ *              The audit trail (adminUpdatedAt / adminUpdatedBy) is set by the repo method.
+ * @param {string} orgId - Organization ObjectId (string).
+ * @param {string} newPlanId - The new plan identifier (must be in config.billing.plans enum).
+ * @param {string} adminUserId - Authenticated admin user ObjectId (string) for audit trail.
+ * @returns {Promise<Object>} Updated subscription document.
+ */
+// biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
+const bumpOrgPlan = async (orgId, newPlanId, adminUserId) => {
+  if (!/^[0-9a-fA-F]{24}$/.test(orgId)) {
+    throw Object.assign(new Error('invalid argument: orgId must be a valid ObjectId'), { status: 422 });
+  }
+  if (!adminUserId) {
+    throw Object.assign(new Error('invalid argument: authenticated user id is missing'), { status: 422 });
+  }
+
+  const existing = await SubscriptionRepository.findByOrganization(orgId);
+  if (!existing) {
+    throw Object.assign(new Error(`subscription not found for orgId=${orgId}`), { status: 404 });
+  }
+
+  const updated = await SubscriptionRepository.adminUpdatePlanOnly(String(existing._id), newPlanId, adminUserId);
+
+  // Sync org plan so meter quotas / feature flags / access control reflect the bump immediately.
+  // Without this the new plan only applies to the subscription doc, but the organization's plan
+  // field — read by requirePlan / requireQuota — stays stale until the next Stripe webhook.
+  await OrganizationRepository.setPlan(orgId, newPlanId);
+
+  logger.info('[billing.admin] plan bumped manually', {
+    orgId,
+    previousPlan: existing.plan,
+    newPlan: newPlanId,
+    adminUserId,
+    subscriptionId: String(existing._id),
+  });
+
+  return updated;
+};
+
 export default {
   getCustomerStatus,
   syncOrgFromStripe,
@@ -431,4 +482,5 @@ export default {
   purgeDeadLetter,
   cancelSubscription,
   creditDisputeReinstated,
+  bumpOrgPlan,
 };

--- a/modules/billing/services/billing.admin.service.js
+++ b/modules/billing/services/billing.admin.service.js
@@ -321,8 +321,9 @@ const creditDisputeReinstated = async (chargeId, amountCents, reason, refundRequ
 
   // Guard: reject credits for non-existent orgs — mirrors the debit existence guard.
   // A 24-hex match that references a ghost org would silently create a ledger doc for nobody.
-  const org = await OrganizationRepository.get(orgId);
-  if (!org) {
+  // OrganizationRepository.exists() uses Mongoose .exists() — lighter than a full findOne+populate.
+  const orgExists = await OrganizationRepository.exists({ _id: orgId });
+  if (!orgExists) {
     throw Object.assign(new Error(`organization not found: ${orgId}`), { status: 422 });
   }
 

--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -5,7 +5,7 @@ import config from '../../../config/index.js';
 import getStripe from '../lib/stripe.js';
 import logger from '../../../lib/services/logger.js';
 import billingEvents from '../lib/events.js';
-import { currentWeekKey } from '../lib/billing.isoWeek.js';
+import { currentWeekKey, weekStartDate } from '../lib/billing.isoWeek.js';
 
 /**
  * Page size for the reconciliation cursor — fetch in batches to avoid long-running queries.
@@ -122,22 +122,22 @@ const _fetchPage = async (SubscriptionRepository, page, limit) => {
  * Returns { diverged: boolean, expectedExtrasUsage: number, actualExtrasDebits: number }.
  *
  * Strategy:
+ *   Both sides use the same ISO week window (currentWeekKey boundaries):
  *   expectedExtrasUsage = units consumed beyond quota in the current week (overflow).
- *   actualExtrasDebits  = absolute sum of debit ledger entries in the current billing period
- *                         (since currentPeriodStart). Note: this may span multiple weekly
- *                         meter buckets — that's intentional; we compare the current-week
- *                         overflow against the period's debit history to detect missing debits.
+ *   actualExtrasDebits  = absolute sum of debit ledger entries within the current week.
+ *
+ * Alignment note: using the same ISO week window avoids the cross-window
+ * mismatch between billing-period debits and weekly meter overflow.
  *
  * Tolerance: divergence is only reported when
  *   |expected - actual| > max(50, 0.5% × max(expected, actual))
  * This avoids noise from timing skew (usage write before debit commits).
  *
  * @param {string} orgId
- * @param {Object} sub - DB subscription (lean) — provides currentPeriodStart.
  * @returns {Promise<{diverged: boolean, expectedExtrasUsage: number, actualExtrasDebits: number}>}
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
-const _checkMeterExtrasMismatch = async (orgId, sub) => {
+const _checkMeterExtrasMismatch = async (orgId) => {
   // Lazy imports — deferred to keep unit tests importable before model registration.
   const { default: BillingUsageRepository } = await import('../repositories/billing.usage.repository.js');
   const { default: BillingExtraBalanceRepository } = await import('../repositories/billing.extraBalance.repository.js');
@@ -152,23 +152,16 @@ const _checkMeterExtrasMismatch = async (orgId, sub) => {
   // meterQuota=0 means free plan — every unit is extras.
   const expectedExtrasUsage = meterQuota === 0 ? meterUsed : Math.max(0, meterUsed - meterQuota);
 
-  // actualExtrasDebits: absolute sum of debit ledger entries since current period started.
-  // Use currentPeriodStart from the DB subscription as period boundary.
-  // When not set (null/undefined), no date cutoff is applied — all debit entries are summed.
-  const periodStart = sub.currentPeriodStart ? new Date(sub.currentPeriodStart) : null;
+  // actualExtrasDebits: server-side aggregated sum of debit entries in the same ISO week.
+  // Both sides share the same week boundary — apples-to-apples comparison (CodeRabbit fix).
+  const weekStart = weekStartDate(weekKey);
+  const weekEnd = new Date(weekStart.getTime() + 7 * 86_400_000); // exclusive upper bound
 
-  const ledger = await BillingExtraBalanceRepository.findLedgerByOrg(orgId);
-  const extraDoc = ledger ? { ledger } : null;
-
-  let actualExtrasDebits = 0;
-  if (extraDoc?.ledger) {
-    for (const entry of extraDoc.ledger) {
-      if (entry.kind !== 'debit') continue;
-      if (periodStart && entry.at && new Date(entry.at) < periodStart) continue;
-      // Debit entries have negative amount; sum their absolute values.
-      actualExtrasDebits += Math.abs(entry.amount);
-    }
-  }
+  const actualExtrasDebits = await BillingExtraBalanceRepository.sumDebitsByWindow(
+    orgId,
+    weekStart,
+    weekEnd,
+  );
 
   // Tolerance: abs(delta) > max(50, 0.5% × max(expected, actual)) triggers divergence.
   const delta = Math.abs(expectedExtrasUsage - actualExtrasDebits);
@@ -204,7 +197,7 @@ const _reconcileOne = async (stripe, sub) => {
   // have an accumulating ledger mismatch if debits were silently dropped.
   let meterExtrasMismatch = false;
   try {
-    const mismatchResult = await _checkMeterExtrasMismatch(orgId, sub);
+    const mismatchResult = await _checkMeterExtrasMismatch(orgId);
     meterExtrasMismatch = mismatchResult.diverged;
 
     if (meterExtrasMismatch) {

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -1029,16 +1029,31 @@ const handleSubscriptionCreated = async (subscription, event) => {
       organizationId,
       eventId: event?.id,
     });
-    await SubscriptionRepository.create({
-      organization: organizationId,
-      stripeCustomerId: subscription.customer,
-      stripeSubscriptionId: subscription.id,
-      plan: newPlan,
-      status: subscription.status,
-      lastSubscriptionEventCreatedAt: event.created,
-      lastSubscriptionEventId: event.id,
-      ...(newPeriodStart ? { currentPeriodStart: newPeriodStart } : {}),
-    });
+    try {
+      await SubscriptionRepository.create({
+        organization: organizationId,
+        stripeCustomerId: subscription.customer,
+        stripeSubscriptionId: subscription.id,
+        plan: newPlan,
+        status: subscription.status,
+        lastSubscriptionEventCreatedAt: event.created,
+        lastSubscriptionEventId: event.id,
+        ...(newPeriodStart ? { currentPeriodStart: newPeriodStart } : {}),
+      });
+    } catch (err) {
+      if (err.code === 11000) {
+        // Duplicate key — a concurrent subscription.created delivery (or checkout.session.completed
+        // racing ahead) already inserted the row. Skip creation gracefully; the existing row
+        // carries the correct state and withIdempotency will not dead-letter this event.
+        logger.warn('[billing.webhook] secondary subscription detected for org, skipping duplicate creation', {
+          organizationId,
+          stripeSubscriptionId: subscription.id,
+          eventId: event?.id,
+        });
+        return { skipped: true, reason: 'duplicate' };
+      }
+      throw err;
+    }
     await syncOrganizationPlan(organizationId, newPlan);
     return;
   }

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -995,7 +995,10 @@ const handleChargeDisputeFundsWithdrawn = async (dispute, event) => {
  *              Idempotent via updateIfEventNewer (existing) or event marker seeding (new row).
  * @param {Object} subscription - Stripe subscription object
  * @param {Object} event - Full Stripe event for event-ordering guard
- * @returns {Promise<void>}
+ * @returns {Promise<void|{skipped: boolean, reason: string}>} Returns a skip sentinel
+ *          `{ skipped: true, reason: 'duplicate' }` when a concurrent delivery triggers an
+ *          E11000 duplicate-key error on create — graceful no-op, does not dead-letter.
+ *          Returns void in all other cases (including stale-event skip via updateIfEventNewer).
  */
 // biome-ignore lint/correctness/useQwikValidLexicalScope: false positive — Node.js service, not Qwik
 const handleSubscriptionCreated = async (subscription, event) => {

--- a/modules/billing/tests/billing.admin.integration.tests.js
+++ b/modules/billing/tests/billing.admin.integration.tests.js
@@ -198,6 +198,9 @@ describe('Billing admin integration tests:', () => {
         listDeadLetters: jest.fn(),
         purgeDeadLetter: jest.fn(),
         cancelSubscription: jest.fn(),
+        creditDisputeReinstated: jest.fn(),
+        // Batch 3a: adminBumpPlan now delegates here (controller→service refactor)
+        bumpOrgPlan: jest.fn().mockResolvedValue({ _id: '607f1f77bcf86cd799439033', plan: 'pro' }),
       },
     }));
 

--- a/modules/billing/tests/billing.admin.service.unit.tests.js
+++ b/modules/billing/tests/billing.admin.service.unit.tests.js
@@ -62,7 +62,7 @@ describe('BillingAdminService unit tests:', () => {
     };
 
     mockOrganizationRepository = {
-      get: jest.fn().mockResolvedValue({ _id: orgId, plan: 'pro' }),
+      exists: jest.fn().mockResolvedValue({ _id: orgId }),
       setPlan: jest.fn().mockResolvedValue({}),
     };
 
@@ -488,7 +488,7 @@ describe('BillingAdminService unit tests:', () => {
     });
 
     test('throws 422 when org does not exist in DB (ghost org guard)', async () => {
-      mockOrganizationRepository.get.mockResolvedValueOnce(null);
+      mockOrganizationRepository.exists.mockResolvedValueOnce(null);
       await expect(
         BillingAdminService.creditDisputeReinstated(chargeId, amountCents, reason, refundRequestId, orgId, adminUserId),
       ).rejects.toMatchObject({ status: 422 });

--- a/modules/billing/tests/billing.admin.service.unit.tests.js
+++ b/modules/billing/tests/billing.admin.service.unit.tests.js
@@ -62,6 +62,7 @@ describe('BillingAdminService unit tests:', () => {
     };
 
     mockOrganizationRepository = {
+      get: jest.fn().mockResolvedValue({ _id: orgId, plan: 'pro' }),
       setPlan: jest.fn().mockResolvedValue({}),
     };
 
@@ -129,11 +130,6 @@ describe('BillingAdminService unit tests:', () => {
     jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
     jest.unstable_mockModule('../../../lib/services/logger.js', () => ({ default: mockLogger }));
     jest.unstable_mockModule('../lib/stripe.js', () => ({ default: mockGetStripe }));
-    jest.unstable_mockModule('mongoose', () => ({
-      default: {
-        Types: { ObjectId: { isValid: (id) => /^[a-f\d]{24}$/i.test(id) } },
-      },
-    }));
     jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
       default: mockSubscriptionRepository,
     }));
@@ -485,10 +481,18 @@ describe('BillingAdminService unit tests:', () => {
       expect(result.ledgerEntry).toBeNull();
     });
 
-    test('throws 422 for invalid orgId', async () => {
+    test('throws 422 for invalid orgId (regex)', async () => {
       await expect(
         BillingAdminService.creditDisputeReinstated(chargeId, amountCents, reason, refundRequestId, 'bad-id', adminUserId),
       ).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('throws 422 when org does not exist in DB (ghost org guard)', async () => {
+      mockOrganizationRepository.get.mockResolvedValueOnce(null);
+      await expect(
+        BillingAdminService.creditDisputeReinstated(chargeId, amountCents, reason, refundRequestId, orgId, adminUserId),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(mockExtraBalanceRepository.creditCompensation).not.toHaveBeenCalled();
     });
 
     test('throws 422 for invalid chargeId (not starting with ch_)', async () => {
@@ -516,6 +520,53 @@ describe('BillingAdminService unit tests:', () => {
       await expect(
         BillingAdminService.creditDisputeReinstated(chargeId, amountCents, 'ab', refundRequestId, orgId, adminUserId),
       ).rejects.toMatchObject({ status: 422 });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // bumpOrgPlan (Item 1 — Batch 3a: controller→service refactor)
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('bumpOrgPlan:', () => {
+    const adminUserId = '617f1f77bcf86cd799439099';
+    const planId = 'starter';
+
+    beforeEach(() => {
+      mockSubscriptionRepository.adminUpdatePlanOnly = jest.fn().mockResolvedValue(makeDbSub({ plan: planId }));
+    });
+
+    test('finds subscription, updates plan-only, syncs org, logs info', async () => {
+      const result = await BillingAdminService.bumpOrgPlan(orgId, planId, adminUserId);
+
+      expect(mockSubscriptionRepository.findByOrganization).toHaveBeenCalledWith(orgId);
+      expect(mockSubscriptionRepository.adminUpdatePlanOnly).toHaveBeenCalledWith(subId, planId, adminUserId);
+      expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, planId);
+      expect(result.plan).toBe(planId);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[billing.admin] plan bumped manually',
+        expect.objectContaining({ orgId, newPlan: planId, adminUserId }),
+      );
+    });
+
+    test('throws 404 when no subscription exists for org', async () => {
+      mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+
+      await expect(BillingAdminService.bumpOrgPlan(orgId, planId, adminUserId)).rejects.toMatchObject({ status: 404 });
+    });
+
+    test('throws 422 for invalid orgId format', async () => {
+      await expect(BillingAdminService.bumpOrgPlan('bad-id', planId, adminUserId)).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('throws 422 when adminUserId is missing', async () => {
+      await expect(BillingAdminService.bumpOrgPlan(orgId, planId, '')).rejects.toMatchObject({ status: 422 });
+      await expect(BillingAdminService.bumpOrgPlan(orgId, planId, null)).rejects.toMatchObject({ status: 422 });
+    });
+
+    test('does not call OrganizationRepository.setPlan when adminUpdatePlanOnly fails', async () => {
+      mockSubscriptionRepository.adminUpdatePlanOnly.mockRejectedValue(new Error('DB write failed'));
+
+      await expect(BillingAdminService.bumpOrgPlan(orgId, planId, adminUserId)).rejects.toThrow('DB write failed');
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
     });
   });
 

--- a/modules/billing/tests/billing.isoWeek.unit.tests.js
+++ b/modules/billing/tests/billing.isoWeek.unit.tests.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 import { describe, test, expect } from '@jest/globals';
-import { currentWeekKey, isoWeekKey } from '../lib/billing.isoWeek.js';
+import { currentWeekKey, isoWeekKey, weekStartDate } from '../lib/billing.isoWeek.js';
 
 /**
  * @function referenceIsoWeekKey
@@ -47,5 +47,29 @@ describe('billing.isoWeek unit tests:', () => {
 
   test('currentWeekKey returns an ISO week key', () => {
     expect(currentWeekKey()).toMatch(/^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/);
+  });
+
+  test('weekStartDate returns the Monday 00:00:00 UTC of the given ISO week key', () => {
+    // 2026-W01 starts on 2025-12-29 (Mon) — ISO week 1 rule: week containing Jan 4
+    expect(weekStartDate('2026-W01').toISOString()).toBe('2025-12-29T00:00:00.000Z');
+    // 2026-W18 starts on 2026-04-27 (Mon)
+    expect(weekStartDate('2026-W18').toISOString()).toBe('2026-04-27T00:00:00.000Z');
+    // 2024-W09 (leap year week containing Feb 29)
+    expect(weekStartDate('2024-W09').toISOString()).toBe('2024-02-26T00:00:00.000Z');
+    // 2020-W53 — 53-week year
+    expect(weekStartDate('2020-W53').toISOString()).toBe('2020-12-28T00:00:00.000Z');
+  });
+
+  test('weekStartDate round-trips with isoWeekKey', () => {
+    const testDates = [
+      new Date('2026-04-27T00:00:00.000Z'),
+      new Date('2021-01-04T00:00:00.000Z'),
+      new Date('2024-02-26T00:00:00.000Z'),
+    ];
+    for (const d of testDates) {
+      const key = isoWeekKey(d);
+      const start = weekStartDate(key);
+      expect(isoWeekKey(start)).toBe(key);
+    }
   });
 });

--- a/modules/billing/tests/billing.policy.unit.tests.js
+++ b/modules/billing/tests/billing.policy.unit.tests.js
@@ -1,0 +1,93 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, expect } from '@jest/globals';
+
+/**
+ * Unit tests for billing CASL policy — subject registration + ability resolution.
+ *
+ * Covers the Item 3 fix from Batch 3a:
+ *   Before the fix, parameterised admin routes (/:orgId, /:eventId) were registered
+ *   without their Express patterns, so deriveSubjectType returned null for those routes.
+ *   A future narrower role with `can('read', 'BillingAdminOps')` would 403 silently.
+ *
+ * After the fix, all 8 admin admin billing paths resolve to 'BillingAdminOps'.
+ */
+
+// Mock logger before importing policy (logger touches config.log at load time)
+jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+  default: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+// Mock CASL — tests only exercise deriveSubjectType (pure string lookup, no ability build needed)
+jest.unstable_mockModule('@casl/ability', () => ({
+  AbilityBuilder: jest.fn().mockImplementation(() => ({
+    can: jest.fn(),
+    cannot: jest.fn(),
+    build: jest.fn().mockReturnValue({ can: jest.fn().mockReturnValue(true) }),
+  })),
+  Ability: jest.fn(),
+  subject: jest.fn((type, doc) => doc),
+}));
+
+const { default: policy } = await import('../../../lib/middlewares/policy.js');
+const { billingSubjectRegistration } = await import('../policies/billing.policy.js');
+
+describe('billing.policy — CASL subject registration unit tests:', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset policy registries so each test starts from a clean state.
+    // discoverPolicies clears the internal registries before repopulating.
+    // We call registerPathSubject directly here via the exported registration fn.
+    //
+    // Workaround: policy registries are module-level arrays. Re-trigger registration
+    // by calling the registration function with the exposed registerPathSubject helper.
+    billingSubjectRegistration({ registerPathSubject: policy.registerPathSubject });
+  });
+
+  // ── User-facing billing routes ──────────────────────────────────────────────
+
+  test.each([
+    ['/api/billing/checkout', 'BillingCheckout'],
+    ['/api/billing/portal', 'BillingPortal'],
+    ['/api/billing/subscription', 'BillingSubscription'],
+    ['/api/billing/usage', 'BillingUsage'],
+    ['/api/billing/plans', 'BillingPlans'],
+    ['/api/billing/extras/checkout', 'BillingExtrasCheckout'],
+    ['/api/billing/extras/balance', 'BillingExtrasBalance'],
+    ['/api/billing/extras/ledger', 'BillingExtrasLedger'],
+  ])('resolves %s → %s', (routePath, expectedSubject) => {
+    expect(policy.deriveSubjectType(routePath)).toBe(expectedSubject);
+  });
+
+  // ── Admin billing routes — non-parameterised ────────────────────────────────
+
+  test.each([
+    ['/api/admin/billing/refund', 'BillingAdminRefund'],
+    ['/api/admin/billing/plans/bump', 'BillingAdminPlanBump'],
+    ['/api/admin/billing/webhook/replay', 'BillingAdminOps'],
+    ['/api/admin/billing/dead-letters', 'BillingAdminOps'],
+  ])('resolves %s → %s', (routePath, expectedSubject) => {
+    expect(policy.deriveSubjectType(routePath)).toBe(expectedSubject);
+  });
+
+  // ── Admin billing routes — parameterised (Item 3 fix) ──────────────────────
+  // These were previously registered WITHOUT their Express patterns, so
+  // deriveSubjectType returned null. Now they must resolve to 'BillingAdminOps'.
+
+  test.each([
+    ['/api/admin/billing/customer/:orgId', 'BillingAdminOps'],
+    ['/api/admin/billing/sync/:orgId', 'BillingAdminOps'],
+    ['/api/admin/billing/dead-letters/:eventId', 'BillingAdminOps'],
+    ['/api/admin/billing/cancel/:orgId', 'BillingAdminOps'],
+    ['/api/admin/billing/dispute/credit/:orgId', 'BillingAdminOps'],
+  ])('parameterised route %s → %s (was null before fix)', (routePath, expectedSubject) => {
+    expect(policy.deriveSubjectType(routePath)).toBe(expectedSubject);
+  });
+
+  // ── Unknown route returns null ──────────────────────────────────────────────
+
+  test('unknown path returns null', () => {
+    expect(policy.deriveSubjectType('/api/billing/unknown-route')).toBeNull();
+  });
+});

--- a/modules/billing/tests/billing.policy.unit.tests.js
+++ b/modules/billing/tests/billing.policy.unit.tests.js
@@ -11,7 +11,7 @@ import { jest, describe, test, beforeEach, expect } from '@jest/globals';
  *   without their Express patterns, so deriveSubjectType returned null for those routes.
  *   A future narrower role with `can('read', 'BillingAdminOps')` would 403 silently.
  *
- * After the fix, all 8 admin admin billing paths resolve to 'BillingAdminOps'.
+ * After the fix, all admin billing paths resolve to their correct CASL subject type.
  */
 
 // Mock logger before importing policy (logger touches config.log at load time)
@@ -34,14 +34,13 @@ const { default: policy } = await import('../../../lib/middlewares/policy.js');
 const { billingSubjectRegistration } = await import('../policies/billing.policy.js');
 
 describe('billing.policy — CASL subject registration unit tests:', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
-    // Reset policy registries so each test starts from a clean state.
-    // discoverPolicies clears the internal registries before repopulating.
-    // We call registerPathSubject directly here via the exported registration fn.
-    //
-    // Workaround: policy registries are module-level arrays. Re-trigger registration
-    // by calling the registration function with the exposed registerPathSubject helper.
+    // Reset the shared module-level registries before each test to avoid cross-test
+    // contamination (registries accumulate entries across calls; discoverPolicies([])
+    // clears them without loading any policy file).
+    await policy.discoverPolicies([]);
+    // Re-register billing subjects so each test has exactly one set of entries.
     billingSubjectRegistration({ registerPathSubject: policy.registerPathSubject });
   });
 

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -74,11 +74,9 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
       findByWeek: jest.fn().mockResolvedValue({ meterUsed: 200, meterQuota: 100 }),
     };
 
-    // Default extra balance: ledger with 100-unit debit (matches expected)
+    // Default extra balance: 100-unit debit sum for the current week (matches expected)
     mockExtraBalanceRepository = {
-      findLedgerByOrg: jest.fn().mockResolvedValue([
-        { kind: 'debit', amount: -100, at: new Date() },
-      ]),
+      sumDebitsByWindow: jest.fn().mockResolvedValue(100),
     };
 
     jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
@@ -87,6 +85,7 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     jest.unstable_mockModule('../lib/events.js', () => ({ default: mockEvents }));
     jest.unstable_mockModule('../lib/billing.isoWeek.js', () => ({
       currentWeekKey: jest.fn().mockReturnValue('2026-W18'),
+      weekStartDate: jest.fn().mockReturnValue(new Date('2026-04-28T00:00:00.000Z')),
     }));
     jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
       default: mockSubscriptionRepository,
@@ -272,12 +271,9 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
       mockStripeInstance.subscriptions.retrieve.mockResolvedValue(makeStripeSub());
 
       // meterUsed=200, meterQuota=100 → expectedExtras=100
-      // ledger debit=-100 → actualDebits=100
-      // delta=0 → within tolerance → no divergence
+      // sumDebitsByWindow returns 100 → delta=0 → within tolerance → no divergence
       mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 200, meterQuota: 100 });
-      mockExtraBalanceRepository.findLedgerByOrg.mockResolvedValue([
-        { kind: 'debit', amount: -100, at: new Date() },
-      ]);
+      mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(100);
 
       const result = await BillingReconcileService.runReconciliation();
 
@@ -298,9 +294,7 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
       // tolerance = max(50, 0.5% × 10000) = max(50, 50) = 50
       // delta(10) <= tolerance(50) → no divergence
       mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 10100, meterQuota: 100 });
-      mockExtraBalanceRepository.findLedgerByOrg.mockResolvedValue([
-        { kind: 'debit', amount: -9990, at: new Date() },
-      ]);
+      mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(9990);
 
       await BillingReconcileService.runReconciliation();
 
@@ -318,9 +312,7 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
       // expectedExtras=10000, actualDebits=5000 → delta=5000
       // tolerance = max(50, 0.5% × 10000) = 50 → delta(5000) >> tolerance
       mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 10100, meterQuota: 100 });
-      mockExtraBalanceRepository.findLedgerByOrg.mockResolvedValue([
-        { kind: 'debit', amount: -5000, at: new Date() },
-      ]);
+      mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(5000);
 
       const result = await BillingReconcileService.runReconciliation();
 
@@ -366,11 +358,9 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
       );
 
       // meterUsed=50, meterQuota=0 → expectedExtras=50 (all units are extras)
-      // actualDebits=50 → delta=0 → no divergence
+      // sumDebitsByWindow returns 50 → delta=0 → no divergence
       mockUsageRepository.findByWeek.mockResolvedValue({ meterUsed: 50, meterQuota: 0 });
-      mockExtraBalanceRepository.findLedgerByOrg.mockResolvedValue([
-        { kind: 'debit', amount: -50, at: new Date() },
-      ]);
+      mockExtraBalanceRepository.sumDebitsByWindow.mockResolvedValue(50);
 
       await BillingReconcileService.runReconciliation();
 

--- a/modules/billing/tests/billing.refund.service.unit.tests.js
+++ b/modules/billing/tests/billing.refund.service.unit.tests.js
@@ -277,9 +277,7 @@ describe('Admin refund controller unit tests:', () => {
 
 describe('adminBumpPlan controller unit tests:', () => {
   let adminBumpPlan;
-  let mockSubscriptionRepository;
-  let mockOrganizationRepository;
-  let mockLogger;
+  let mockBillingAdminService;
   let mockResponses;
 
   const orgId = '507f1f77bcf86cd799439011';
@@ -295,19 +293,16 @@ describe('adminBumpPlan controller unit tests:', () => {
   beforeEach(async () => {
     jest.resetModules();
 
-    mockSubscriptionRepository = {
-      findByOrganization: jest.fn().mockResolvedValue({ _id: subId, plan: 'free', organization: orgId }),
-      adminUpdatePlanOnly: jest.fn().mockResolvedValue({ _id: subId, plan: 'pro' }),
-    };
-
-    mockOrganizationRepository = {
-      setPlan: jest.fn().mockResolvedValue({}),
-    };
-
-    mockLogger = {
-      info: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
+    // Controller delegates entirely to BillingAdminService.bumpOrgPlan — mock the service.
+    mockBillingAdminService = {
+      bumpOrgPlan: jest.fn().mockResolvedValue({ _id: subId, plan: 'pro' }),
+      getCustomerStatus: jest.fn(),
+      syncOrgFromStripe: jest.fn(),
+      replayWebhookEvent: jest.fn(),
+      listDeadLetters: jest.fn(),
+      purgeDeadLetter: jest.fn(),
+      cancelSubscription: jest.fn(),
+      creditDisputeReinstated: jest.fn(),
     };
 
     mockResponses = {
@@ -315,35 +310,28 @@ describe('adminBumpPlan controller unit tests:', () => {
       error: jest.fn(() => jest.fn()),
     };
 
-    jest.unstable_mockModule('../repositories/billing.subscription.repository.js', () => ({
-      default: mockSubscriptionRepository,
-    }));
-
-    jest.unstable_mockModule('../../organizations/repositories/organizations.repository.js', () => ({
-      default: mockOrganizationRepository,
-    }));
-
-    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
-      default: mockLogger,
+    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
+      default: mockBillingAdminService,
     }));
 
     jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
       default: mockResponses,
     }));
 
-    // Stripe not needed for adminBumpPlan but imported at module level
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+    }));
+
+    // Stripe imported at module level but not used by adminBumpPlan anymore
     jest.unstable_mockModule('../lib/stripe.js', () => ({ default: jest.fn(() => null) }));
 
-    // Mock admin service to prevent deep import chain touching mongoose models
-    jest.unstable_mockModule('../services/billing.admin.service.js', () => ({
-      default: {
-        getCustomerStatus: jest.fn(),
-        syncOrgFromStripe: jest.fn(),
-        replayWebhookEvent: jest.fn(),
-        listDeadLetters: jest.fn(),
-        purgeDeadLetter: jest.fn(),
-        cancelSubscription: jest.fn(),
-      },
+    // AdminDeadLettersQuery imported at module level
+    jest.unstable_mockModule('../models/billing.subscription.schema.js', () => ({
+      AdminDeadLettersQuery: { safeParse: jest.fn().mockReturnValue({ success: true, data: { page: 1, limit: 20 } }) },
+      AdminRefundRequest: {},
+      AdminBumpPlanRequest: {},
+      AdminWebhookReplayRequest: {},
+      AdminDisputeCreditRequest: {},
     }));
 
     const mod = await import('../controllers/billing.admin.controller.js');
@@ -354,42 +342,44 @@ describe('adminBumpPlan controller unit tests:', () => {
     jest.restoreAllMocks();
   });
 
-  test('returns 422 when req.user._id is missing', async () => {
+  test('returns 422 when req.user._id is missing (service throws 422)', async () => {
+    mockBillingAdminService.bumpOrgPlan.mockRejectedValue(
+      Object.assign(new Error('invalid argument: authenticated user id is missing'), { status: 422 }),
+    );
     const req = { body: { orgId, planId: 'pro' }, user: {} };
     const res = makeRes();
 
     await adminBumpPlan(req, res);
 
     expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to bump plan');
-    expect(mockSubscriptionRepository.findByOrganization).not.toHaveBeenCalled();
   });
 
-  test('returns 404 when no subscription found for org', async () => {
-    mockSubscriptionRepository.findByOrganization.mockResolvedValue(null);
+  test('returns 404 when no subscription found for org (service throws 404)', async () => {
+    mockBillingAdminService.bumpOrgPlan.mockRejectedValue(
+      Object.assign(new Error(`subscription not found for orgId=${orgId}`), { status: 404 }),
+    );
     const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
     const res = makeRes();
 
     await adminBumpPlan(req, res);
 
-    expect(mockResponses.error).toHaveBeenCalledWith(res, 404, 'Not Found', 'Subscription not found for organization');
-    expect(mockSubscriptionRepository.adminUpdatePlanOnly).not.toHaveBeenCalled();
+    expect(mockResponses.error).toHaveBeenCalledWith(res, 404, 'Not Found', 'Failed to bump plan');
   });
 
-  test('returns 200 on happy path', async () => {
+  test('returns 200 on happy path — delegates to BillingAdminService.bumpOrgPlan', async () => {
     const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
     const res = makeRes();
 
     await adminBumpPlan(req, res);
 
-    expect(mockSubscriptionRepository.adminUpdatePlanOnly).toHaveBeenCalledWith(subId, 'pro', adminId);
-    expect(mockOrganizationRepository.setPlan).toHaveBeenCalledWith(orgId, 'pro');
+    expect(mockBillingAdminService.bumpOrgPlan).toHaveBeenCalledWith(orgId, 'pro', adminId);
     expect(mockResponses.success).toHaveBeenCalledWith(res, 'subscription plan bumped');
   });
 
-  test('returns 422 on Mongoose ValidationError', async () => {
+  test('returns 422 on Mongoose ValidationError from service', async () => {
     const validationErr = new Error('plan is invalid');
     validationErr.name = 'ValidationError';
-    mockSubscriptionRepository.adminUpdatePlanOnly.mockRejectedValue(validationErr);
+    mockBillingAdminService.bumpOrgPlan.mockRejectedValue(validationErr);
     const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
     const res = makeRes();
 
@@ -398,8 +388,8 @@ describe('adminBumpPlan controller unit tests:', () => {
     expect(mockResponses.error).toHaveBeenCalledWith(res, 422, 'Unprocessable Entity', 'Failed to bump plan');
   });
 
-  test('returns 500 on unexpected error', async () => {
-    mockSubscriptionRepository.adminUpdatePlanOnly.mockRejectedValue(new Error('db timeout'));
+  test('returns 500 on unexpected error from service', async () => {
+    mockBillingAdminService.bumpOrgPlan.mockRejectedValue(new Error('db timeout'));
     const req = { body: { orgId, planId: 'pro' }, user: { _id: adminId } };
     const res = makeRes();
 

--- a/modules/billing/tests/billing.webhook.integration.tests.js
+++ b/modules/billing/tests/billing.webhook.integration.tests.js
@@ -560,6 +560,43 @@ describe('Billing webhook integration tests:', () => {
       expect(mockSubscriptionRepository.findByStripeCustomerId).not.toHaveBeenCalled();
       expect(mockSubscriptionRepository.create).not.toHaveBeenCalled();
     });
+
+    test('E11000 duplicate key: logs warn and returns { skipped: true, reason: duplicate } without dead-lettering', async () => {
+      const orgSub = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+      mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(orgSub);
+      const dupErr = Object.assign(new Error('E11000 duplicate key error'), { code: 11000 });
+      mockSubscriptionRepository.create.mockRejectedValue(dupErr);
+
+      const result = await WebhookService.handleSubscriptionCreated(
+        {
+          id: 'sub_dup_001',
+          customer: 'cus_123',
+          status: 'active',
+          items: { data: [{ current_period_start: 1700000000, price: { metadata: { planId: 'pro' } } }] },
+        },
+        makeEvent({ id: 'evt_dup_1', created: 1700000070 }),
+      );
+
+      expect(result).toMatchObject({ skipped: true, reason: 'duplicate' });
+      // org plan sync must NOT have been called when creation was skipped
+      expect(mockOrganizationRepository.setPlan).not.toHaveBeenCalled();
+    });
+
+    test('E11000 catch: re-throws non-duplicate errors (not all errors are swallowed)', async () => {
+      const orgSub = { _id: subId, organization: orgId };
+      mockSubscriptionRepository.findByStripeSubscriptionId.mockResolvedValue(null);
+      mockSubscriptionRepository.findByStripeCustomerId.mockResolvedValue(orgSub);
+      const dbErr = Object.assign(new Error('DB connection lost'), { code: 13435 });
+      mockSubscriptionRepository.create.mockRejectedValue(dbErr);
+
+      await expect(
+        WebhookService.handleSubscriptionCreated(
+          { id: 'sub_dberr', customer: 'cus_123', status: 'active', items: { data: [] } },
+          makeEvent(),
+        ),
+      ).rejects.toThrow('DB connection lost');
+    });
   });
 
   describe('handleChargeDisputeFundsReinstated', () => {


### PR DESCRIPTION
## Summary

- **Policy**: Register all admin routes with `:param` suffixes — fixes 403 for `/api/admin/billing/customer/:orgId`, `/sync/:orgId`, `/cancel/:orgId`, `/dead-letters/:eventId` (CASL `deriveSubjectType` uses exact-string match on `req.route.path`)
- **Admin service**: Extract `bumpOrgPlan()` from controller into service layer; add org-existence guard in `creditDisputeReinstated` (ghost org can't silently create a ledger doc)
- **Reconcile**: Align meter↔extras comparison to same ISO week window on both sides using `sumDebitsByWindow()` aggregation + `weekStartDate()` — fixes false positives on annual plans spanning multiple weekly buckets
- **Webhook**: Wrap `SubscriptionRepository.create` in duplicate-key guard (code 11000) for concurrent `subscription.created` delivery
- **RUNBOOKS.md**: Blank lines + language tags on fenced blocks (markdownlint fix)

## Test plan

- [ ] All 90 unit test suites green (`npm run test:unit` — 1316 tests)
- [ ] Lint clean (`npm run lint` — 0 errors)
- [ ] Integration tests green (CI)
- [ ] CodeRabbit 0 threads