### PR TITLE
fix(billing): reconcile trialing subscriptions

### DIFF
--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -37,7 +37,7 @@ const resolveStripePlan = (subscription) => {
 
 /**
  * @function runReconciliation
- * @description Paginate all active|past_due subscriptions, fetch live Stripe status for each,
+ * @description Paginate all active|past_due|trialing subscriptions, fetch live Stripe status for each,
  *              and emit billing.reconciliation.divergence when status or plan diverges.
  *
  *              LOG-ONLY policy: this function NEVER writes to the DB or Stripe.

--- a/modules/billing/services/billing.reconcile.service.js
+++ b/modules/billing/services/billing.reconcile.service.js
@@ -15,7 +15,7 @@ const RECONCILE_PAGE_SIZE = 100;
 /**
  * Statuses reconciled against Stripe.
  */
-const RECONCILE_STATUSES = ['active', 'past_due'];
+const RECONCILE_STATUSES = ['active', 'past_due', 'trialing'];
 
 /**
  * Valid plan names from config.

--- a/modules/billing/tests/billing.reconcile.service.unit.tests.js
+++ b/modules/billing/tests/billing.reconcile.service.unit.tests.js
@@ -182,6 +182,25 @@ describe('BillingReconcileService.runReconciliation unit tests:', () => {
     );
   });
 
+  test('detects plan drift on trialing sub — emits billing.reconciliation.divergence (C4)', async () => {
+    const sub = makeDbSub({ status: 'trialing', plan: 'pro' });
+    mockSubscriptionRepository.findPageForReconciliation
+      .mockResolvedValueOnce([sub])
+      .mockResolvedValue([]);
+    // Stripe has plan: starter — simulates Dashboard bump with lost webhook
+    mockStripeInstance.subscriptions.retrieve.mockResolvedValue(
+      makeStripeSub({ status: 'trialing', items: { data: [{ price: { metadata: { planId: 'starter' } } }] } }),
+    );
+
+    const result = await BillingReconcileService.runReconciliation();
+
+    expect(result).toMatchObject({ checked: 1, divergences: 1, errors: 0 });
+    expect(mockEvents.emit).toHaveBeenCalledWith(
+      'billing.reconciliation.divergence',
+      expect.objectContaining({ organizationId: orgId, planMismatch: true }),
+    );
+  });
+
   test('counts errors and continues on individual Stripe retrieve failure', async () => {
     const subs = [makeDbSub(), makeDbSub({ _id: 'sub_doc_002', stripeSubscriptionId: 'sub_test_002' })];
     mockSubscriptionRepository.findPageForReconciliation


### PR DESCRIPTION
## Summary

- V8 audit C4: add `'trialing'` to `RECONCILE_STATUSES` in `billing.reconcile.service.js` (1 production LOC)
- Trialing orgs now included in the weekly Stripe↔DB reconciliation sweep, closing a 7-14 day blind spot where plan/status drift was invisible until trial conversion
- Adds unit test: trialing sub with DB plan=`pro` vs Stripe plan=`starter` → `billing.reconciliation.divergence` emitted

## Test plan

- [ ] `billing.reconcile.service.unit.tests.js` — 19/19 pass (was 18/18), new test: `detects plan drift on trialing sub — emits billing.reconciliation.divergence (C4)`
- [ ] Lint: ESLint 0 issues
- [ ] LOG-ONLY policy preserved: no DB writes in the changed paths