### PR TITLE
docs(billing): document MongoDB ≥ 5.2 minimum (#3630)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Designed to be cloned into downstream projects and kept up-to-date via `git merg
 - Git - [Download & Install Git](https://git-scm.com/downloads)
 - Node.js (22.x or 24.x) - [Download & Install Node.js](https://nodejs.org/en/download/)
   - Recommended: Use [nvm](https://github.com/nvm-sh/nvm) for Node version management
-- MongoDB - [Download & Install MongoDB](https://www.mongodb.com/try/download/community)
+- MongoDB **≥ 5.2** - [Download & Install MongoDB](https://www.mongodb.com/try/download/community) — **5.2 or later required** (the `billing` module uses the `$sortArray` aggregation operator, introduced in 5.2; CI runs `mongo:7`)
 
 ## :boom: Installation
 

--- a/modules/billing/STRIPE_SETUP.md
+++ b/modules/billing/STRIPE_SETUP.md
@@ -1,5 +1,11 @@
 # Stripe Dashboard Setup
 
+## Requirements
+
+- **MongoDB ≥ 5.2** — the billing module uses `$sortArray` (added in 5.2). On older versions (e.g. 5.0.x) the `billing.extraBalance.listLedger.perf.integration.tests.js` suite fails with `Unrecognized expression '$sortArray'`. CI runs `mongo:7` and is unaffected.
+
+---
+
 Configuration steps required in the Stripe Dashboard before going LIVE. All steps apply to both test mode (staging validation) and LIVE mode (production).
 
 ---


### PR DESCRIPTION
## Summary

Document MongoDB ≥ 5.2 as the minimum supported version. The `billing` module uses the `\$sortArray` aggregation operator (introduced in 5.2). CI already runs `mongo:7` so production is unaffected — this is a local DX fix.

## Changes

- `README.md` — bump install instruction + Prerequisites block
- `modules/billing/STRIPE_SETUP.md` — add Requirements section with the version + symptom

## Why option 1 (docs)?

Per the issue, three options were considered:
1. **Document min version** ← chosen (smallest blast radius, CI already on mongo:7)
2. Skip-guard the failing test at runtime
3. Refactor the aggregation to avoid `\$sortArray`

Option 1 was selected to keep the change local DX-only and avoid touching billing aggregation code for an LSE local-Mongo issue.

## Test plan

- [x] Markdown still renders cleanly
- [x] No code or test changes
- [x] CI green (docs-only)

closes pierreb-devkit/Node#3630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites and setup documentation to specify MongoDB version ≥ 5.2 as a minimum requirement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Node/pull/3638)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->