### PR TITLE
feat(analytics): restructure PostHog config under analytics.posthog + wire env vars

### DIFF
--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -79,15 +79,17 @@ const config = {
   trust: {
     proxy: false,
   },
-  posthog: {
-    enabled: false, // set to true + apiKey to activate (default off, no breakage on unconfigured projects)
-    // apiKey: process.env.DEVKIT_NODE_posthog_apiKey ?? '',
-    // host: process.env.DEVKIT_NODE_posthog_host ?? 'https://eu.i.posthog.com',
-    // appTag: process.env.DEVKIT_NODE_posthog_appTag ?? '', // e.g. 'trawl', 'comes' — auto-injected on every capture
-    flushAt: 20,
-    flushInterval: 10000,
-    errorTracking: true, // PostHog Error Tracking — active when posthog.apiKey is set
-    autoCapture: false, // opt-in: auto-capture api_request events (default: off)
+  analytics: {
+    posthog: {
+      enabled: process.env.DEVKIT_NODE_analytics_posthog_enabled === 'true',
+      key: process.env.DEVKIT_NODE_analytics_posthog_key ?? '',
+      host: process.env.DEVKIT_NODE_analytics_posthog_host ?? 'https://eu.i.posthog.com',
+      appTag: process.env.DEVKIT_NODE_analytics_posthog_appTag ?? '',
+      flushAt: 20,
+      flushInterval: 10000,
+      errorTracking: process.env.DEVKIT_NODE_analytics_posthog_errorTracking === 'true',
+      autoCapture: process.env.DEVKIT_NODE_analytics_posthog_autoCapture === 'true',
+    },
   },
   domain: '',
   cookie: {

--- a/lib/services/analytics.js
+++ b/lib/services/analytics.js
@@ -10,7 +10,7 @@ import config from '../../config/index.js';
 let client = null;
 
 /**
- * Resolved at init time from config.posthog.appTag.
+ * Resolved at init time from config.analytics.posthog.appTag.
  * Stored here so capture() doesn't re-read config on every call.
  * @type {string|undefined}
  */
@@ -18,7 +18,7 @@ let _appTag;
 
 /**
  * Initialise the PostHog client using application config.
- * When `posthog.enabled` is false OR `posthog.apiKey` is absent the service
+ * When `analytics.posthog.enabled` is false OR `analytics.posthog.key` is absent the service
  * stays in no-op mode — every public method silently returns without
  * side-effects so that downstream projects that don't use PostHog are
  * never affected.
@@ -30,13 +30,13 @@ let _appTag;
  */
 const init = async () => {
   if (client) return; // already initialised — singleton guard
-  const { enabled, apiKey, host, flushAt, flushInterval, appTag } = config.posthog ?? {};
-  if (!enabled || !apiKey) return;
+  const { enabled, key, host, flushAt, flushInterval, appTag } = config.analytics?.posthog ?? {};
+  if (!enabled || !key) return;
   const { PostHog } = await import('posthog-node');
   const options = { host: host || 'https://eu.i.posthog.com' };
   if (flushAt != null) options.flushAt = flushAt;
   if (flushInterval != null) options.flushInterval = flushInterval;
-  client = new PostHog(apiKey, options);
+  client = new PostHog(key, options);
   _appTag = appTag;
 };
 
@@ -57,7 +57,7 @@ const track = (distinctId, event, properties, groups) => {
 
 /**
  * Capture an analytics event with automatic context injection.
- * Auto-injects `app` (from config.posthog.appTag) and `env` (NODE_ENV)
+ * Auto-injects `app` (from config.analytics.posthog.appTag) and `env` (NODE_ENV)
  * into every event. Custom properties take precedence over defaults.
  * No-op when client is not initialised, distinctId or event are missing.
  *

--- a/lib/services/errorTracker.js
+++ b/lib/services/errorTracker.js
@@ -7,8 +7,8 @@ import analyticsService from './analytics.js';
 /**
  * Capture an exception in PostHog.
  *
- * Active when `config.posthog.apiKey` is set AND
- * `config.posthog.errorTracking === true`.
+ * Active when `config.analytics.posthog.key` is set AND
+ * `config.analytics.posthog.errorTracking === true`.
  *
  * Safe no-op when PostHog is not configured.
  *
@@ -19,8 +19,8 @@ import analyticsService from './analytics.js';
  * @returns {void}
  */
 const captureException = (err, ctx = {}) => {
-  const posthogConfig = config?.posthog ?? {};
-  if (posthogConfig.apiKey && posthogConfig.errorTracking === true) {
+  const posthogConfig = config?.analytics?.posthog ?? {};
+  if (posthogConfig.key && posthogConfig.errorTracking === true) {
     analyticsService.captureException(err, ctx);
   }
 };

--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -292,10 +292,10 @@ const init = async () => {
   // Initialize analytics (PostHog).
   // Mounted after pre-parser routes so webhooks are not tracked.
   // Wrapped in try/catch so analytics failures never prevent app startup.
-  // auto-capture middleware is opt-in: only mounted when posthog.autoCapture === true.
+  // auto-capture middleware is opt-in: only mounted when analytics.posthog.autoCapture === true.
   try {
     await AnalyticsService.init();
-    if (config.posthog?.autoCapture === true) {
+    if (config.analytics?.posthog?.autoCapture === true) {
       app.use(analyticsMiddleware);
     }
   } catch (err) {

--- a/lib/services/tests/analytics.capture.unit.tests.js
+++ b/lib/services/tests/analytics.capture.unit.tests.js
@@ -35,9 +35,9 @@ describe('Analytics capture() and enabled-flag:', () => {
   // 1. enabled=false disables client creation
   // ─────────────────────────────────────────────────────────────────
   describe('enabled flag:', () => {
-    test('returns null client when enabled=false even if apiKey is present', async () => {
+    test('returns null client when enabled=false even if key is present', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: false, apiKey: 'phc_test_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: false, key: 'phc_test_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -51,9 +51,9 @@ describe('Analytics capture() and enabled-flag:', () => {
       expect(mockPostHogInstance.capture).not.toHaveBeenCalled();
     });
 
-    test('returns null client when apiKey is missing even if enabled=true', async () => {
+    test('returns null client when key is missing even if enabled=true', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true } },
+        default: { analytics: { posthog: { enabled: true } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -66,9 +66,9 @@ describe('Analytics capture() and enabled-flag:', () => {
       expect(PostHog).not.toHaveBeenCalled();
     });
 
-    test('creates client when enabled=true and apiKey is present', async () => {
+    test('creates client when enabled=true and key is present', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_test_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_test_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -82,7 +82,7 @@ describe('Analytics capture() and enabled-flag:', () => {
 
     test('passes flushAt and flushInterval to PostHog constructor', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com', flushAt: 20, flushInterval: 10000 } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com', flushAt: 20, flushInterval: 10000 } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -100,7 +100,7 @@ describe('Analytics capture() and enabled-flag:', () => {
 
     test('singleton: two init() calls on the same module instance result in one PostHog client', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -120,7 +120,7 @@ describe('Analytics capture() and enabled-flag:', () => {
   describe('capture() no-ops:', () => {
     test('is a no-op when client is null', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: false, apiKey: 'phc_key' } },
+        default: { analytics: { posthog: { enabled: false, key: 'phc_key' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -134,7 +134,7 @@ describe('Analytics capture() and enabled-flag:', () => {
 
     test('is a no-op when distinctId is missing', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -148,7 +148,7 @@ describe('Analytics capture() and enabled-flag:', () => {
 
     test('is a no-op when event is missing', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -167,7 +167,7 @@ describe('Analytics capture() and enabled-flag:', () => {
   describe('capture() property injection:', () => {
     beforeEach(async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com', appTag: 'myapp' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com', appTag: 'myapp' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -208,7 +208,7 @@ describe('Analytics capture() and enabled-flag:', () => {
       }));
 
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');
@@ -266,7 +266,7 @@ describe('Analytics capture() and enabled-flag:', () => {
   describe('shutdown idempotency:', () => {
     test('two shutdown() calls invoke client.shutdown exactly once', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://eu.i.posthog.com' } },
+        default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://eu.i.posthog.com' } } },
       }));
 
       const mod = await import('../analytics.js');

--- a/lib/services/tests/analytics.forRequest.unit.tests.js
+++ b/lib/services/tests/analytics.forRequest.unit.tests.js
@@ -34,7 +34,7 @@ describe('analytics request-aware feature-flag helpers:', () => {
     }));
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
-      default: { posthog: { enabled: true, apiKey: 'phk_test', host: 'https://posthog.test' } },
+      default: { analytics: { posthog: { enabled: true, key: 'phk_test', host: 'https://posthog.test' } } },
     }));
 
     const mod = await import('../analytics.js');
@@ -145,7 +145,7 @@ describe('analytics request-aware feature-flag helpers:', () => {
       await AnalyticsService.shutdown();
       jest.resetModules();
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
       const mod = await import('../analytics.js');
       const svc = mod.default;
@@ -197,7 +197,7 @@ describe('analytics request-aware feature-flag helpers:', () => {
       await AnalyticsService.shutdown();
       jest.resetModules();
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
       const mod = await import('../analytics.js');
       const svc = mod.default;

--- a/lib/services/tests/analytics.service.resilience.unit.tests.js
+++ b/lib/services/tests/analytics.service.resilience.unit.tests.js
@@ -28,7 +28,7 @@ describe('Analytics service resilience tests:', () => {
     }));
 
     jest.unstable_mockModule('../../../config/index.js', () => ({
-      default: { posthog: { enabled: true, apiKey: 'phc_key', host: 'https://test.posthog.com' } },
+      default: { analytics: { posthog: { enabled: true, key: 'phc_key', host: 'https://test.posthog.com' } } },
     }));
 
     const mod = await import('../analytics.js');

--- a/lib/services/tests/analytics.service.unit.tests.js
+++ b/lib/services/tests/analytics.service.unit.tests.js
@@ -32,9 +32,9 @@ describe('Analytics service unit tests:', () => {
   });
 
   describe('no-op mode (PostHog not configured)', () => {
-    test('should not create a client when apiKey is missing', async () => {
+    test('should not create a client when key is missing', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
 
       const mod = await import('../analytics.js');
@@ -49,7 +49,7 @@ describe('Analytics service unit tests:', () => {
       expect(PostHog).not.toHaveBeenCalled();
     });
 
-    test('should not create a client when posthog config section is missing', async () => {
+    test('should not create a client when analytics.posthog config section is missing', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {},
       }));
@@ -66,7 +66,7 @@ describe('Analytics service unit tests:', () => {
 
     test('getFeatureFlag should return undefined when not configured', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
 
       const mod = await import('../analytics.js');
@@ -80,7 +80,7 @@ describe('Analytics service unit tests:', () => {
 
     test('isFeatureEnabled should return undefined when not configured', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
 
       const mod = await import('../analytics.js');
@@ -94,7 +94,7 @@ describe('Analytics service unit tests:', () => {
 
     test('shutdown should be safe when not configured', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
 
       const mod = await import('../analytics.js');
@@ -109,10 +109,12 @@ describe('Analytics service unit tests:', () => {
     beforeEach(async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: {
-            enabled: true,
-            apiKey: 'phc_test_key',
-            host: 'https://test.posthog.com',
+          analytics: {
+            posthog: {
+              enabled: true,
+              key: 'phc_test_key',
+              host: 'https://test.posthog.com',
+            },
           },
         },
       }));
@@ -136,10 +138,12 @@ describe('Analytics service unit tests:', () => {
       }));
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: {
-            enabled: true,
-            apiKey: 'phc_test_key',
-            host: '',
+          analytics: {
+            posthog: {
+              enabled: true,
+              key: 'phc_test_key',
+              host: '',
+            },
           },
         },
       }));

--- a/lib/services/tests/errorTracker.unit.tests.js
+++ b/lib/services/tests/errorTracker.unit.tests.js
@@ -41,7 +41,7 @@ describe('errorTracker service unit tests:', () => {
   describe('no trackers configured', () => {
     test('should be a silent no-op when posthog is not configured', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
-        default: { posthog: {} },
+        default: { analytics: { posthog: {} } },
       }));
 
       const { default: errorTracker } = await import('../errorTracker.js');
@@ -70,7 +70,7 @@ describe('errorTracker service unit tests:', () => {
     test('should call analytics.captureException when posthog is configured with errorTracking=true', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key', errorTracking: true },
+          analytics: { posthog: { key: 'ph_test_key', errorTracking: true } },
         },
       }));
 
@@ -84,10 +84,10 @@ describe('errorTracker service unit tests:', () => {
       expect(mockAnalyticsCapture).toHaveBeenCalledWith(err, ctx);
     });
 
-    test('should NOT call analytics when posthog.apiKey is set but errorTracking is false (default-safe)', async () => {
+    test('should NOT call analytics when analytics.posthog.key is set but errorTracking is false (default-safe)', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key', errorTracking: false },
+          analytics: { posthog: { key: 'ph_test_key', errorTracking: false } },
         },
       }));
 
@@ -97,10 +97,10 @@ describe('errorTracker service unit tests:', () => {
       expect(mockAnalyticsCapture).not.toHaveBeenCalled();
     });
 
-    test('should NOT call analytics when posthog.apiKey is set but errorTracking is missing (default-safe)', async () => {
+    test('should NOT call analytics when analytics.posthog.key is set but errorTracking is missing (default-safe)', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key' },
+          analytics: { posthog: { key: 'ph_test_key' } },
         },
       }));
 
@@ -129,7 +129,7 @@ describe('errorTracker service unit tests:', () => {
     test('should mount PostHog 4-arg error middleware', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key', errorTracking: true },
+          analytics: { posthog: { key: 'ph_test_key', errorTracking: true } },
         },
       }));
 
@@ -159,7 +159,7 @@ describe('errorTracker service unit tests:', () => {
     test('should use req.user.id fallback when _id is absent', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key', errorTracking: true },
+          analytics: { posthog: { key: 'ph_test_key', errorTracking: true } },
         },
       }));
 
@@ -181,7 +181,7 @@ describe('errorTracker service unit tests:', () => {
     test('should use anonymous when no user is attached', async () => {
       jest.unstable_mockModule('../../../config/index.js', () => ({
         default: {
-          posthog: { apiKey: 'ph_test_key', errorTracking: true },
+          analytics: { posthog: { key: 'ph_test_key', errorTracking: true } },
         },
       }));
 

--- a/modules/home/services/home.service.js
+++ b/modules/home/services/home.service.js
@@ -163,7 +163,7 @@ const getReadinessStatus = () => {
   });
 
   // analytics — PostHog
-  const posthogConfigured = isSet(config.posthog?.apiKey);
+  const posthogConfigured = isSet(config.analytics?.posthog?.key);
   checks.push({
     category: 'analytics',
     status: posthogConfigured ? 'ok' : 'warning',
@@ -171,11 +171,11 @@ const getReadinessStatus = () => {
   });
 
   // errorTracking — PostHog
-  const errorTrackingEnabled = posthogConfigured && config.posthog?.errorTracking === true;
+  const errorTrackingEnabled = posthogConfigured && config.analytics?.posthog?.errorTracking === true;
   checks.push({
     category: 'errorTracking',
     status: errorTrackingEnabled ? 'ok' : 'warning',
-    message: errorTrackingEnabled ? 'PostHog $exception capture enabled' : 'PostHog Error Tracking not enabled (set posthog.errorTracking=true)',
+    message: errorTrackingEnabled ? 'PostHog $exception capture enabled' : 'PostHog Error Tracking not enabled (set analytics.posthog.errorTracking=true)',
   });
 
   return checks;

--- a/modules/home/tests/home.integration.tests.js
+++ b/modules/home/tests/home.integration.tests.js
@@ -248,14 +248,14 @@ describe('Home integration tests:', () => {
       const origJwt = config.jwt.secret;
       const origOAuth = config.oAuth;
       const origStripe = config.stripe;
-      const origPosthog = config.posthog;
+      const origAnalytics = config.analytics;
       const mailerSpy = jest.spyOn(mailer, 'isConfigured').mockReturnValue(true);
       try {
         config.domain = 'example.com';
         config.jwt.secret = 'a-real-custom-secret-key';
         config.oAuth = { google: { clientID: 'google-id' }, apple: { clientID: 'apple-id' } };
         config.stripe = { secretKey: 'sk_test_123' };
-        config.posthog = { apiKey: 'phk_123', errorTracking: true };
+        config.analytics = { posthog: { key: 'phk_123', errorTracking: true } };
 
         const result = await agent.get('/api/admin/readiness').set('Cookie', `TOKEN=${adminToken}`).expect(200);
         result.body.data.forEach((item) => {
@@ -270,7 +270,7 @@ describe('Home integration tests:', () => {
         config.jwt.secret = origJwt;
         config.oAuth = origOAuth;
         config.stripe = origStripe;
-        config.posthog = origPosthog;
+        config.analytics = origAnalytics;
         mailerSpy.mockRestore();
       }
     });

--- a/modules/home/tests/home.service.unit.tests.js
+++ b/modules/home/tests/home.service.unit.tests.js
@@ -42,7 +42,7 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
         jwt: { secret: 'WaosSecretKeyExampleToChnageAbsolutely' },
         oAuth: {},
         stripe: {},
-        posthog: {},
+        analytics: { posthog: {} },
         ...configOverride,
       },
     }));
@@ -59,9 +59,9 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
   });
 
   describe('errorTracking row', () => {
-    test('ok when posthog.apiKey is set AND errorTracking=true', async () => {
+    test('ok when analytics.posthog.key is set AND errorTracking=true', async () => {
       const HomeService = await withConfig({
-        posthog: { apiKey: 'ph_test_key', errorTracking: true },
+        analytics: { posthog: { key: 'ph_test_key', errorTracking: true } },
       });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'errorTracking');
@@ -69,19 +69,19 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
       expect(row.message).toBe('PostHog $exception capture enabled');
     });
 
-    test('warning when posthog.apiKey is set but errorTracking=false', async () => {
+    test('warning when analytics.posthog.key is set but errorTracking=false', async () => {
       const HomeService = await withConfig({
-        posthog: { apiKey: 'ph_test_key', errorTracking: false },
+        analytics: { posthog: { key: 'ph_test_key', errorTracking: false } },
       });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'errorTracking');
       expect(row.status).toBe('warning');
-      expect(row.message).toContain('posthog.errorTracking=true');
+      expect(row.message).toContain('analytics.posthog.errorTracking=true');
     });
 
-    test('warning when posthog.apiKey is missing (even if errorTracking=true)', async () => {
+    test('warning when analytics.posthog.key is missing (even if errorTracking=true)', async () => {
       const HomeService = await withConfig({
-        posthog: { errorTracking: true },
+        analytics: { posthog: { errorTracking: true } },
       });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'errorTracking');
@@ -89,7 +89,7 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
     });
 
     test('warning when posthog is not configured at all', async () => {
-      const HomeService = await withConfig({ posthog: {} });
+      const HomeService = await withConfig({ analytics: { posthog: {} } });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'errorTracking');
       expect(row.status).toBe('warning');
@@ -97,9 +97,9 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
   });
 
   describe('analytics row', () => {
-    test('ok when posthog.apiKey is set', async () => {
+    test('ok when analytics.posthog.key is set', async () => {
       const HomeService = await withConfig({
-        posthog: { apiKey: 'ph_test_key' },
+        analytics: { posthog: { key: 'ph_test_key' } },
       });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'analytics');
@@ -107,8 +107,8 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
       expect(row.message).toContain('PostHog configured');
     });
 
-    test('warning when posthog.apiKey is missing', async () => {
-      const HomeService = await withConfig({ posthog: {} });
+    test('warning when analytics.posthog.key is missing', async () => {
+      const HomeService = await withConfig({ analytics: { posthog: {} } });
       const checks = HomeService.getReadinessStatus();
       const row = checks.find((c) => c.category === 'analytics');
       expect(row.status).toBe('warning');


### PR DESCRIPTION
## Summary

- **Root cause**: Wave 1 PR #3637 left `config.posthog.{apiKey,host,appTag}` commented out and `enabled: false`. The Trawl Node manifest sets `POSTHOG_*` env vars but no code path read them, so `config.posthog.apiKey === undefined` → service stayed no-op. Prod logs: `WARN analytics PostHog not configured`.
- **Fix (Wave 3 W3.1)**: Move `config.posthog.*` → `config.analytics.posthog.*`, rename `apiKey` → `key`, and wire all env reads to `DEVKIT_NODE_analytics_posthog_{enabled,key,host,appTag,errorTracking,autoCapture}`.
- **Convention alignment**: Node now matches Vue's `config.analytics.posthog.key` path (cf `pierreb-devkit/Vue` + `trawl_vue/.github/workflows/build.yml`).

## Files changed

- `config/defaults/development.config.js` — restructure block, uncomment env reads, drop `sentry:` remnant
- `lib/services/analytics.js` — `config.posthog` → `config.analytics?.posthog`, `apiKey` → `key`
- `lib/services/errorTracker.js` — same path migration + `apiKey` → `key`
- `lib/services/express.js` — `config.posthog?.autoCapture` → `config.analytics?.posthog?.autoCapture`
- `modules/home/services/home.service.js` — readiness check: `config.posthog?.apiKey` → `config.analytics?.posthog?.key`
- 7 test files — fixture migration: `{ posthog: { apiKey:... } }` → `{ analytics: { posthog: { key:... } } }`

## Downstream impact

After merge: `trawl_node` picks this up via `/update-stack`, then infra manifest renames `POSTHOG_*` → `DEVKIT_NODE_analytics_posthog_*` (Wave W3.3). No downstream project overrides `config.posthog` at config level — all get values via env vars.

## Test plan

- [x] `npm run lint` — ESLint: No issues found
- [x] `npm run test:unit` — 1358 passed, 0 failed (all analytics/errorTracker/home tests green)
- [x] `npm run test:coverage` — 1759 passed, 3 pre-existing failures (MongoDB `$sortArray` version constraint, unrelated)
- [x] DeepSeek critical-review — Verdict: **OK with nits** (0 critical, 0 high introduced; 2 pre-existing in env-var mapper noted as tech-debt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Reorganized analytics configuration structure from top-level to nested namespace
  - Added environment variable support for analytics settings with fallback defaults
  - Updated internal configuration references across services and tests

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Node/pull/3641)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->