### PR TITLE
fix(observability): pass err via { error } in initErrorRoutes for Winston dedup

### DIFF
--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -265,7 +265,7 @@ const initModulesServerRoutes = async (app) => {
 const initErrorRoutes = (app) => {
   app.use((err, req, res, next) => {
     if (!err) return next();
-    logger.error(err.stack);
+    logger.error('Unhandled express error', { error: err });
     res.status(err.status || 500).send({
       message: err.message,
       code: err.code,

--- a/lib/services/tests/logger.posthog.transport.unit.tests.js
+++ b/lib/services/tests/logger.posthog.transport.unit.tests.js
@@ -68,6 +68,16 @@ describe('PostHogErrorTransport:', () => {
     expect(cb).toHaveBeenCalled();
   });
 
+  test('skips when info.error.posthogCaptured is true (dedup via { error: err } meta — express initErrorRoutes path)', () => {
+    const t = new PostHogErrorTransport();
+    const err = Object.assign(new Error('already captured'), { posthogCaptured: true });
+    const info = { level: 'error', message: 'Unhandled express error', error: err };
+    const cb = jest.fn();
+    t.log(info, cb);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(cb).toHaveBeenCalled();
+  });
+
   test('sets posthogCaptured = true on the source Error after forwarding', () => {
     const t = new PostHogErrorTransport();
     const err = new Error('boom');


### PR DESCRIPTION
## Summary

- Fixes #3656 — `logger.error(err.stack)` in `initErrorRoutes` passed a string, so `PostHogErrorTransport` couldn't read `posthogCaptured` on the Error → 2 `$exception` events per uncaught express error (validated prod 2026-05-11: 3 curl POSTs → 6 events)
- One-line fix: `logger.error('Unhandled express error', { error: err })` so transport reads `info.error` → dedup path works
- Adds 1 unit test covering the `info.error.posthogCaptured` dedup path (the `info instanceof Error` path was already tested)

## Files touched

- `lib/services/express.js` — 1-line fix in `initErrorRoutes`
- `lib/services/tests/logger.posthog.transport.unit.tests.js` — +1 test (8 total, was 7)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 1380 passed (1 new test added)
- [x] `npm run test:coverage` — thresholds met (pre-existing `$sortArray` perf test failure is unrelated to this change, fails on master too)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging with structured format for improved diagnostics and issue tracking.

* **Tests**
  * Added test coverage to verify error transport handling and prevent duplicate error captures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Node/pull/3657)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->