### PR TITLE
fix(billing): requirePlan gates on subscription.status + top-level errorCode response shape

### DIFF
--- a/modules/billing/middlewares/billing.requirePlan.js
+++ b/modules/billing/middlewares/billing.requirePlan.js
@@ -3,12 +3,23 @@
  */
 import SubscriptionRepository from '../repositories/billing.subscription.repository.js';
 
-import responses from '../../../lib/helpers/responses.js';
+/**
+ * Statuses considered "active" for plan-entitlement checks.
+ * canceled / past_due / unpaid / incomplete fall back to 'free' resolution.
+ * @type {Set<string>}
+ */
+const ACTIVE_STATUSES = new Set(['active', 'trialing']);
 
 /**
- * Returns Express middleware that gates access based on subscription plan.
- * This middleware is orthogonal to CASL — CASL gates by role, requirePlan
- * gates by subscription plan.
+ * Returns Express middleware that gates access based on subscription plan AND status.
+ * Orthogonal to CASL — CASL gates by role, requirePlan gates by subscription plan.
+ *
+ * A plan is only effective when subscription.status ∈ {active, trialing}.
+ * canceled / past_due / unpaid / incomplete are treated as 'free'.
+ *
+ * Response shape on deny matches the downstream trawl_node contract (top-level errorCode):
+ *   { type: 'error', message: 'Forbidden', code: 403, status: 403,
+ *     errorCode: 'PLAN_REQUIRED', description, requiredPlans: string[], currentPlan: string }
  *
  * Expects `req.organization` to be set by resolveOrganization upstream.
  *
@@ -18,17 +29,30 @@ import responses from '../../../lib/helpers/responses.js';
 function requirePlan(...plans) {
   return async function requirePlanMiddleware(req, res, next) {
     if (!req.organization) {
-      return responses.error(res, 403, 'Forbidden', 'Organization context is required to check subscription plan')();
+      return res.status(403).json({
+        type: 'error',
+        message: 'Forbidden',
+        code: 403,
+        status: 403,
+        errorCode: 'ORG_CONTEXT_REQUIRED',
+        description: 'Organization context is required to check subscription plan',
+      });
     }
 
     try {
       const subscription = await SubscriptionRepository.findByOrganization(req.organization._id);
-      const currentPlan = subscription?.plan || 'free';
+      const isEffective = subscription && ACTIVE_STATUSES.has(subscription.status);
+      const currentPlan = isEffective ? subscription.plan : 'free';
 
       if (plans.includes(currentPlan)) return next();
 
-      return responses.error(res, 403, 'Forbidden', 'Your current plan does not allow access to this resource')({
-        type: 'PLAN_REQUIRED',
+      return res.status(403).json({
+        type: 'error',
+        message: 'Forbidden',
+        code: 403,
+        status: 403,
+        errorCode: 'PLAN_REQUIRED',
+        description: 'Your current plan does not allow access to this resource',
         requiredPlans: plans,
         currentPlan,
       });

--- a/modules/billing/tests/billing.requirePlan.unit.tests.js
+++ b/modules/billing/tests/billing.requirePlan.unit.tests.js
@@ -46,7 +46,7 @@ describe('requirePlan middleware unit tests:', () => {
   });
 
   test('should call next when subscription plan matches the required plan', async () => {
-    mockFindByOrganization.mockResolvedValue({ plan: 'pro' });
+    mockFindByOrganization.mockResolvedValue({ plan: 'pro', status: 'active' });
 
     const middleware = requirePlan('pro');
     const req = mockReq();
@@ -60,7 +60,7 @@ describe('requirePlan middleware unit tests:', () => {
   });
 
   test('should call next when subscription plan is in multiple allowed plans', async () => {
-    mockFindByOrganization.mockResolvedValue({ plan: 'starter' });
+    mockFindByOrganization.mockResolvedValue({ plan: 'starter', status: 'active' });
 
     const middleware = requirePlan('starter', 'pro', 'enterprise');
     const req = mockReq();
@@ -74,7 +74,7 @@ describe('requirePlan middleware unit tests:', () => {
   });
 
   test('should return 403 when subscription plan does not match', async () => {
-    mockFindByOrganization.mockResolvedValue({ plan: 'free' });
+    mockFindByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
 
     const middleware = requirePlan('pro', 'enterprise');
     const req = mockReq();
@@ -85,7 +85,9 @@ describe('requirePlan middleware unit tests:', () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', message: 'Forbidden' }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'Forbidden', errorCode: 'PLAN_REQUIRED' }),
+    );
   });
 
   test('should default to free plan when no subscription exists', async () => {
@@ -126,7 +128,171 @@ describe('requirePlan middleware unit tests:', () => {
 
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', message: 'Forbidden' }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', message: 'Forbidden', errorCode: 'ORG_CONTEXT_REQUIRED' }),
+    );
     expect(mockFindByOrganization).not.toHaveBeenCalled();
+  });
+});
+
+describe('requirePlan — subscription.status gating:', () => {
+  const fakeOrgId = new mongoose.Types.ObjectId();
+
+  function mockReq(overrides = {}) {
+    return {
+      organization: { _id: fakeOrgId, name: 'Test Org' },
+      ...overrides,
+    };
+  }
+
+  function mockRes() {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('treats a canceled growth subscription as free (denies access)', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'growth', status: 'canceled' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('growth', 'pro')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = res.json.mock.calls[0][0];
+    expect(body.currentPlan).toBe('free');
+  });
+
+  test('treats a past_due growth subscription as free (denies access)', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'growth', status: 'past_due' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('growth')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = res.json.mock.calls[0][0];
+    expect(body.currentPlan).toBe('free');
+  });
+
+  test('treats unpaid subscription as free (denies access)', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'pro', status: 'unpaid' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('pro')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = res.json.mock.calls[0][0];
+    expect(body.currentPlan).toBe('free');
+  });
+
+  test('treats incomplete subscription as free (denies access)', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'pro', status: 'incomplete' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('pro')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = res.json.mock.calls[0][0];
+    expect(body.currentPlan).toBe('free');
+  });
+
+  test('passes an active growth subscription', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'growth', status: 'active' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('growth')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('passes a trialing pro subscription', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'pro', status: 'trialing' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('pro')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('requirePlan — response shape (top-level errorCode):', () => {
+  const fakeOrgId = new mongoose.Types.ObjectId();
+
+  function mockReq(overrides = {}) {
+    return {
+      organization: { _id: fakeOrgId, name: 'Test Org' },
+      ...overrides,
+    };
+  }
+
+  function mockRes() {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns top-level errorCode, requiredPlans, currentPlan on PLAN_REQUIRED', async () => {
+    mockFindByOrganization.mockResolvedValue({ plan: 'free', status: 'active' });
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('growth', 'pro')(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.errorCode).toBe('PLAN_REQUIRED');
+    expect(body.requiredPlans).toEqual(['growth', 'pro']);
+    expect(body.currentPlan).toBe('free');
+    expect(body.type).toBe('error');
+    expect(body.message).toBe('Forbidden');
+    expect(body.code).toBe(403);
+    expect(body.status).toBe(403);
+  });
+
+  test('returns ORG_CONTEXT_REQUIRED errorCode when req.organization is absent', async () => {
+    const req = mockReq({ organization: undefined });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await requirePlan('growth')(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.errorCode).toBe('ORG_CONTEXT_REQUIRED');
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(body.type).toBe('error');
   });
 });


### PR DESCRIPTION
Closes #3679.

## What — two drifts fixed in one PR

### 1. Logic gap: `subscription.status` not checked (pre-existing)

`requirePlan` previously gated only on `subscription?.plan`. A `growth` subscription with `status: 'canceled'`, `past_due'`, `'unpaid'`, or `'incomplete'` still passed the check — the user kept access after their subscription lapsed.

**Fix:** introduce `ACTIVE_STATUSES = Set(['active', 'trialing'])`. Plan is only effective when `subscription.status ∈ ACTIVE_STATUSES`. Everything else resolves `currentPlan` to `'free'`.

This was pre-existing but harmless in devkit (middleware had zero route usages) — became a real gate when trawl_node #1183 wired it on apiKeys / webhooks / org-invites.

### 2. Response-shape divergence: upstreams the trawl_node #1183 patch

trawl_node #1183 patched the response to top-level `errorCode` to make it consumable by the Vue client:

```json
{
  "type": "error",
  "message": "Forbidden",
  "code": 403,
  "status": 403,
  "errorCode": "PLAN_REQUIRED",
  "description": "Your current plan does not allow access to this resource",
  "requiredPlans": ["growth", "pro"],
  "currentPlan": "free"
}
```

That patch lived only in trawl_node; the next `/update-stack --theirs` would have silently wiped it (see `feedback_update_stack_theirs_wipes_patches.md`). This PR upstreams the shape to devkit so the contract is safe on future stack updates.

**ORG_CONTEXT_REQUIRED** follows the same top-level shape for consistency.

## Decision (locked)

- Active statuses: `{active, trialing}` only
- Response shape: matches trawl_node #1183 exactly (`type + message + code + status + errorCode + description + requiredPlans + currentPlan`)

## Breaking change note

This is a **breaking response-shape change** for any consumer reading `body.type === 'PLAN_REQUIRED'` (legacy nested key). The old shape used `responses.error` which wrapped meta inside the object differently. trawl_node already moved to `errorCode` in #1183. devkit has zero other consumers today. The `responses.js` import is removed.

## Verification

- Lint: `ESLint: No issues found`
- Tests: **1468/1468 pass** (99 suites) — includes 14 tests in the billing.requirePlan suite (6 baseline updated for new shape + 8 new covering status gating and response-shape assertions)