### PR TITLE
test(billing): use fake timers in checkout webhook fallback test

### DIFF
--- a/modules/billing/tests/billing.webhook.checkout.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.checkout.unit.tests.js
@@ -104,6 +104,7 @@ describe('Billing webhook checkout unit tests:', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -284,17 +285,21 @@ describe('Billing webhook checkout unit tests:', () => {
     });
 
     test('should not throw when paymentIntents.update fails (non-fatal fallback)', async () => {
+      jest.useFakeTimers();
       const paymentIntentId = 'pi_test_failing';
       mockStripeInstance.paymentIntents.update.mockRejectedValue(new Error('Stripe API error'));
 
-      await expect(
-        BillingWebhookService.handleCheckoutPaymentCompleted({
-          id: stripeSessionId,
-          payment_status: 'paid',
-          payment_intent: paymentIntentId,
-          metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
-        }),
-      ).resolves.toBeUndefined();
+      const promise = BillingWebhookService.handleCheckoutPaymentCompleted({
+        id: stripeSessionId,
+        payment_status: 'paid',
+        payment_intent: paymentIntentId,
+        metadata: { organizationId: orgId, packId: 'pack_500k', kind: 'extras' },
+      });
+      // handleCheckoutPaymentCompleted catches the retry exhaustion internally (non-fatal),
+      // so the promise resolves; advance the backoff timers while it is pending.
+      const assertion = expect(promise).resolves.toBeUndefined();
+      await jest.runAllTimersAsync();
+      await assertion;
 
       // creditPack should still have run despite the PI update failure
       expect(mockExtraService.creditPack).toHaveBeenCalledWith(orgId, 'pack_500k', stripeSessionId);


### PR DESCRIPTION
## Summary
- Convert the `should not throw when paymentIntents.update fails (non-fatal fallback)` test to `jest.useFakeTimers()` + `jest.runAllTimersAsync()`, eliminating ~600ms of real `retryWithBackoff` backoff delay per run (≈600ms → ~5ms).
- Restore real timers in `afterEach` so fake timers can't leak into sibling tests.
- Assertions unchanged (resolves undefined + `creditPack` still called with the right args).

## Test plan
- [x] `npm run test:unit` — checkout webhook suite green, target test now ~5ms
- [x] lint clean
- [x] no sibling-test regression

Closes #3689