### PR TITLE
fix(billing): classify non-transient Stripe errors via rawType + auth/permission

### DIFF
--- a/modules/billing/lib/billing.stripe-errors.js
+++ b/modules/billing/lib/billing.stripe-errors.js
@@ -1,0 +1,30 @@
+/**
+ * Classify Stripe errors for retry / short-circuit decisions.
+ *
+ * stripe-node sets `err.type` to the error CLASS NAME (Error.js: `this.type = type || this.constructor.name`,
+ * and every subclass passes its own name via `super(raw, 'StripeXError')`), while the raw API error type
+ * string (e.g. `'invalid_request_error'`) lives on `err.rawType`. Unwrapped/raw API error objects instead
+ * carry the wire type directly on `.type`. Both shapes are handled below.
+ */
+
+const NON_TRANSIENT_STRIPE_ERROR_CLASSES = new Set([
+  'StripeInvalidRequestError', // 400/404 — bad params, deterministic
+  'StripeAuthenticationError', // 401 — bad/missing API key, deterministic
+  'StripePermissionError', // 403 — key lacks permission for the resource, deterministic
+]);
+
+/**
+ * True when a Stripe error is deterministic and will never succeed on retry
+ * (invalid request, authentication, or permission failures). Transient errors
+ * (api_error/500, connection, rate_limit/429) return false so they keep retrying.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isNonTransientStripeError(err) {
+  if (!err || typeof err !== 'object') return false;
+  // SDK-wrapped errors expose the class name on `.type`.
+  if (NON_TRANSIENT_STRIPE_ERROR_CLASSES.has(err.type)) return true;
+  // SDK mirrors the wire type on `.rawType`; unwrapped API error objects carry it on `.type`.
+  return err.rawType === 'invalid_request_error' || err.type === 'invalid_request_error';
+}

--- a/modules/billing/lib/billing.stripe-errors.js
+++ b/modules/billing/lib/billing.stripe-errors.js
@@ -9,14 +9,17 @@
 
 const NON_TRANSIENT_STRIPE_ERROR_CLASSES = new Set([
   'StripeInvalidRequestError', // 400/404 — bad params, deterministic
+  'StripeIdempotencyError', // 400 — idempotency key reused with conflicting params, deterministic
   'StripeAuthenticationError', // 401 — bad/missing API key, deterministic
   'StripePermissionError', // 403 — key lacks permission for the resource, deterministic
 ]);
 
 /**
  * True when a Stripe error is deterministic and will never succeed on retry
- * (invalid request, authentication, or permission failures). Transient errors
- * (api_error/500, connection, rate_limit/429) return false so they keep retrying.
+ * (invalid request, idempotency, authentication, or permission failures). Transient
+ * errors (api_error/500, connection, rate_limit/429) return false so they keep
+ * retrying. StripeCardError (402) is intentionally excluded — some decline codes
+ * (processing_error, issuer_unavailable) are transient.
  *
  * @param {unknown} err
  * @returns {boolean}

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -15,6 +15,7 @@ import BillingResetService from './billing.reset.service.js';
 import billingEvents from '../lib/events.js';
 import { SENTINEL_PENDING } from '../lib/billing.constants.js';
 import { retryWithBackoff } from '../lib/billing.retry.js';
+import { isNonTransientStripeError } from '../lib/billing.stripe-errors.js';
 
 /**
  * Treats a stripeSessionId as "unresolved" when absent, empty, or still the
@@ -326,11 +327,9 @@ const handleCheckoutPaymentCompleted = async (session) => {
           {
             attempts: 3,
             baseMs: 200,
-            // Skip retries on Stripe invalid-request errors (invalid_request_error /
-            // StripeInvalidRequestError) — these are deterministic client errors that never
-            // succeed on retry and only delay the dead-letter path.
-            shouldRetry: (err) =>
-              err?.type !== 'StripeInvalidRequestError' && err?.type !== 'invalid_request_error',
+            // Skip retries on deterministic Stripe errors (invalid request / auth / permission) —
+            // they never succeed on retry and only delay the dead-letter path. See billing.stripe-errors.js.
+            shouldRetry: (err) => !isNonTransientStripeError(err),
           },
         );
       } catch (err) {

--- a/modules/billing/tests/billing.stripe-errors.unit.tests.js
+++ b/modules/billing/tests/billing.stripe-errors.unit.tests.js
@@ -1,0 +1,46 @@
+/**
+ * Module dependencies.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { isNonTransientStripeError } from '../lib/billing.stripe-errors.js';
+
+/**
+ * Unit tests for isNonTransientStripeError — deterministic Stripe errors that
+ * should short-circuit retries (invalid request / authentication / permission),
+ * across both SDK-wrapped (.type = class name) and raw (.type = wire string) shapes.
+ */
+describe('isNonTransientStripeError', () => {
+  test.each(['StripeInvalidRequestError', 'StripeAuthenticationError', 'StripePermissionError'])(
+    'returns true for SDK error class %s (err.type = class name)',
+    (type) => {
+      expect(isNonTransientStripeError({ type })).toBe(true);
+    },
+  );
+
+  test('returns true for an SDK-wrapped error carrying rawType invalid_request_error', () => {
+    expect(
+      isNonTransientStripeError({ type: 'StripeInvalidRequestError', rawType: 'invalid_request_error' }),
+    ).toBe(true);
+  });
+
+  test('returns true for an unwrapped API error object (type = invalid_request_error)', () => {
+    expect(isNonTransientStripeError({ type: 'invalid_request_error' })).toBe(true);
+  });
+
+  test.each(['StripeAPIError', 'StripeConnectionError', 'StripeRateLimitError'])(
+    'returns false for transient SDK error class %s',
+    (type) => {
+      expect(isNonTransientStripeError({ type })).toBe(false);
+    },
+  );
+
+  test('returns false for a generic non-Stripe error', () => {
+    expect(isNonTransientStripeError(new Error('boom'))).toBe(false);
+  });
+
+  test('returns false for null / undefined / non-object', () => {
+    expect(isNonTransientStripeError(null)).toBe(false);
+    expect(isNonTransientStripeError(undefined)).toBe(false);
+    expect(isNonTransientStripeError('invalid_request_error')).toBe(false);
+  });
+});

--- a/modules/billing/tests/billing.stripe-errors.unit.tests.js
+++ b/modules/billing/tests/billing.stripe-errors.unit.tests.js
@@ -10,17 +10,19 @@ import { isNonTransientStripeError } from '../lib/billing.stripe-errors.js';
  * across both SDK-wrapped (.type = class name) and raw (.type = wire string) shapes.
  */
 describe('isNonTransientStripeError', () => {
-  test.each(['StripeInvalidRequestError', 'StripeAuthenticationError', 'StripePermissionError'])(
-    'returns true for SDK error class %s (err.type = class name)',
-    (type) => {
-      expect(isNonTransientStripeError({ type })).toBe(true);
-    },
-  );
+  test.each([
+    'StripeInvalidRequestError',
+    'StripeIdempotencyError',
+    'StripeAuthenticationError',
+    'StripePermissionError',
+  ])('returns true for SDK error class %s (err.type = class name)', (type) => {
+    expect(isNonTransientStripeError({ type })).toBe(true);
+  });
 
-  test('returns true for an SDK-wrapped error carrying rawType invalid_request_error', () => {
-    expect(
-      isNonTransientStripeError({ type: 'StripeInvalidRequestError', rawType: 'invalid_request_error' }),
-    ).toBe(true);
+  test('returns true via the rawType branch when the class is not listed', () => {
+    expect(isNonTransientStripeError({ type: 'StripeFutureUnknownError', rawType: 'invalid_request_error' })).toBe(
+      true,
+    );
   });
 
   test('returns true for an unwrapped API error object (type = invalid_request_error)', () => {
@@ -33,6 +35,10 @@ describe('isNonTransientStripeError', () => {
       expect(isNonTransientStripeError({ type })).toBe(false);
     },
   );
+
+  test('returns false for StripeCardError (402 — some decline codes are transient)', () => {
+    expect(isNonTransientStripeError({ type: 'StripeCardError' })).toBe(false);
+  });
 
   test('returns false for a generic non-Stripe error', () => {
     expect(isNonTransientStripeError(new Error('boom'))).toBe(false);


### PR DESCRIPTION
## Summary
Follow-up to #3697. Extracts `isNonTransientStripeError(err)` into `modules/billing/lib/billing.stripe-errors.js` and wires it into the webhook PI-backfill retry (`shouldRetry: (err) => !isNonTransientStripeError(err)`).

Fixes two issues from the `/critical-review` of #3697 (filed as #3699):
- **`err.rawType` vs `err.type`** — stripe-node sets `err.type` to the **class name** (`StripeInvalidRequestError`); the wire string (`invalid_request_error`) lives on `err.rawType`. Verified in `node_modules/stripe/cjs/Error.js` (`this.type = type || this.constructor.name`; each subclass `super(raw, 'StripeXError')`). The old `err.type === 'invalid_request_error'` was dead for SDK errors.
- **Auth/permission** — `StripeAuthenticationError` (401) + `StripePermissionError` (403) are equally deterministic; now short-circuited.

The classifier keys on the SDK class name (`.type`) for the non-transient set **plus** `invalid_request_error` on `.type`/`.rawType` for unwrapped objects.

## Scope notes
- `StripeIdempotencyError` (400) included (deterministic). `StripeCardError` (402) **excluded** — some decline codes (`processing_error`, `issuer_unavailable`) are transient.
- `billing.admin.controller.js` left as-is (different HTTP-422 mapping semantics + `charge_already_refunded`; can adopt the helper later).

## Validation
- [x] `npm run test:unit` — 1521/1521 green (new `billing.stripe-errors.unit.tests.js`: class names, rawType branch, raw-object, transient classes false, card excluded, null/non-object guards)
- [x] ESLint clean
- [x] No regression in the webhook/refund-correlation retry tests

Closes #3699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced billing error handling to skip retries on non-recoverable Stripe errors, improving system reliability and reducing processing delays.

* **Tests**
  * Added comprehensive test coverage for Stripe error classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Node/pull/3700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->