### PR TITLE
fix(users): admin GET /users/:id no longer leaks password hash and tokens

### DIFF
--- a/modules/users/controllers/users.admin.controller.js
+++ b/modules/users/controllers/users.admin.controller.js
@@ -41,7 +41,7 @@ const list = async (req, res) => {
  */
 const get = async (req, res) => {
   try {
-    const user = req.model ? req.model.toJSON() : {};
+    const user = req.model ? UserService.removeSensitive(req.model) : {};
     const memberships = await MembershipService.listByUser(user._id || user.id);
     user.memberships = memberships.map((m) => {
       const obj = m.toJSON ? m.toJSON() : { ...m };

--- a/modules/users/tests/user.admin.integration.tests.js
+++ b/modules/users/tests/user.admin.integration.tests.js
@@ -233,6 +233,18 @@ describe('User admin integration tests:', () => {
         expect(err).toBeFalsy();
       }
 
+      // Seed token fields so the regression test is meaningful — without this,
+      // the assertions pass vacuously because the fields are simply absent.
+      try {
+        await UserService.updateById(userEdited._id, {
+          resetPasswordToken: 'test-reset-token',
+          emailVerificationToken: 'test-verification-token',
+        });
+      } catch (err) {
+        console.log(err);
+        expect(err).toBeFalsy();
+      }
+
       try {
         const result = await agent.get(`/api/admin/users/${userEdited._id}`).expect(200);
         expect(result.body.data).toBeInstanceOf(Object);

--- a/modules/users/tests/user.admin.integration.tests.js
+++ b/modules/users/tests/user.admin.integration.tests.js
@@ -225,6 +225,34 @@ describe('User admin integration tests:', () => {
       }
     });
 
+    test('should not expose sensitive fields (password, tokens) in admin GET /users/:id', async () => {
+      try {
+        userEdited = await signupAndPromoteAdmin(agent, { ..._userEdited, roles: ['user', 'admin'] });
+      } catch (err) {
+        console.log(err);
+        expect(err).toBeFalsy();
+      }
+
+      try {
+        const result = await agent.get(`/api/admin/users/${userEdited._id}`).expect(200);
+        expect(result.body.data).toBeInstanceOf(Object);
+        expect(result.body.data.password).toBeUndefined();
+        expect(result.body.data.resetPasswordToken).toBeUndefined();
+        expect(result.body.data.emailVerificationToken).toBeUndefined();
+        expect(result.body.data.salt).toBeUndefined();
+      } catch (err) {
+        console.log(err);
+        expect(err).toBeFalsy();
+      }
+
+      try {
+        await UserService.remove(userEdited);
+      } catch (err) {
+        console.log(err);
+        expect(err).toBeFalsy();
+      }
+    });
+
     test('should be able to update a single user details if admin', async () => {
       try {
         userEdited = await signupAndPromoteAdmin(agent, { ..._userEdited, roles: ['user', 'admin'] });


### PR DESCRIPTION
## Summary

- `get` handler in `users.admin.controller.js` was calling `req.model.toJSON()` directly on a raw Mongoose doc (loaded via `getBrut`, which intentionally skips sanitization), leaking `password` (bcrypt hash), `resetPasswordToken`, `emailVerificationToken`, and `salt` in the API response.
- Fix: replace `req.model.toJSON()` with `UserService.removeSensitive(req.model)`, matching how the sibling `list` endpoint already works.
- Adds an integration test asserting `password`, `resetPasswordToken`, `emailVerificationToken`, and `salt` are absent from the `GET /api/admin/users/:id` response.

Closes #3723

## Test plan

- [x] New integration test `should not expose sensitive fields (password, tokens) in admin GET /users/:id` — passes
- [x] All existing admin user integration tests still pass (13/13)
- [x] Lint clean
- [x] Phase 0 pre-push gate (DeepSeek): OK, 0 findings, 95/100 confidence