### PR TITLE
fix(uploads): allowlist Content-Type on serve paths — defense-in-depth against stored-XSS (#3729)

### DIFF
--- a/modules/uploads/controllers/uploads.controller.js
+++ b/modules/uploads/controllers/uploads.controller.js
@@ -10,6 +10,18 @@ import responses from '../../../lib/helpers/responses.js';
 import UploadsService from '../services/uploads.service.js';
 
 /**
+ * Allowlisted MIME types for private download (get).
+ * Defense-in-depth: prevents stored-XSS when a downstream kind permits a dangerous MIME.
+ */
+const SAFE_MIME = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'application/pdf']);
+
+/**
+ * Allowlisted MIME types for public image serving (getSharp).
+ * Restricted to image types — the sharp pipeline only handles images.
+ */
+const SAFE_IMAGE_MIME = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']);
+
+/**
  * @desc Endpoint to get an upload by fileName
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
@@ -21,8 +33,10 @@ const get = async (req, res) => {
     stream.on('error', (err) => {
       responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
     });
-    const contentType = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
+    const raw = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
+    const contentType = SAFE_MIME.has(raw) ? raw : 'application/octet-stream';
     res.set('Content-Type', contentType);
+    res.set('Content-Disposition', 'attachment');
     if (req.upload.length) res.set('Content-Length', req.upload.length);
     stream.pipe(res);
   } catch (err) {
@@ -42,7 +56,8 @@ const getSharp = async (req, res) => {
     stream.on('error', (err) => {
       responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
     });
-    const contentType = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
+    const raw = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
+    const contentType = SAFE_IMAGE_MIME.has(raw) ? raw : 'image/jpeg';
     res.set('Content-Type', contentType);
     switch (req.sharpOption) {
       case 'blur':

--- a/modules/uploads/controllers/uploads.controller.js
+++ b/modules/uploads/controllers/uploads.controller.js
@@ -22,6 +22,15 @@ const SAFE_MIME = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 
 const SAFE_IMAGE_MIME = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']);
 
 /**
+ * Normalize a raw Content-Type value for safe allowlist comparison.
+ * MIME types are case-insensitive and may include parameters (e.g. `image/jpeg; charset=binary`).
+ * Strip any `;` parameter segment, lowercase, and trim before checking the allowlist.
+ * @param {string} raw - Raw content-type string.
+ * @returns {string} Normalized MIME type (e.g. `image/jpeg`).
+ */
+const normalizeMime = (raw) => String(raw).toLowerCase().split(';')[0].trim();
+
+/**
  * @desc Endpoint to get an upload by fileName
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
@@ -34,7 +43,8 @@ const get = async (req, res) => {
       responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
     });
     const raw = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
-    const contentType = SAFE_MIME.has(raw) ? raw : 'application/octet-stream';
+    const norm = normalizeMime(raw);
+    const contentType = SAFE_MIME.has(norm) ? norm : 'application/octet-stream';
     res.set('Content-Type', contentType);
     res.set('Content-Disposition', 'attachment');
     if (req.upload.length) res.set('Content-Length', req.upload.length);
@@ -48,6 +58,7 @@ const get = async (req, res) => {
  * @desc Endpoint to get an upload by fileName with sharp options
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
+ * @returns {Promise<void>} Resolves when the image stream has been piped to the response.
  */
 const getSharp = async (req, res) => {
   try {
@@ -57,7 +68,8 @@ const getSharp = async (req, res) => {
       responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
     });
     const raw = req.upload.contentType || req.upload.metadata?.contentType || 'application/octet-stream';
-    const contentType = SAFE_IMAGE_MIME.has(raw) ? raw : 'image/jpeg';
+    const norm = normalizeMime(raw);
+    const contentType = SAFE_IMAGE_MIME.has(norm) ? norm : 'image/jpeg';
     res.set('Content-Type', contentType);
     switch (req.sharpOption) {
       case 'blur':

--- a/modules/uploads/tests/uploads.controller.contenttype.unit.tests.js
+++ b/modules/uploads/tests/uploads.controller.contenttype.unit.tests.js
@@ -13,10 +13,13 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
 
   /**
    * Returns a minimal readable stream for mocking getStream.
+   * stream.pipe returns `dest` to satisfy chained pipe calls
+   * (stream.pipe(transform).pipe(res)) without throwing.
    */
   const makeStream = () => {
     const s = new Readable({ read() {} });
     s.push(null);
+    s.pipe = jest.fn((dest) => dest);
     return s;
   };
 
@@ -50,13 +53,15 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       default: { uploads: { sharp: { blur: 3 } } },
     }));
 
-    // sharp is a real dependency; mock it to avoid needing native bindings in unit context
+    // sharp is a real dependency; mock it to avoid needing native bindings in unit context.
+    // pipe must return `dest` (matching the real Stream.pipe contract) so that chained
+    // calls stream.pipe(transform).pipe(res) work without throwing.
     jest.unstable_mockModule('sharp', () => ({
       default: jest.fn(() => ({
         resize: jest.fn().mockReturnThis(),
         blur: jest.fn().mockReturnThis(),
         grayscale: jest.fn().mockReturnThis(),
-        pipe: jest.fn(),
+        pipe: jest.fn((dest) => dest),
       })),
     }));
 
@@ -86,7 +91,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'image/jpeg', length: 100 } },
@@ -101,7 +105,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'image/png', length: 100 } },
@@ -115,7 +118,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'application/pdf', length: 100 } },
@@ -129,7 +131,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'text/html', length: 100 } },
@@ -143,7 +144,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'image/svg+xml', length: 100 } },
@@ -157,7 +157,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'text/javascript', length: 100 } },
@@ -167,11 +166,36 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
     });
 
+    test('should normalize uppercase MIME to lowercase and pass through (Image/JPEG → image/jpeg)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'Image/JPEG', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should strip MIME parameters before allowlist check (image/jpeg; charset=binary → image/jpeg)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'image/jpeg; charset=binary', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
     test('should fall back to application/octet-stream when contentType is missing', async () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', length: 100 } },
@@ -185,7 +209,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', metadata: { contentType: 'image/webp' }, length: 50 } },
@@ -199,7 +222,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', metadata: { contentType: 'text/html' }, length: 50 } },
@@ -213,7 +235,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.get(
         { upload: { _id: '1', contentType: 'image/jpeg', length: 100 } },
@@ -233,11 +254,16 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       sharpOption: null,
     });
 
+    const makeImageReqMeta = (metaContentType) => ({
+      upload: { _id: '1', metadata: { contentType: metaContentType }, length: 200 },
+      sharpSize: 512,
+      sharpOption: null,
+    });
+
     test('should pass through image/jpeg on public path', async () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.getSharp(makeImageReq('image/jpeg'), res);
 
@@ -248,7 +274,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.getSharp(makeImageReq('text/html'), res);
 
@@ -259,7 +284,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.getSharp(makeImageReq('image/svg+xml'), res);
 
@@ -270,7 +294,6 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.getSharp(makeImageReq('application/pdf'), res);
 
@@ -281,11 +304,60 @@ describe('Uploads controller content-type allowlist unit tests:', () => {
       const stream = makeStream();
       mockUploadsService.getStream.mockResolvedValue(stream);
       const res = makeRes();
-      stream.pipe = jest.fn();
 
       await UploadsController.getSharp(makeImageReq('image/webp'), res);
 
       expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/webp');
+    });
+
+    test('should normalize uppercase MIME and pass through (IMAGE/PNG → image/png)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.getSharp(makeImageReq('IMAGE/PNG'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+    });
+
+    test('should strip MIME parameters before allowlist check (image/jpeg; charset=binary → image/jpeg)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.getSharp(makeImageReq('image/jpeg; charset=binary'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should use metadata.contentType as fallback when contentType is absent (safe value)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.getSharp(makeImageReqMeta('image/png'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+    });
+
+    test('should downgrade dangerous metadata.contentType to image/jpeg on public path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.getSharp(makeImageReqMeta('text/html'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should fall back to image/jpeg when both contentType and metadata.contentType are absent', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+
+      await UploadsController.getSharp({ upload: { _id: '1', length: 200 }, sharpSize: 512, sharpOption: null }, res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
     });
   });
 });

--- a/modules/uploads/tests/uploads.controller.contenttype.unit.tests.js
+++ b/modules/uploads/tests/uploads.controller.contenttype.unit.tests.js
@@ -1,0 +1,291 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, beforeEach, afterEach, expect } from '@jest/globals';
+import { Readable } from 'stream';
+
+/**
+ * Unit tests for uploads controller Content-Type allowlist (defense-in-depth against stored-XSS).
+ */
+describe('Uploads controller content-type allowlist unit tests:', () => {
+  let UploadsController;
+  let mockUploadsService;
+
+  /**
+   * Returns a minimal readable stream for mocking getStream.
+   */
+  const makeStream = () => {
+    const s = new Readable({ read() {} });
+    s.push(null);
+    return s;
+  };
+
+  /**
+   * Returns a mock res object tracking set() calls.
+   */
+  const makeRes = () => {
+    const headers = {};
+    return {
+      set: jest.fn((key, value) => { headers[key] = value; }),
+      _headers: headers,
+      pipe: jest.fn(),
+    };
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    mockUploadsService = {
+      getStream: jest.fn(),
+      get: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../services/uploads.service.js', () => ({
+      default: mockUploadsService,
+    }));
+
+    // Minimal config mock — sharp config is read inside getSharp only for operations
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: { uploads: { sharp: { blur: 3 } } },
+    }));
+
+    // sharp is a real dependency; mock it to avoid needing native bindings in unit context
+    jest.unstable_mockModule('sharp', () => ({
+      default: jest.fn(() => ({
+        resize: jest.fn().mockReturnThis(),
+        blur: jest.fn().mockReturnThis(),
+        grayscale: jest.fn().mockReturnThis(),
+        pipe: jest.fn(),
+      })),
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/errors.js', () => ({
+      default: { getMessage: jest.fn((e) => e.message) },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: {
+        error: jest.fn(() => jest.fn()),
+        success: jest.fn(() => jest.fn()),
+      },
+    }));
+
+    const mod = await import('../controllers/uploads.controller.js');
+    UploadsController = mod.default;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── get (private download path) ───────────────────────────────────────────
+
+  describe('get — Content-Type allowlist', () => {
+    test('should pass through a safe MIME type (image/jpeg)', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'image/jpeg', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+      expect(res.set).toHaveBeenCalledWith('Content-Disposition', 'attachment');
+    });
+
+    test('should pass through image/png', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'image/png', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+    });
+
+    test('should pass through application/pdf', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'application/pdf', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+    });
+
+    test('should downgrade dangerous MIME text/html to application/octet-stream', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'text/html', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    });
+
+    test('should downgrade image/svg+xml to application/octet-stream', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'image/svg+xml', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    });
+
+    test('should downgrade text/javascript to application/octet-stream', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'text/javascript', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    });
+
+    test('should fall back to application/octet-stream when contentType is missing', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    });
+
+    test('should use metadata.contentType as fallback when contentType is absent', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', metadata: { contentType: 'image/webp' }, length: 50 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/webp');
+    });
+
+    test('should downgrade dangerous metadata.contentType to application/octet-stream', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', metadata: { contentType: 'text/html' }, length: 50 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    });
+
+    test('should set Content-Disposition: attachment on every private download', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.get(
+        { upload: { _id: '1', contentType: 'image/jpeg', length: 100 } },
+        res,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Content-Disposition', 'attachment');
+    });
+  });
+
+  // ── getSharp (public image path) ──────────────────────────────────────────
+
+  describe('getSharp — Content-Type allowlist (image-only)', () => {
+    const makeImageReq = (contentType) => ({
+      upload: { _id: '1', contentType, length: 200 },
+      sharpSize: 512,
+      sharpOption: null,
+    });
+
+    test('should pass through image/jpeg on public path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.getSharp(makeImageReq('image/jpeg'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should downgrade text/html to image/jpeg on public image path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.getSharp(makeImageReq('text/html'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should downgrade image/svg+xml to image/jpeg on public image path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.getSharp(makeImageReq('image/svg+xml'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should downgrade application/pdf to image/jpeg on public image path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.getSharp(makeImageReq('application/pdf'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
+    });
+
+    test('should pass through image/webp on public image path', async () => {
+      const stream = makeStream();
+      mockUploadsService.getStream.mockResolvedValue(stream);
+      const res = makeRes();
+      stream.pipe = jest.fn();
+
+      await UploadsController.getSharp(makeImageReq('image/webp'), res);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/webp');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3729 — NODE-UPLOADS-01 (defense-in-depth / downstream-misconfig).

The download handler was reflecting the stored `contentType` verbatim. Stock config only allows safe image MIMEs, but any downstream project configuring a kind that permits `text/html` / `image/svg+xml` would get stored-XSS on the public unauthenticated image route.

### Changes

- **`get` (private download):** Validates stored content-type against `SAFE_MIME` set (`image/jpeg`, `image/jpg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`). Falls back to `application/octet-stream` for any unrecognized or dangerous type. Adds `Content-Disposition: attachment` as an additional XSS backstop.
- **`getSharp` (public image):** Validates against `SAFE_IMAGE_MIME` (image types only — the sharp pipeline only handles images). Falls back to `image/jpeg`. Both `contentType` and `metadata.contentType` paths are covered.

### Behavioral note

`Content-Disposition: attachment` is added to the **private** `get` route (authenticated, behind CASL). This is intentional: the private route is for downloads, not inline embedding. The **public** `getSharp` route (used for avatar images in `<img>` tags) is unaffected.

### Tests

15 new unit tests in `uploads.controller.contenttype.unit.tests.js` asserting:
- Safe MIMEs (`image/jpeg`, `image/png`, `image/webp`, `application/pdf`) pass through unchanged on both paths
- Dangerous MIMEs (`text/html`, `image/svg+xml`, `text/javascript`) are downgraded to safe fallbacks
- Both `contentType` and `metadata.contentType` fields are covered
- `Content-Disposition: attachment` is set on every private download
- `application/pdf` (safe on `get`, downgraded to `image/jpeg` on `getSharp`) is tested on both paths

All 1561 unit tests pass. Lint clean. Audit vulnerabilities are pre-existing (unchanged deps).