### PR TITLE
fix(home): restrict /team fields, remove releases/changelog, add jwt readiness check (#3724 #3725 #3718)

### DIFF
--- a/modules/home/config/home.development.config.js
+++ b/modules/home/config/home.development.config.js
@@ -1,21 +1,3 @@
-const config = {
-  repos: [
-    {
-      // generate releases and changelogs list auto /api/core/changelogs /api/core/releases
-      title: 'Node',
-      owner: 'pierreb-devkit',
-      repo: 'node',
-      changelog: 'CHANGELOG.md',
-      token: null,
-    },
-    {
-      title: 'Vue',
-      owner: 'pierreb-devkit',
-      repo: 'vue',
-      changelog: 'CHANGELOG.md',
-      token: null,
-    },
-  ],
-};
+const config = {};
 
 export default config;

--- a/modules/home/controllers/home.controller.js
+++ b/modules/home/controllers/home.controller.js
@@ -8,34 +8,6 @@ import responses from '../../../lib/helpers/responses.js';
 import HomeService from '../services/home.service.js';
 
 /**
- * @desc Endpoint to ask the service to get the releases
- * @param {Object} req - Express request object
- * @param {Object} res - Express response object
- */
-const releases = async (req, res) => {
-  try {
-    const releases = await HomeService.releases();
-    responses.success(res, 'releases')(releases);
-  } catch (err) {
-    responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
-  }
-};
-
-/**
- * @desc Endpoint to ask the service to get the changelogs
- * @param {Object} req - Express request object
- * @param {Object} res - Express response object
- */
-const changelogs = async (req, res) => {
-  try {
-    const changelogs = await HomeService.changelogs();
-    responses.success(res, 'changelogs')(changelogs);
-  } catch (err) {
-    responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
-  }
-};
-
-/**
  * @desc Endpoint to ask the service to get the list of users
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
@@ -112,8 +84,6 @@ const readiness = (req, res) => {
 };
 
 export default {
-  releases,
-  changelogs,
   team,
   page,
   pageByName,

--- a/modules/home/policies/home.policy.js
+++ b/modules/home/policies/home.policy.js
@@ -15,7 +15,7 @@ export function homeSubjectRegistration({ registerPathSubject }) {
 
 /**
  * Define home-related abilities for an authenticated user.
- * All authenticated users can read home content (releases, changelogs, team, pages).
+ * All authenticated users can read home content (team, pages).
  * @param {Object} user - The authenticated user
  * @param {Object|null} membership - Optional organization membership (reserved for future use)
  * @param {Object} builder - CASL AbilityBuilder helpers
@@ -30,7 +30,7 @@ export function homeAbilities(user, membership, { can }) {
 
 /**
  * Define home-related abilities for unauthenticated guests.
- * Guests can read all home content (releases, changelogs, team, pages).
+ * Guests can read all home content (team, pages).
  * @param {Object} builder - CASL AbilityBuilder helpers
  * @param {Function} builder.can - Grant an ability
  */

--- a/modules/home/repositories/home.repository.js
+++ b/modules/home/repositories/home.repository.js
@@ -9,7 +9,7 @@ const User = mongoose.model('User');
  * @desc Function to get all user in db
  * @return {Array} All users
  */
-const team = () => User.find({ roles: 'admin' }, 'firstName lastName bio position avatar').sort('-createdAt').exec();
+const team = () => User.find({ roles: 'admin' }, 'firstName lastName bio position avatar -_id').lean().sort('-createdAt').exec();
 
 export default {
   team,

--- a/modules/home/repositories/home.repository.js
+++ b/modules/home/repositories/home.repository.js
@@ -9,7 +9,7 @@ const User = mongoose.model('User');
  * @desc Function to get all user in db
  * @return {Array} All users
  */
-const team = () => User.find({ roles: 'admin' }, '-password -providerData -complementary').sort('-createdAt').exec();
+const team = () => User.find({ roles: 'admin' }, 'firstName lastName bio position avatar').sort('-createdAt').exec();
 
 export default {
   team,

--- a/modules/home/routes/home.route.js
+++ b/modules/home/routes/home.route.js
@@ -27,11 +27,7 @@ const optionalAuth = (req, res, next) => {
 export default (app) => {
   // health check — public, enriched response for admins
   app.route('/api/health').get(optionalAuth, home.health);
-  // changelogs
-  app.route('/api/home/releases').all(policy.isAllowed).get(home.releases);
-  // changelogs
-  app.route('/api/home/changelogs').all(policy.isAllowed).get(home.changelogs);
-  // changelogs
+  // team — public staff page
   app.route('/api/home/team').all(policy.isAllowed).get(home.team);
   // markdown files
   app.route('/api/home/pages/:name').all(policy.isAllowed).get(home.page);

--- a/modules/home/services/home.service.js
+++ b/modules/home/services/home.service.js
@@ -36,12 +36,10 @@ const page = async (name) => {
 
 /**
  * @desc Function to get all admin users in db, returning only public-safe fields.
- * @returns {Promise<Array>} Public user profiles (firstName, lastName, bio, position, avatar)
+ * Uses a lean projection so no Mongoose virtuals (e.g. `id`) can re-introduce hidden fields.
+ * @returns {Promise<Array<{firstName: string, lastName: string, bio: string, position: string, avatar: string}>>} Public user profiles
  */
-const team = async () => {
-  const result = await HomeRepository.team();
-  return result.map((user) => (typeof user.toJSON === 'function' ? user.toJSON() : user));
-};
+const team = async () => HomeRepository.team();
 
 /**
  * @desc Build health status including database connectivity.

--- a/modules/home/services/home.service.js
+++ b/modules/home/services/home.service.js
@@ -1,17 +1,14 @@
 /**
  * Module dependencies
  */
-import axios from 'axios';
 import path from 'path';
 import _ from 'lodash';
-import { Base64 } from 'js-base64';
 import { promises as fs } from 'fs';
 import mongoose from 'mongoose';
 
 import config from '../../../config/index.js';
 import mailer from '../../../lib/helpers/mailer/index.js';
 import HomeRepository from '../repositories/home.repository.js';
-import { removeSensitive } from '../../users/utils/sanitizeUser.js';
 
 /**
  * @desc Check whether a config value is meaningfully set (non-empty, not a DEVKIT placeholder).
@@ -38,61 +35,12 @@ const page = async (name) => {
 };
 
 /**
- * @desc Fetch releases from configured GitHub repos. Returns an empty array on API failure (graceful degradation).
- * @return {Promise<Array<{title: string, list: Array}>>} Releases grouped by repo, or [] on error
- */
-const releases = async () => {
-  try {
-    const requests = config.repos.map((item) =>
-      axios.get(`https://api.github.com/repos/${item.owner}/${item.repo}/releases`, {
-        headers: item.token ? { Authorization: `token ${item.token}` } : {},
-      }),
-    );
-    let results = await axios.all(requests);
-    results = results.map((result, i) => ({
-      title: config.repos[i].title,
-      list: result.data.map((release) => ({
-        name: release.name,
-        prerelease: release.prerelease,
-        published_at: release.published_at,
-      })),
-    }));
-    return results;
-  } catch (_err) {
-    return [];
-  }
-};
-
-/**
- * @desc Fetch changelogs from configured GitHub repos. Returns an empty array on API failure (graceful degradation).
- * @return {Promise<Array<{title: string, markdown: string}>>} Changelogs grouped by repo, or [] on error
- */
-const changelogs = async () => {
-  try {
-    const repos = _.filter(config.repos, (repo) => repo.changelog);
-    const requests = repos.map((item) =>
-      axios.get(`https://api.github.com/repos/${item.owner}/${item.repo}/contents/${item.changelog}`, {
-        headers: item.token ? { Authorization: `token ${item.token}` } : {},
-      }),
-    );
-    let results = await axios.all(requests);
-    results = results.map((result, i) => ({
-      title: repos[i].title,
-      markdown: Base64.decode(result.data.content),
-    }));
-    return results;
-  } catch (_err) {
-    return [];
-  }
-};
-
-/**
- * @desc Function to get all admin users in db
- * @returns {Promise<Array>} All users (sanitized)
+ * @desc Function to get all admin users in db, returning only public-safe fields.
+ * @returns {Promise<Array>} Public user profiles (firstName, lastName, bio, position, avatar)
  */
 const team = async () => {
   const result = await HomeRepository.team();
-  return result.map((user) => removeSensitive(user));
+  return result.map((user) => (typeof user.toJSON === 'function' ? user.toJSON() : user));
 };
 
 /**
@@ -183,8 +131,6 @@ const getReadinessStatus = () => {
 
 export default {
   page,
-  releases,
-  changelogs,
   team,
   getHealthStatus,
   getReadinessStatus,

--- a/modules/home/tests/home.integration.tests.js
+++ b/modules/home/tests/home.integration.tests.js
@@ -74,14 +74,13 @@ describe('Home integration tests:', () => {
         expect(result.body.type).toBe('success');
         expect(result.body.message).toBe('team list');
         expect(result.body.data).toBeInstanceOf(Array);
-        // Verify no sensitive fields are exposed
+        // Assert the strict public-field allowlist: every key must be one of these,
+        // so no unexpected field (incl. _id / id / sensitive data) can ever leak.
+        const ALLOWED_FIELDS = new Set(['firstName', 'lastName', 'bio', 'position', 'avatar']);
         result.body.data.forEach((member) => {
-          expect(member).not.toHaveProperty('email');
-          expect(member).not.toHaveProperty('emailVerified');
-          expect(member).not.toHaveProperty('lastLoginAt');
-          expect(member).not.toHaveProperty('roles');
-          expect(member).not.toHaveProperty('password');
-          expect(member).not.toHaveProperty('providerData');
+          Object.keys(member).forEach((key) => {
+            expect(ALLOWED_FIELDS.has(key)).toBe(true);
+          });
         });
       } catch (err) {
         expect(err).toBeFalsy();

--- a/modules/home/tests/home.integration.tests.js
+++ b/modules/home/tests/home.integration.tests.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 import { jest } from '@jest/globals';
-import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 import path from 'path';
@@ -26,16 +25,6 @@ describe('Home integration tests:', () => {
 
   //  init
   beforeAll(async () => {
-    // Mock GitHub API calls to avoid real network requests in tests
-    jest.spyOn(axios, 'get').mockImplementation(async (url) => {
-      if (url.includes('/releases')) {
-        return { data: [{ name: 'v1.0.0', prerelease: false, published_at: '2024-01-01T00:00:00Z' }] };
-      }
-      if (url.includes('/contents/')) {
-        return { data: { content: Buffer.from('# Changelog\n## v1.0.0\n- First release').toString('base64') } };
-      }
-      throw new Error(`Unexpected GitHub API URL: ${url}`);
-    });
     try {
       originalOrganizationsEnabled = config.organizations.enabled;
       config.organizations.enabled = false;
@@ -79,26 +68,21 @@ describe('Home integration tests:', () => {
   // into later describes (#3472). Auth-required cases still use explicit
   // `set('Cookie', 'TOKEN=...')` headers derived from JWTs.
   describe('Logout', () => {
-    test('should be able to get releases', async () => {
-      const result = await request(app).get('/api/home/releases').expect(200);
-      expect(result.body.type).toBe('success');
-      expect(result.body.message).toBe('releases');
-      expect(result.body.data).toBeInstanceOf(Array);
-    });
-
-    test('should be able to get changelogs', async () => {
-      const result = await request(app).get('/api/home/changelogs').expect(200);
-      expect(result.body.type).toBe('success');
-      expect(result.body.message).toBe('changelogs');
-      expect(result.body.data).toBeInstanceOf(Array);
-    });
-
-    test('should be able to get team members', async () => {
+    test('should be able to get team members with public fields only', async () => {
       try {
         const result = await request(app).get('/api/home/team').expect(200);
         expect(result.body.type).toBe('success');
         expect(result.body.message).toBe('team list');
         expect(result.body.data).toBeInstanceOf(Array);
+        // Verify no sensitive fields are exposed
+        result.body.data.forEach((member) => {
+          expect(member).not.toHaveProperty('email');
+          expect(member).not.toHaveProperty('emailVerified');
+          expect(member).not.toHaveProperty('lastLoginAt');
+          expect(member).not.toHaveProperty('roles');
+          expect(member).not.toHaveProperty('password');
+          expect(member).not.toHaveProperty('providerData');
+        });
       } catch (err) {
         expect(err).toBeFalsy();
         console.log(err);
@@ -129,51 +113,6 @@ describe('Home integration tests:', () => {
         console.log(err);
         expect(err).toBeFalsy();
       }
-    });
-
-    test('should return empty releases gracefully when GitHub API fails', async () => {
-      axios.get.mockRejectedValueOnce(new Error('GitHub API unavailable'));
-      const result = await request(app).get('/api/home/releases').expect(200);
-      expect(result.body.type).toBe('success');
-      expect(result.body.message).toBe('releases');
-      expect(result.body.data).toEqual([]);
-    });
-
-    test('should return empty changelogs gracefully when GitHub API fails', async () => {
-      axios.get.mockRejectedValueOnce(new Error('GitHub API unavailable'));
-      const result = await request(app).get('/api/home/changelogs').expect(200);
-      expect(result.body.type).toBe('success');
-      expect(result.body.message).toBe('changelogs');
-      expect(result.body.data).toEqual([]);
-    });
-
-    test('should use Authorization header when a token is configured for releases', async () => {
-      const originalRepos = config.repos;
-      axios.get.mockClear();
-      // Temporarily set a fake token to cover the token-truthy branch in home.service releases()
-      config.repos = originalRepos.map((repo) => ({ ...repo, token: 'fake-test-token' }));
-      const result = await request(app).get('/api/home/releases').expect(200);
-      expect(result.body.type).toBe('success');
-      const releaseCalls = axios.get.mock.calls.filter(([url]) => url.includes('/releases'));
-      expect(releaseCalls.length).toBeGreaterThan(0);
-      releaseCalls.forEach(([, options]) => {
-        expect(options.headers.Authorization).toBe('token fake-test-token');
-      });
-      config.repos = originalRepos;
-    });
-
-    test('should use Authorization header when a token is configured for changelogs', async () => {
-      const originalRepos = config.repos;
-      axios.get.mockClear();
-      config.repos = originalRepos.map((repo) => ({ ...repo, token: 'fake-test-token' }));
-      const result = await request(app).get('/api/home/changelogs').expect(200);
-      expect(result.body.type).toBe('success');
-      const changelogCalls = axios.get.mock.calls.filter(([url]) => url.includes('/contents/'));
-      expect(changelogCalls.length).toBeGreaterThan(0);
-      changelogCalls.forEach(([, options]) => {
-        expect(options.headers.Authorization).toBe('token fake-test-token');
-      });
-      config.repos = originalRepos;
     });
 
     test('should return minimal health status without auth', async () => {

--- a/modules/home/tests/home.service.unit.tests.js
+++ b/modules/home/tests/home.service.unit.tests.js
@@ -25,10 +25,6 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
       default: { team: jest.fn().mockResolvedValue([]) },
     }));
 
-    // Mock axios to avoid real network calls
-    jest.unstable_mockModule('axios', () => ({
-      default: { get: jest.fn().mockResolvedValue({ data: [] }), all: jest.fn().mockResolvedValue([]) },
-    }));
   });
 
   afterEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@casl/ability": "^7.0.0",
         "@jest/globals": "^30.4.1",
-        "axios": "^1.16.1",
         "bcrypt": "^6.0.0",
         "bson": "^7.2.0",
         "chalk": "^5.6.2",
@@ -28,7 +27,6 @@
         "helmet": "~8.2.0",
         "inquirer": "^13.4.3",
         "jest-environment-jsdom": "^30.4.1",
-        "js-base64": "^3.7.8",
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
         "lodash": "^4.18.1",
@@ -5563,43 +5561,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -8568,26 +8529,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -13018,12 +12959,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17195,15 +17130,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pstree.remy": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@casl/ability": "^7.0.0",
     "@jest/globals": "^30.4.1",
-    "axios": "^1.16.1",
     "bcrypt": "^6.0.0",
     "bson": "^7.2.0",
     "chalk": "^5.6.2",
@@ -68,7 +67,6 @@
     "helmet": "~8.2.0",
     "inquirer": "^13.4.3",
     "jest-environment-jsdom": "^30.4.1",
-    "js-base64": "^3.7.8",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.18.1",


### PR DESCRIPTION
## Summary

- **#3724**: Restrict `/api/home/team` to public-safe fields only. Changed repository query from negative projection (`-password -providerData -complementary`) to positive projection (`firstName lastName bio position avatar`). Removed `removeSensitive` call in service — projection already enforces the whitelist. Vue staff page still renders (reads name/bio/position/avatar).
- **#3725**: Remove releases + changelogs feature entirely (product decision: changelog handled via blog). Removed `releases` and `changelogs` service functions, controller handlers, routes, `config.repos` config block. Removed unused `axios` and `js-base64` imports.
- **#3718**: JWT default-secret readiness check already present in `getReadinessStatus()` under the `security` category (warns when secret equals `WaosSecretKeyExampleToChnageAbsolutely`). Updated tests to match current category list `['config','security','auth','mail','billing','analytics','errorTracking']`.

## Cross-reference

Vue PR: pierreb-devkit/Vue (refactor(home): remove releases/changelog consumers + static home stat #3725)

## Test plan

- [ ] `npm run lint` → 0 issues
- [ ] `npm run test:coverage` → home tests (26) pass; only pre-existing `billing.extraBalance.listLedger.perf` failures (MongoDB `$sortArray` incompatibility, unrelated)
- [ ] `/api/home/team` returns only `firstName`, `lastName`, `bio`, `position`, `avatar` — no `email`, `roles`, `lastLoginAt`
- [ ] `/api/home/releases` and `/api/home/changelogs` no longer registered (404)
- [ ] `/api/admin/readiness` returns `security` check with warning when JWT secret is default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team endpoint now displays restricted user information.

* **Removed Features**
  * Removed releases and changelogs API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pierreb-devkit/Node/pull/3735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->