### PR TITLE
feat(auth): include user.complementary in /token response

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -307,6 +307,7 @@ const token = async (req, res) => {
       emailVerified: req.user.emailVerified,
       currentOrganization: req.user.currentOrganization,
       lastLoginAt: req.user.lastLoginAt,
+      complementary: req.user.complementary,
     };
   }
 

--- a/modules/auth/tests/auth.token.controller.unit.tests.js
+++ b/modules/auth/tests/auth.token.controller.unit.tests.js
@@ -1,0 +1,173 @@
+/**
+ * Module dependencies.
+ *
+ * Unit tests for auth.controller `token` handler.
+ * Regression guard: /api/auth/token must include `complementary` in the user
+ * projection so per-user UI prefs / extras rehydrate correctly across refresh.
+ */
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+describe('auth.controller.token — user projection:', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../modules/users/services/users.service.js', () => ({
+      default: { getBrut: jest.fn(), update: jest.fn(), create: jest.fn(), remove: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.service.js', () => ({
+      default: { handleSignupOrganization: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.crud.service.js', () => ({
+      default: { autoSetCurrentOrganization: jest.fn().mockResolvedValue(undefined) },
+    }));
+
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.membership.service.js', () => ({
+      default: {
+        findByUserAndOrganization: jest.fn().mockResolvedValue(null),
+        listPendingByUser: jest.fn().mockResolvedValue([]),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        sign: { up: true, in: true },
+        jwt: { secret: 'test-secret', expiresIn: 3600 },
+        cookie: { secure: false, sameSite: 'lax' },
+        organizations: { enabled: false },
+        app: { title: 'Test', contact: 'test@test.com' },
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/model.js', () => ({
+      default: { getResultFromZod: jest.fn(), checkError: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/mailer/index.js', () => ({
+      default: { isConfigured: jest.fn().mockReturnValue(false), sendMail: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: {
+        success: jest.fn().mockReturnValue(jest.fn()),
+        error: jest.fn().mockReturnValue(jest.fn()),
+      },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/errors.js', () => ({
+      default: { getMessage: jest.fn().mockReturnValue('error') },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/AppError.js', () => ({
+      default: class AppError extends Error {
+        constructor(msg, opts) {
+          super(msg);
+          this.code = opts?.code;
+          this.details = opts?.details;
+        }
+      },
+    }));
+
+    jest.unstable_mockModule('../../../modules/users/models/users.schema.js', () => ({
+      default: { User: {} },
+    }));
+
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: { defineAbilityFor: jest.fn().mockResolvedValue({}) },
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/abilities.js', () => ({
+      default: jest.fn().mockReturnValue([]),
+    }));
+
+    jest.unstable_mockModule('../../../lib/helpers/getBaseUrl.js', () => ({
+      default: jest.fn().mockReturnValue('http://localhost:3000'),
+    }));
+
+    jest.unstable_mockModule('../../../lib/services/analytics.js', () => ({
+      default: { identify: jest.fn(), groupIdentify: jest.fn() },
+    }));
+
+    // Mock invite-only gate (auth.controller imports InvitationService)
+    jest.unstable_mockModule('../../../modules/auth/services/auth.invitation.service.js', () => ({
+      default: {
+        validateInviteToken: jest.fn().mockResolvedValue(null),
+        consumeInviteToken: jest.fn().mockResolvedValue(undefined),
+      },
+    }));
+  });
+
+  test('should include `complementary` in the returned user object (regression guard: per-user UI prefs / extras must rehydrate across refresh)', async () => {
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = {
+      user: {
+        id: 'u1',
+        provider: 'local',
+        roles: ['user'],
+        avatar: '',
+        email: 'a@b.com',
+        lastName: 'Doe',
+        firstName: 'Jane',
+        additionalProvidersData: {},
+        emailVerified: true,
+        currentOrganization: null,
+        lastLoginAt: new Date(0),
+        complementary: { ui: { layout: 'grid' } },
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await AuthController.token(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.user).toBeDefined();
+    expect(payload.user.complementary).toEqual({ ui: { layout: 'grid' } });
+    // Sanity — existing projection keys still present
+    expect(payload.user.id).toBe('u1');
+    expect(payload.user.email).toBe('a@b.com');
+  });
+
+  test('should preserve a missing/undefined `complementary` as undefined (no crash)', async () => {
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = {
+      user: {
+        id: 'u2',
+        provider: 'local',
+        roles: ['user'],
+        avatar: '',
+        email: 'c@d.com',
+        lastName: 'Smith',
+        firstName: 'John',
+        additionalProvidersData: {},
+        emailVerified: true,
+        currentOrganization: null,
+        lastLoginAt: new Date(0),
+        // complementary intentionally omitted
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await AuthController.token(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.user).toBeDefined();
+    expect('complementary' in payload.user).toBe(true);
+    expect(payload.user.complementary).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `complementary: req.user.complementary` to the user-projection object in the `token` handler (`modules/auth/controllers/auth.controller.js`), closing a gap vs the existing account controller projection and User model/schema which already expose this field.
- Ports a regression test (`modules/auth/tests/auth.token.controller.unit.tests.js`) to lock the field in the projection going forward.

## Why

Every devkit downstream that stores per-user UI preferences or extra data in `user.complementary` needs this field to survive a full-page refresh — the client calls `/api/auth/token` on reload to rehydrate session state. Without `complementary` in the token response, per-user prefs silently reset on reload.

The `complementary` field already exists in:
- `modules/users/models/users.model.mongoose.js` (model)
- `modules/users/models/users.schema.js` (Zod schema)
- `modules/users/config/users.development.config.js` (read/update/updateAdmin projections)
- `modules/users/controllers/users.account.controller.js` (account endpoint projection)

The token handler was the only place missing it, forcing downstreams to patch locally.

## Test plan

- [x] `npm run lint` — ESLint clean
- [x] `npm run test:unit` — 111 suites, 1582 tests pass (including 2 new regression tests)
- [x] Phase 0 critical-review gate → OK (no findings)

Closes #3738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The authentication token endpoint now includes complementary user profile data in responses.

* **Tests**
  * Added comprehensive unit tests to validate user profile data serialization in authentication responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->