### PR TITLE
fix(billing): re-apply lost C.2 review nits (warn-on-unknown-priceId + 4 hardening)

### DIFF
--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -58,12 +58,15 @@ const validatePlan = (plan) => {
 const planRanks = Object.fromEntries((config.billing?.plans || []).map((p, i) => [p, i]));
 
 /**
- * Reverse-map from Stripe price ID → plan name, built from config.stripe.prices at boot.
- * config.stripe.prices = { growth: { monthly: 'price_xxx', annual: 'price_yyy' }, pro: { ... } }
- * This avoids relying on price.metadata.planId (empty on Stripe webhook payloads — planId
- * lives on the Product, not the Price) and avoids a Stripe API call per webhook.
+ * Build a reverse-map from Stripe price ID → plan name, sourced from `config.stripe.prices`
+ * at module load. Shape: `{ growth: { monthly: 'price_xxx', annual: 'price_yyy' }, pro: {...} }`.
  *
- * Fix: resolvePlan no longer reads price.metadata (always empty in real Stripe webhook payloads).
+ * Why: `price.metadata.planId` is empty on real Stripe webhook payloads — `planId` lives on
+ * the Product, not the Price exposed by `customer.subscription.updated`. The reverse-map gives
+ * a robust priceId→plan lookup without an extra Stripe API call per webhook. `resolvePlan`
+ * keeps `price.metadata.planId` as a legacy fallback (test fixtures, manual Stripe edits).
+ *
+ * @returns {Record<string, string>} priceId → planId map (built once at module init)
  */
 const buildPriceIdToPlanMap = () => {
   const map = {};
@@ -95,7 +98,17 @@ const resolvePlan = (subscription) => {
   }
   // Legacy fallback: price metadata set explicitly (e.g. test fixtures or manual Stripe edits)
   const rawMeta = item?.price?.metadata?.planId || item?.plan?.metadata?.planId;
-  return validatePlan(rawMeta) || 'free';
+  const fromMeta = validatePlan(rawMeta);
+  if (fromMeta) return fromMeta;
+  // Last-resort fallback — warn so misconfigured config.stripe.prices is visible
+  // (otherwise this silently downgrades paid orgs to 'free', which is the exact bug #1250 fixed).
+  if (priceId) {
+    logger.warn('[billing.webhook] resolvePlan: priceId not in priceIdToPlan map and metadata empty — falling back to free', {
+      priceId,
+      stripeSubscriptionId: subscription?.id,
+    });
+  }
+  return 'free';
 };
 
 /**
@@ -421,7 +434,7 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   if (typeof subscription.cancel_at_period_end === 'boolean') {
     fields.cancelAtPeriodEnd = subscription.cancel_at_period_end;
   }
-  if (subscription.cancel_at) {
+  if (typeof subscription.cancel_at === 'number') {
     fields.cancelAt = new Date(subscription.cancel_at * 1000);
   } else if (subscription.cancel_at === null) {
     fields.cancelAt = null;
@@ -464,10 +477,13 @@ const handleSubscriptionUpdated = async (subscription, event) => {
   let planChangeResetTriggered = false;
   if (previousItems) {
     const previousPriceId = previousItems[0]?.price?.id;
-    const previousPlan = (previousPriceId && priceIdToPlan[previousPriceId])
+    const previousRaw = (previousPriceId && priceIdToPlan[previousPriceId])
       || previousItems[0]?.price?.metadata?.planId
       || previousItems[0]?.plan?.metadata?.planId
       || null;
+    // Validate against the canonical plan enum — legacy metadata can carry stale or invalid
+    // values that would otherwise emit plan.changed + trigger forceRotateForPlanChange with junk.
+    const previousPlan = validatePlan(previousRaw);
     if (previousPlan && previousPlan !== newPlan) {
       const prevRank = planRanks[previousPlan];
       const newRank = planRanks[newPlan];

--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -100,10 +100,12 @@ const resolvePlan = (subscription) => {
   const rawMeta = item?.price?.metadata?.planId || item?.plan?.metadata?.planId;
   const fromMeta = validatePlan(rawMeta);
   if (fromMeta) return fromMeta;
-  // Last-resort fallback — warn so misconfigured config.stripe.prices is visible
-  // (otherwise this silently downgrades paid orgs to 'free', which is the exact bug #1250 fixed).
-  if (priceId) {
-    logger.warn('[billing.webhook] resolvePlan: priceId not in priceIdToPlan map and metadata empty — falling back to free', {
+  // Last-resort fallback — warn only when metadata is also absent so misconfigured
+  // config.stripe.prices is visible (otherwise this silently downgrades paid orgs to 'free',
+  // which is the exact bug #1250 fixed). When metadata is present but invalid, validatePlan()
+  // above already emitted an "unrecognized planId" warning — no double-warn needed.
+  if (priceId && !rawMeta) {
+    logger.warn('[billing.webhook] resolvePlan: priceId not in priceIdToPlan map and no metadata — falling back to free', {
       priceId,
       stripeSubscriptionId: subscription?.id,
     });

--- a/modules/billing/tests/billing.webhook.priceid-map.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.priceid-map.unit.tests.js
@@ -68,7 +68,9 @@ const makeBaseSetup = (configOverride = {}) => {
       model: () => ({}),
     },
   }));
-  // Suppress retryWithBackoff delays in tests (replace setTimeout with immediate resolve)
+  // Mock the failed-backfill repository so the retry recorder is a no-op in unit tests
+  // (does not suppress the retryWithBackoff setTimeout delays themselves — tests that exercise
+  // retry pathways still pay the real delay, so keep retry attempt counts low in fixtures).
   jest.unstable_mockModule('../repositories/billing.failedBackfill.repository.js', () => ({
     default: { record: jest.fn().mockResolvedValue({}) },
   }));


### PR DESCRIPTION
## Context

PR #3743 (`fix(billing): resolve plan via priceId map, not price.metadata.planId (#1250)`, merge commit `0693e497`) was merged to devkit master with 5 unfixed Copilot review findings. A controller-side fix commit (`11b00505`) was prepared locally but never pushed to `origin/feat/resolveplan-priceid-map` — the push silently appeared to succeed (RTK wrapper reported "ok") while `git ls-remote` shows the SHA never reached origin. The 5 review threads were resolved on GitHub against the wrong commit, and the squash-merge captured only the agent's original content.

**Net: 5 known bugs were live in devkit master. This PR re-applies all 5 fixes.**

Closes #3757. Refs: #3743, plan `2026-05-30-trawl-devkit-perfect-alignment.md`.

## Findings re-applied

1. **JSDoc accuracy** (`buildPriceIdToPlanMap`): replaced stale comment with accurate description + `@returns` tag
2. **Silent free-fallback warn log** (`resolvePlan`): adds `logger.warn` when priceId is present but not in the map and metadata is empty — the operationally critical one, same silent-downgrade shape as the P0 from #1250
3. **`cancel_at` typeof check**: `if (subscription.cancel_at)` → `if (typeof subscription.cancel_at === 'number')` — prevents `cancel_at = 0` (epoch) from being silently skipped
4. **`previousPlan` validatePlan()**: raw priceIdToPlan/metadata value validated before comparison — prevents stale/invalid metadata from triggering `plan.changed` + `forceRotateForPlanChange` with junk plan names
5. **Test comment correction**: corrects misleading "Suppress retryWithBackoff delays" claim — the mock makes the repo a no-op, it does NOT suppress `setTimeout` delays

## Verification

- `npm run lint` → ESLint: No issues found
- `npm run test:unit -- modules/billing/tests/billing.webhook` → **1714/1714 pass**
- `npm audit --audit-level=high` → pre-existing baseline (no new vulnerabilities)
- Push SHA verified via `git ls-remote`: `6ec833edb3dba2bb914f818f2db06041d502c055`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cancellation timing handling to properly validate timestamp values and support null values
  * Enhanced plan resolution logic with better fallback behavior and improved visibility when plans cannot be resolved
  * Strengthened plan-change detection accuracy through validation before comparison

* **Tests**
  * Updated test infrastructure documentation for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->