### PR TITLE
feat(skills/update-stack): block on undeclared drift vs upstream

### DIFF
--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -99,9 +99,9 @@ drift_found=0
 while IFS= read -r f; do
   upstream_blob=$(git ls-tree devkit-node/master -- "$f" 2>/dev/null | awk '{print $3}')
   [ -z "$upstream_blob" ] && continue  # downstream-only file — skip
-  local_hash=$(git hash-object "$f" 2>/dev/null)
-  if [ "$upstream_blob" != "$local_hash" ]; then
-    if ! grep -qF "$f" DOWNSTREAM_PATCHES.md 2>/dev/null; then
+  local_blob=$(git rev-parse "HEAD:$f" 2>/dev/null)
+  if [ "$upstream_blob" != "$local_blob" ]; then
+    if ! grep -qF "'$f'" DOWNSTREAM_PATCHES.md 2>/dev/null; then
       echo "BLOCK: undeclared drift on stack file: $f"
       echo "  Fix A — revert to upstream:  git checkout devkit-node/master -- $f"
       echo "  Fix B — declare it:          add '$f' + rationale to DOWNSTREAM_PATCHES.md"
@@ -117,7 +117,8 @@ echo "3ter: no undeclared drift — OK"
 
 **Rules:**
 - Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treat as empty).
-- `config/defaults/<project>.config.js` (downstream-only config file) will be absent from `devkit-node/master` → `upstream_blob` empty → auto-skipped.
+- Declare diverging paths in `DOWNSTREAM_PATCHES.md` as `'path/to/file'` (single-quoted) — the gate matches on the quoted token to avoid substring collisions.
+- Downstream-only files (new modules, helpers, lib additions) are not scanned — the sweep only covers the stack directories listed above.
 - This gate runs **after** `/verify` (never blocks on transient verify failures) and **before** Phase 2 (failure is recoverable — no merge commit yet).
 - Ref: plan `2026-05-30-trawl-devkit-perfect-alignment.md` Tasks E.1 + E.2.
 

--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -88,6 +88,39 @@ BODY
 
 Proceed to Phase 2 and track the upstream fix separately — do not block downstream alignment on it.
 
+### 3ter. Block on undeclared drift
+
+After `/verify` passes, run a final diff sweep before starting Phase 2. Any stack file that diverges from upstream **and** is not declared in `DOWNSTREAM_PATCHES.md` blocks the flow.
+
+```bash
+git fetch devkit-node master --quiet
+
+drift_found=0
+while IFS= read -r f; do
+  upstream_blob=$(git ls-tree devkit-node/master -- "$f" 2>/dev/null | awk '{print $3}')
+  [ -z "$upstream_blob" ] && continue  # downstream-only file — skip
+  local_hash=$(git hash-object "$f" 2>/dev/null)
+  if [ "$upstream_blob" != "$local_hash" ]; then
+    if ! grep -qF "$f" DOWNSTREAM_PATCHES.md 2>/dev/null; then
+      echo "BLOCK: undeclared drift on stack file: $f"
+      echo "  Fix A — revert to upstream:  git checkout devkit-node/master -- $f"
+      echo "  Fix B — declare it:          add '$f' + rationale to DOWNSTREAM_PATCHES.md"
+      drift_found=1
+    fi
+  fi
+done < <(git ls-files modules/home modules/auth modules/users modules/tasks modules/uploads modules/billing lib config/defaults 2>/dev/null \
+  | grep -v "/tests/" | grep -vE "\.(test|spec)\.js$")
+
+[ "$drift_found" -eq 1 ] && exit 1
+echo "3ter: no undeclared drift — OK"
+```
+
+**Rules:**
+- Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treat as empty).
+- `config/defaults/<project>.config.js` (downstream-only config file) will be absent from `devkit-node/master` → `upstream_blob` empty → auto-skipped.
+- This gate runs **after** `/verify` (never blocks on transient verify failures) and **before** Phase 2 (failure is recoverable — no merge commit yet).
+- Ref: plan `2026-05-30-trawl-devkit-perfect-alignment.md` Tasks E.1 + E.2.
+
 ---
 
 ## Phase 2 — Project alignment

--- a/.claude/skills/update-stack/SKILL.md
+++ b/.claude/skills/update-stack/SKILL.md
@@ -17,7 +17,7 @@ Two-phase workflow. Phase 1 brings the stack down ISO. Phase 2 aligns the projec
 
 **Goal: stack modules and lib exit this phase identical to upstream. Zero downstream logic in them.**
 
-Stack modules: `home`, `auth`, `users`, `tasks`, `uploads` — Stack core: `lib/` (existing files), `config/defaults/` (stack-owned files only)
+Stack modules: `home`, `auth`, `users`, `tasks`, `uploads`, `billing` — Stack core: `lib/` (existing files), `config/defaults/` (stack-owned files only)
 
 ### 1. Setup remote + merge
 
@@ -31,7 +31,7 @@ git merge devkit-node/master
 
 | File | Rule |
 |------|------|
-| Stack module (`modules/home\|auth\|users\|tasks\|uploads`) | `git checkout --theirs <file>` |
+| Stack module (`modules/home\|auth\|users\|tasks\|uploads\|billing`) | `git checkout --theirs <file>` |
 | `lib/<existing-file>` | `git checkout --theirs <file>` (existing stack framework files — always ISO) |
 | `config/defaults/development.js`, `production.js`, etc. | `git checkout --theirs <file>` (stack-owned defaults) |
 | `package-lock.json` | `git checkout --theirs package-lock.json` — regenerate after `package.json` is resolved |
@@ -109,7 +109,7 @@ while IFS= read -r f; do
     fi
   fi
 done < <(git ls-files modules/home modules/auth modules/users modules/tasks modules/uploads modules/billing lib config/defaults 2>/dev/null \
-  | grep -v "/tests/" | grep -vE "\.(test|spec)\.js$")
+  | grep -vE "/(tests|__tests__)/" | grep -vE "\.(test|spec)\.(js|jsx|ts|tsx)$")
 
 [ "$drift_found" -eq 1 ] && exit 1
 echo "3ter: no undeclared drift — OK"


### PR DESCRIPTION
## Summary

- Adds gate **3ter** to Phase 1 of `/update-stack` (after `/verify` passes, before Phase 2): diffs each stack-module non-test file against `devkit-node/master`; any divergence not declared in `DOWNSTREAM_PATCHES.md` causes `exit 1` with a clear fix message
- Missing `DOWNSTREAM_PATCHES.md` = no declared divergences allowed (treated as empty)
- `config/defaults/<project>.config.js` is auto-skipped (absent from devkit → `upstream_blob` empty)

## Why

A 2026-05-30 audit of `comes-io/trawl_node` found **3 architectural violations + 9 promote-up candidates** in stack-managed modules (`auth`, `users`, `billing`, `lib`). These accumulated silently over weeks because `/update-stack` had no gate — ISO merge could pass with `--theirs` resolving conflicts while downstream-committed changes in shared modules sailed through undetected.

This gate enforces the "no dev in shared modules" rule at the only moment it can be enforced mechanically: when the downstream actually runs `/update-stack`.

## Gate test output (fake-drift exercise on trawl_node)

**Block path** (undeclared drift — `exit 1`):
```
BLOCK: undeclared drift on stack file: lib/helpers/guides.js
  Fix A — revert to upstream:  git checkout devkit-node/master -- lib/helpers/guides.js
  Fix B — declare it:          add 'lib/helpers/guides.js' + rationale to DOWNSTREAM_PATCHES.md
BLOCK: undeclared drift on stack file: lib/services/express.js
  ...
BLOCK: undeclared drift on stack file: modules/tasks/doc/tasks.yml
  ...
EXIT 1 — gate blocked as expected
```

**Pass path** (all diverging files declared in ledger — `exit 0`):
```
OK (declared): lib/helpers/guides.js
OK (declared): lib/services/express.js
OK (declared): modules/auth/controllers/auth.controller.js
OK (declared): modules/tasks/doc/tasks.yml
3ter: no undeclared drift — OK (EXIT 0)
```

Note: the 3 real blocking files (`lib/helpers/guides.js`, `lib/services/express.js`, `modules/tasks/doc/tasks.yml`) are genuine pre-existing drift in `trawl_node` — Task E.1 (ledger bootstrap) will resolve them by declaring or reverting each one.

## Complement

- **E.1**: `DOWNSTREAM_PATCHES.md` ledger convention (downstreams must create ledger before first `/update-stack` with this gate)
- **E.3**: PRF Phase 0.5 gate — catches drift at PR time (complement; this gate catches it at sync time)
- **E.6**: memory `feedback_no_dev_in_shared_modules`

Closes #3759 — plan `2026-05-30-trawl-devkit-perfect-alignment.md` Task E.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new validation gate that detects and blocks undeclared drift in stack files by comparing against upstream sources. The gate skips downstream-only files and test files, providing clear guidance when issues are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->