### PR TITLE
feat(auth): trigger handleSignupOrganization on verifyEmail success (best-effort)

### DIFF
--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -666,6 +666,21 @@ const verifyEmail = async (req, res) => {
       emailVerificationToken: null,
       emailVerificationExpires: null,
     }, 'recover');
+    // Mark verified on the local object so handleSignupOrganization sees emailVerified=true
+    user.emailVerified = true;
+
+    // Post-verification org setup — provision org/grant if not yet done (best-effort).
+    // handleSignupOrganization is idempotent: if the org already exists it converges
+    // without double-crediting. Failure must never block email verification success.
+    try {
+      await AuthOrganizationService.handleSignupOrganization(user);
+    } catch (orgErr) {
+      logger.warn('[auth.verifyEmail] org/grant provisioning failed (non-fatal)', {
+        userId: user.id,
+        error: orgErr?.message,
+      });
+    }
+
     return responses.success(res, 'Email verified successfully')({ emailVerified: true });
   } catch (err) {
     responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);

--- a/modules/auth/tests/auth.verifyEmail.signup-org.unit.tests.js
+++ b/modules/auth/tests/auth.verifyEmail.signup-org.unit.tests.js
@@ -1,0 +1,146 @@
+/**
+ * Module dependencies.
+ */
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+/**
+ * Unit tests for auth.controller verifyEmail() — handleSignupOrganization wiring.
+ *
+ * Verifies that:
+ *  1. verifyEmail calls handleSignupOrganization after the user's emailVerified flag is set.
+ *  2. A failure in handleSignupOrganization does NOT cause verifyEmail to fail (best-effort).
+ */
+describe('auth.controller verifyEmail — handleSignupOrganization wiring:', () => {
+  let handleSignupOrganizationMock;
+  let mockUserService;
+  let mockResponses;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    handleSignupOrganizationMock = jest.fn().mockResolvedValue({ _id: 'org_001' });
+
+    mockUserService = {
+      create: jest.fn(),
+      getBrut: jest.fn().mockResolvedValue({
+        _id: 'user_001',
+        id: 'user_001',
+        email: 'user@example.com',
+        emailVerificationToken: 'tok',
+        emailVerificationExpires: Date.now() + 3600000,
+      }),
+      update: jest.fn().mockResolvedValue({}),
+      remove: jest.fn(),
+      search: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
+    };
+
+    mockResponses = {
+      successCb: jest.fn(),
+      errorCb: jest.fn(),
+    };
+
+    jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
+      default: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../config/index.js', () => ({
+      default: {
+        sign: { up: true, in: true },
+        jwt: { secret: 's', expiresIn: 3600 },
+        cookie: { secure: false, sameSite: 'lax' },
+        organizations: { enabled: true },
+        app: { title: 'Test', contact: 'a@b.com' },
+      },
+    }));
+    jest.unstable_mockModule('../../../modules/users/services/users.service.js', () => ({
+      default: mockUserService,
+    }));
+    jest.unstable_mockModule('../../../modules/auth/services/auth.invitation.service.js', () => ({
+      default: { findValid: jest.fn().mockResolvedValue(null), consume: jest.fn().mockResolvedValue(null) },
+    }));
+    jest.unstable_mockModule('../../../modules/auth/services/auth.signupCapacity.js', () => ({
+      computeSignupCapacity: jest.fn().mockResolvedValue({ cap: null, remaining: null }),
+    }));
+    jest.unstable_mockModule('../../../modules/users/repositories/users.repository.js', () => ({
+      default: { update: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.service.js', () => ({
+      default: { handleSignupOrganization: handleSignupOrganizationMock },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.crud.service.js', () => ({
+      default: { autoSetCurrentOrganization: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../modules/organizations/services/organizations.membership.service.js', () => ({
+      default: { findByUserAndOrganization: jest.fn(), listPendingByUser: jest.fn().mockResolvedValue([]) },
+    }));
+    jest.unstable_mockModule('../../../modules/users/models/users.schema.js', () => ({
+      default: { User: {} },
+    }));
+    jest.unstable_mockModule('../../../lib/middlewares/model.js', () => ({
+      default: { getResultFromZod: jest.fn(), checkError: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../lib/middlewares/policy.js', () => ({
+      default: { defineAbilityFor: jest.fn().mockResolvedValue({}) },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/mailer/index.js', () => ({
+      default: { isConfigured: jest.fn().mockReturnValue(false), sendMail: jest.fn() },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/responses.js', () => ({
+      default: {
+        success: jest.fn().mockReturnValue(mockResponses.successCb),
+        error: jest.fn().mockReturnValue(mockResponses.errorCb),
+      },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/errors.js', () => ({
+      default: { getMessage: jest.fn().mockReturnValue('error') },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/AppError.js', () => ({
+      default: class AppError extends Error {
+        constructor(msg, opts) {
+          super(msg);
+          this.code = opts?.code;
+          this.details = opts?.details;
+        }
+      },
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/abilities.js', () => ({
+      default: jest.fn().mockReturnValue([]),
+    }));
+    jest.unstable_mockModule('../../../lib/helpers/getBaseUrl.js', () => ({
+      default: jest.fn().mockReturnValue('http://localhost:3000'),
+    }));
+    jest.unstable_mockModule('../../../lib/services/analytics.js', () => ({
+      default: { identify: jest.fn(), capture: jest.fn(), groupIdentify: jest.fn() },
+    }));
+  });
+
+  test('calls handleSignupOrganization when email verification succeeds', async () => {
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = { params: { token: 'tok' } };
+    const res = {};
+
+    await AuthController.verifyEmail(req, res);
+
+    expect(handleSignupOrganizationMock).toHaveBeenCalledTimes(1);
+    // Must be called with a user that has emailVerified=true (marked before the call)
+    expect(handleSignupOrganizationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ emailVerified: true }),
+    );
+  });
+
+  test('does not crash if handleSignupOrganization throws (best-effort)', async () => {
+    handleSignupOrganizationMock.mockRejectedValue(new Error('org boom'));
+
+    const { default: AuthController } = await import('../../../modules/auth/controllers/auth.controller.js');
+
+    const req = { params: { token: 'tok' } };
+    const res = {};
+
+    // Email verification must NOT fail because of an org-setup error
+    await AuthController.verifyEmail(req, res);
+
+    // The success response must still be sent
+    expect(mockResponses.successCb).toHaveBeenCalledWith({ emailVerified: true });
+  });
+});


### PR DESCRIPTION
## Summary

Promote-up from trawl_node (trawl#1317 + alignment plan `2026-05-30-trawl-devkit-perfect-alignment.md` E.1 — Task 4 of `2026-06-01-trawl-promote-up-followups.md`).

- Wire `AuthOrganizationService.handleSignupOrganization(user)` into `verifyEmail` after the `emailVerified` flag is persisted to DB and marked on the local object
- Wrapped in `try/catch` — **org-setup failure must NEVER fail email verification** (regression risk if wrapper is removed; second test proves it)
- `user.emailVerified = true` marked on the local object before the call so `handleSignupOrganization` sees the correct flag state

## Why this is needed

When a downstream uses a real mailer (SMTP configured), org provisioning is deferred at signup time (the user hasn't verified yet). Without this call, users who go through the email-verification flow never get their org/grant provisioned. The `signup` handler already calls `handleSignupOrganization`, but that path short-circuits when mailer is active — `verifyEmail` is the completion point.

`handleSignupOrganization` is idempotent (convergence guard: re-verify edge cases do not double-credit the grant, and if the org already exists it converges cleanly).

## Safety

Best-effort `try/catch` — an org-setup error (transient DB, re-verify edge case) logs a `warn` and lets email verification succeed. This is the identical pattern used in trawl production since trawl#1251.

## Files changed

- `modules/auth/controllers/auth.controller.js` — 15 lines: `user.emailVerified = true` mark + `handleSignupOrganization` try/catch block in `verifyEmail`
- `modules/auth/tests/auth.verifyEmail.signup-org.unit.tests.js` (new) — 2 unit tests: (1) handler called with `emailVerified=true` user; (2) org failure does NOT crash `verifyEmail`

## Pre-push gate

`/critical-review --via deepseek`: **OK** — 0 critical/high/medium, 1 low (cosmetic log field, matches trawl reference verbatim). Verdict: proceed.

Closes #3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email verification now automatically provisions user organization access and associated grants upon successful email confirmation, streamlining the new user onboarding experience and eliminating additional manual setup steps.

* **Tests**
  * Added comprehensive test coverage to ensure organization provisioning is correctly triggered during email verification and operates as expected within the verification workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->