### PR TITLE
fix(billing): cleanup 4 Copilot nits on subscription_changed analytics (#3772)

### DIFF
--- a/modules/billing/services/billing.webhook.service.js
+++ b/modules/billing/services/billing.webhook.service.js
@@ -508,25 +508,19 @@ const handleSubscriptionUpdated = async (subscription, event) => {
       }
 
       // Emit analytics observability event for downstreams running PostHog (no-op otherwise).
-      // Mirrors the internal billing.plan.changed event but lands in the analytics pipeline.
+      // Mirrors the internal plan.changed event but lands in the analytics pipeline.
+      // AnalyticsService.capture() swallows its own errors — no outer try/catch needed.
       if (AnalyticsService.isConfigured()) {
-        try {
-          AnalyticsService.capture({
-            distinctId: organizationId,
-            event: 'subscription_changed',
-            source: 'stripe-webhook',
-            properties: {
-              previousPlan,
-              newPlan,
-              isDowngrade,
-            },
-          });
-        } catch (capErr) {
-          logger.error('[billing.webhook] analytics capture subscription_changed failed (non-fatal)', {
-            organizationId,
-            error: capErr?.message ?? String(capErr),
-          });
-        }
+        AnalyticsService.capture({
+          distinctId: organizationId,
+          event: 'subscription_changed',
+          source: 'stripe-webhook',
+          properties: {
+            previousPlan,
+            newPlan,
+            isDowngrade,
+          },
+        });
       }
 
       // Plan switch mid-cycle = refresh the active week snapshot to the new plan.

--- a/modules/billing/tests/billing.webhook.subscription-changed-analytics.unit.tests.js
+++ b/modules/billing/tests/billing.webhook.subscription-changed-analytics.unit.tests.js
@@ -225,8 +225,8 @@ describe('billing.webhook.service — subscription_changed analytics emit:', () 
   });
 
   describe('when plan did not change', () => {
-    test('does not capture subscription_changed', async () => {
-      // No previous_attributes.items — no plan change detected
+    test('does not capture subscription_changed when previous_attributes.items is absent', async () => {
+      // No previous_attributes.items — plan-change branch is skipped entirely
       await BillingWebhookService.handleSubscriptionUpdated(
         _mkStripeSubscription(),
         _mkEvent({
@@ -239,15 +239,51 @@ describe('billing.webhook.service — subscription_changed analytics emit:', () 
       );
       expect(subscriptionChangedCalls).toHaveLength(0);
     });
+
+    test('does not capture subscription_changed when previousPlan === newPlan (same-plan guard)', async () => {
+      // previous_attributes.items IS present but the plan is the same — the
+      // `previousPlan !== newPlan` guard should prevent the emit.
+      await BillingWebhookService.handleSubscriptionUpdated(
+        _mkStripeSubscription({
+          items: {
+            data: [{ price: { id: 'price_growth', metadata: { planId: 'growth' } }, current_period_start: 1700000000 }],
+          },
+        }),
+        _mkEvent({
+          data: {
+            previous_attributes: {
+              items: { data: [{ price: { id: 'price_growth', metadata: { planId: 'growth' } } }] },
+            },
+          },
+        }),
+      );
+
+      const subscriptionChangedCalls = mockAnalyticsCapture.mock.calls.filter(
+        ([arg]) => arg.event === 'subscription_changed',
+      );
+      expect(subscriptionChangedCalls).toHaveLength(0);
+    });
   });
 
   describe('when event is stale (updateIfEventNewer returns null)', () => {
     test('does not capture subscription_changed', async () => {
+      // Fixture includes previous_attributes.items so the stale-event guard is what
+      // actually prevents capture (not the absence of a plan change).
       mockSubscriptionRepository.updateIfEventNewer.mockResolvedValue(null);
 
       await BillingWebhookService.handleSubscriptionUpdated(
-        _mkStripeSubscription(),
-        _mkEvent(),
+        _mkStripeSubscription({
+          items: {
+            data: [{ price: { id: 'price_growth', metadata: { planId: 'growth' } }, current_period_start: 1700000000 }],
+          },
+        }),
+        _mkEvent({
+          data: {
+            previous_attributes: {
+              items: { data: [{ price: { id: 'price_free', metadata: { planId: 'free' } } }] },
+            },
+          },
+        }),
       );
 
       const subscriptionChangedCalls = mockAnalyticsCapture.mock.calls.filter(


### PR DESCRIPTION
## Summary

Addresses the 4 Copilot nits from issue #3772 left over from the `subscription_changed` analytics PR (#3769):

- **Remove redundant try/catch** around `AnalyticsService.capture()` — the service wraps `client.capture` in its own `catch (_) {}` and is documented to never throw; the outer catch was dead code
- **Fix comment naming mismatch** — comment said `billing.plan.changed` but the code emits `plan.changed` via `billingEvents.emit('plan.changed', …)`; updated to match for grep/trace correctness
- **Fix stale-event test fixture** — the "stale event" test was using `_mkEvent()` with no `previous_attributes.items`, which skipped the plan-change branch before reaching the stale guard; fixture now includes `previous_attributes.items` so the `updateIfEventNewer → null` guard is what prevents capture
- **Add same-plan test coverage** — the "no emit on same plan" block only covered absent `previous_attributes.items`; added a second case where items IS present and `previousPlan === newPlan` is the guard that fires

## Test plan

- [ ] `npm run test:unit -- modules/billing/tests/billing.webhook` — all 6 tests in the analytics suite pass (verified locally: 1753/1753 total)
- [ ] CI green
- [ ] CodeRabbit 0 unresolved threads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for subscription change analytics events, including additional scenarios for improved reliability assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->