### PR TITLE
fix(templates): noun-agnostic copy for billing-quota-reached-100

### DIFF
--- a/config/templates/billing-quota-reached-100.html
+++ b/config/templates/billing-quota-reached-100.html
@@ -3,7 +3,7 @@
 <body>
   <p>Hello,</p>
   <p>Your <b>{{appName}}</b> weekly quota is now fully used ({{meterUsed}} / {{meterQuota}} units).</p>
-  <p>If you have an extras pack, your scheduled jobs keep running from its remaining balance until it's used up. Otherwise they pause until you add an extras pack or upgrade your plan — nothing is charged automatically.</p>
+  <p>If you have an extras pack, your usage continues drawing from its remaining balance until it's used up. Otherwise it pauses until you add an extras pack or upgrade your plan — nothing is charged automatically.</p>
   <p>Check your consumption or add an extras pack on your <a href="{{billingUrl}}">billing dashboard</a>.</p>
   <br />
   <p>The <b>{{appName}}</b> Team.</p>


### PR DESCRIPTION
## Summary

Replace \"scheduled jobs\" with \"usage continues\" in the 100%-quota email template. Neutral phrasing works for every downstream regardless of product domain (scraps, hikes, jobs, items, etc.).

Lets trawl drop its trawl-branded overlay entirely in a follow-up trawl PR — removes the last template-overlay divergence from \`DOWNSTREAM_PATCHES.md\`.

## Test plan

- [x] Pure copy change — no structural change, same {{appName}}/{{meterUsed}}/{{meterQuota}}/{{billingUrl}}/{{appContact}} substitutions
- [x] Push verified via \`git ls-remote\` SHA match (\`2869730b\`)

Part of plan \`infra/docs/superpowers/plans/2026-06-02-trawl-billing-residual-cleanup.md\` T7a (added post-plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified notification messaging for billing quota status to improve clarity on how the extras-pack balance is utilized after the weekly quota is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->