### PR TITLE
docs(billing): document meter service as calc-agnostic

### DIFF
--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -2,6 +2,12 @@
 
 Stripe-based billing with per-plan quota management and meter-based compute pricing.
 
+## Module boundary — the meter service is calc-agnostic
+
+`billing.meter.service.js` converts a feature-keyed **USD cost map → meter units** via config ratios (`dollarsToUnitRatio`, per-plan `ratios`) and applies config knobs (`runBase`, `maxUnitsPerOperation`). It does **not** know what a run costs.
+
+**Downstream cost semantics — what a scrap/op costs, per-run infra base, product-specific floors/caps — live in the downstream's own cost module + config (e.g. Trawl `modules/costs`), never inline in this service.** An inline downstream patch here is silently wiped by `/update-stack`: a tier0 run-base floor added downstream inside a `billing.meter.service.js` copy was lost on the next stack sync, zero-ing metering for free-tier scrapes (trawl `#1293` → `#1316`). If a behaviour must live in this service, add it as a **default-off config knob**, never a hardcoded downstream rule.
+
 ## Quota System
 
 ### Configuration

--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -6,7 +6,7 @@ Stripe-based billing with per-plan quota management and meter-based compute pric
 
 `billing.meter.service.js` converts a feature-keyed **USD cost map → meter units** via config ratios (`dollarsToUnitRatio`, per-plan `ratios`) and applies config knobs (`runBase`, `maxUnitsPerOperation`). It does **not** know what a run costs.
 
-**Downstream cost semantics — what a scrap/op costs, per-run infra base, product-specific floors/caps — live in the downstream's own cost module + config (e.g. Trawl `modules/costs`), never inline in this service.** An inline downstream patch here is silently wiped by `/update-stack`: a tier0 run-base floor added downstream inside a `billing.meter.service.js` copy was lost on the next stack sync, zero-ing metering for free-tier scrapes (trawl `#1293` → `#1316`). If a behaviour must live in this service, add it as a **default-off config knob**, never a hardcoded downstream rule.
+**Downstream cost semantics — what a scrape/op costs, per-run infra base, product-specific floors/caps — live in the downstream's own cost module + config (e.g. Trawl `modules/costs`), never inline in this service.** An inline downstream patch here is silently wiped by `/update-stack`: a tier0 run-base floor added downstream inside a `billing.meter.service.js` copy was lost on the next stack sync, zeroing metering for free-tier scrapes (trawl `#1293` → `#1316`). If a behaviour must live in this service, add it as a **default-off config knob**, never a hardcoded downstream rule.
 
 ## Quota System
 


### PR DESCRIPTION
## Why

`billing.meter.service.js` has no downstream product knowledge by design — it only converts a USD cost map to meter units via config ratios. But this boundary was invisible, so downstream patches (per-run infra base, product floors/caps) kept landing **inside the service copy** on downstream repos, then getting silently wiped on the next `/update-stack` sync.

Root incident: a tier0 run-base floor added inside `billing.meter.service.js` in Trawl was lost on the next stack sync → metering zeroed for free-tier scrapes (trawl `#1293` → `#1316`).

## What

6-line note added at the top of `modules/billing/README.md`:
- Explains what the service does (USD cost map → units via ratios/knobs)
- Explicitly states downstream cost semantics stay in the downstream's own cost module + config
- Documents the wipe mechanism and the safe alternative (default-off config knob upstream)

## Scope

Doc-only. No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified billing module documentation regarding module boundaries and cost configuration organization. Added detailed guidance on proper placement of cost-specific business logic within downstream systems, configuration management practices, explicit warnings about custom modifications being overwritten during platform updates, and best practices for extending functionality through configurable knobs rather than hardcoded customizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->