### PR TITLE
feat(auth): expose app version in GET /api/auth/config

### DIFF
--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -13,6 +13,7 @@ const config = {
     keywords: 'node, express, mongo, jwt, stack, boilerplate',
     googleAnalyticsTrackingID: 'DEVKIT_NODE_app_googleAnalyticsTrackingID',
     contact: 'contact@example.com',
+    version: '', // app release version — overridden at build via DEVKIT_NODE_app_version (Layer 4 env override); getConfig falls back to package.json version
   },
   swagger: {
     enable: true,

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -626,6 +626,13 @@ const getConfig = async (req, res) => {
       mail: {
         configured: isMailerConfigured(),
       },
+      app: {
+        version: (() => {
+          const v = config.app?.version;
+          if (v && !String(v).startsWith('DEVKIT_NODE_')) return v;
+          return config.package?.version || 'dev';
+        })(),
+      },
     };
 
     // Authenticated users get extended org config and billing config

--- a/modules/auth/tests/auth.integration.tests.js
+++ b/modules/auth/tests/auth.integration.tests.js
@@ -1548,6 +1548,13 @@ describe('Auth integration tests:', () => {
       const result = await agent.get('/api/auth/config').expect(200);
       expect(result.body.data.billing).toBeUndefined();
     });
+
+    test('should expose app.version in the public config', async () => {
+      const result = await agent.get('/api/auth/config').expect(200);
+      expect(result.body.data.app).toBeDefined();
+      expect(typeof result.body.data.app.version).toBe('string');
+      expect(result.body.data.app.version.length).toBeGreaterThan(0);
+    });
   });
 
   describe('Config endpoint (authenticated)', () => {


### PR DESCRIPTION
## Summary

- Add `version: ''` to `config/defaults/development.config.js` (app block), overridden at build via `DEVKIT_NODE_app_version` env var
- Expose `app: { version }` in the public block of `getConfig` (resolution: build-arg → `package.json` version → `'dev'`)
- Add integration test asserting `data.app.version` is a non-empty string

## Why

Footer (Vue side) needs the running API version to display build info. This is the Node side of the cross-repo feature.

**Part B of pierreb-devkit/Vue#4270**

## Scope

- Module(s) impacted: `auth` (controller, test), `config/defaults`
- Cross-module impact: none
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: `version` is intentionally public (same exposure as `package.json` version already in most build artifacts)
- Mergeability considerations: additive only — no existing field modified
- Follow-up tasks: downstream projects should set `DEVKIT_NODE_app_version` build-arg in their Docker builds to surface the real version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version is now included in the API configuration, enabling clients to retrieve the current version information.

* **Tests**
  * Added integration test coverage to verify version information is properly exposed in the authentication configuration endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->