### PR TITLE
feat(invitations): edge-case hardening — two-phase claim, CI email index, cap unify (P3)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,24 @@ Breaking changes and upgrade notes for downstream projects.
 
 ---
 
+## Invitations hardening: case-insensitive unique email index + two-phase invite claim (2026-06-10)
+
+Phase 3 of the invitations↔org decouple epic (#3811). Two downstream-relevant changes.
+
+### What changed (this repo)
+
+- **`users.email` is now lowercased + case-insensitively unique.** Inline `unique:true` removed; `lowercase:true` added; an explicit collation index `{ email:1 }, { unique:true, name:'email_ci_unique', collation:{ locale:'en', strength:2 } }` declared on the schema. Email inputs normalized to lowercase in `findByEmail` / get-by-email / `linkProviderByEmail` / `remove`. New migration **`modules/users/migrations/20260610120000-users-email-ci-unique-index.js`**: pre-checks for case-variant duplicate emails and **ABORTS boot if any exist** (no auto-merge), then creates the collation index FIRST and drops the legacy `email_1` (never a window without a unique index). `lib/helpers/errors.js` `getUniqueMessage` now derives the field from `err.keyPattern` (index-name-agnostic) so the collation index still yields a friendly "Email already exists." message.
+- **Invitation `consumingAt` two-phase claim** (new optional field on the `invitations` collection): the signup gate now atomically claims an invite before user creation and finalizes/releases after, with a lazy stale-claim sweep (15 min, no scheduler). Pure additive schema change — no data migration needed.
+
+### Action required for downstream projects (`/update-project`)
+
+1. The model/repository/migration changes are devkit-owned → arrive via `/update-stack` (`--theirs`).
+2. **🔴 Before the first boot that carries the new schema, pre-check prod for case-variant duplicate emails** (`db.users.aggregate([{$group:{_id:{$toLower:'$email'},n:{$sum:1}}},{$match:{n:{$gt:1}}}])`). If any exist, resolve them BEFORE deploy — otherwise the migration aborts boot. (Trawl: handled in epic Phase 9 / #3815.)
+3. Migrations run at boot before `listen()`; the index swap + the `consumingAt` field land automatically once the dupe pre-check passes.
+4. No client/contract change; existing 200/422 signup assertions pass unchanged.
+
+---
+
 ## @casl/ability v6 → v7 (2026-05-22)
 
 `@casl/ability` upgraded from `^6.8.1` to `^7.0.0`.

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -6,6 +6,16 @@
 const getUniqueMessage = (err) => {
   let output;
 
+  // Primary: derive the field from the driver-supplied keyPattern (e.g. { email: 1 }).
+  // This is index-NAME-agnostic, so it works for both the legacy `email_1` index and
+  // the E3 case-insensitive `email_ci_unique` collation index — the old errmsg parse
+  // below assumed a `{field}_1` index name and broke on any other name (and the
+  // collation index's keyValue is binary-garbled, so keyPattern is the right source).
+  const keyField = err.keyPattern && typeof err.keyPattern === 'object' ? Object.keys(err.keyPattern)[0] : null;
+  if (keyField) {
+    return `${keyField.charAt(0).toUpperCase() + keyField.slice(1)} already exists`;
+  }
+
   try {
     let begin = 0;
     if (err.errmsg.lastIndexOf('.$') !== -1) {

--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -1,0 +1,42 @@
+/**
+ * Sensitive query-string parameters that must never reach the request log.
+ *
+ * `inviteToken` rides the query string of `POST /api/auth/signup?inviteToken=…`
+ * (the Vue client puts it there, not in the body). The morgan log pattern logs
+ * `:url`, so without redaction a live single-use invite token lands in prod logs
+ * (and any log shipper / aggregator downstream). Redact it to `REDACTED`.
+ */
+const SENSITIVE_QUERY_KEYS = ['inviteToken'];
+
+/**
+ * @desc Redact sensitive query-string parameters from a request URL for logging.
+ * Preserves the path and every other query parameter; only the value of a
+ * sensitive key is replaced with `REDACTED`. Tolerant of a missing/empty URL and
+ * URLs with no query string (returned unchanged). Pure + synchronous so it is
+ * safe to call on every logged request.
+ * @param {String} url - the raw request URL (path + optional query string)
+ * @returns {String} the URL with sensitive query values redacted
+ */
+const redactUrl = (url) => {
+  if (!url || typeof url !== 'string') return url;
+  const queryStart = url.indexOf('?');
+  if (queryStart === -1) return url;
+
+  const pathPart = url.slice(0, queryStart);
+  const queryPart = url.slice(queryStart + 1);
+
+  const redactedQuery = queryPart
+    .split('&')
+    .map((pair) => {
+      const eq = pair.indexOf('=');
+      const key = eq === -1 ? pair : pair.slice(0, eq);
+      if (SENSITIVE_QUERY_KEYS.includes(key)) return `${key}=REDACTED`;
+      return pair;
+    })
+    .join('&');
+
+  return `${pathPart}?${redactedQuery}`;
+};
+
+export default redactUrl;
+export { SENSITIVE_QUERY_KEYS };

--- a/lib/helpers/tests/errors.uniqueMessage.unit.tests.js
+++ b/lib/helpers/tests/errors.uniqueMessage.unit.tests.js
@@ -1,0 +1,37 @@
+import { describe, test, expect } from '@jest/globals';
+import errors from '../errors.js';
+
+/**
+ * getUniqueMessage (via errors.getMessage on an E11000) must derive the friendly
+ * "X already exists." message from the driver keyPattern — index-NAME-agnostic — so
+ * it survives the E3 rename of the email unique index from `email_1` to the
+ * collation-named `email_ci_unique`.
+ */
+describe('errors.getMessage — E11000 unique violation (keyPattern, index-name agnostic)', () => {
+  test('derives the field from keyPattern for the collation email index (no _1 suffix)', () => {
+    const err = {
+      code: 11000,
+      keyPattern: { email: 1 },
+      // collation index name + a binary-garbled key value (real-world shape)
+      errmsg: 'E11000 duplicate key error collection: db.users index: email_ci_unique collation: { locale: "en" } dup key: { email: "??" }',
+    };
+    expect(errors.getMessage(err)).toBe('Email already exists.');
+  });
+
+  test('still works via keyPattern for a legacy email_1 index', () => {
+    const err = {
+      code: 11000,
+      keyPattern: { email: 1 },
+      errmsg: 'E11000 duplicate key error collection: db.users index: email_1 dup key: { : "a@b.co" }',
+    };
+    expect(errors.getMessage(err)).toBe('Email already exists.');
+  });
+
+  test('falls back to the legacy errmsg parse when keyPattern is absent (older drivers)', () => {
+    const err = {
+      code: 11000,
+      errmsg: 'E11000 duplicate key error collection: db.users index: email_1 dup key: { : "a@b.co" }',
+    };
+    expect(errors.getMessage(err)).toBe('Email already exists.');
+  });
+});

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -1,0 +1,44 @@
+import { describe, test, expect } from '@jest/globals';
+import redactUrl, { SENSITIVE_QUERY_KEYS } from '../redactUrl.js';
+
+describe('redactUrl', () => {
+  test('redacts an inviteToken value, preserving the path', () => {
+    expect(redactUrl('/api/auth/signup?inviteToken=abc123deadbeef')).toBe('/api/auth/signup?inviteToken=REDACTED');
+  });
+
+  test('redacts inviteToken among other query params, leaving the rest intact', () => {
+    expect(redactUrl('/api/auth/signup?foo=1&inviteToken=secret&bar=2')).toBe('/api/auth/signup?foo=1&inviteToken=REDACTED&bar=2');
+  });
+
+  test('redacts inviteToken when it is the first of several params', () => {
+    expect(redactUrl('/x?inviteToken=secret&bar=2')).toBe('/x?inviteToken=REDACTED&bar=2');
+  });
+
+  test('leaves a URL without a query string unchanged', () => {
+    expect(redactUrl('/api/auth/signup')).toBe('/api/auth/signup');
+  });
+
+  test('leaves a URL whose query has no sensitive key unchanged', () => {
+    expect(redactUrl('/api/users?page=2&perPage=10')).toBe('/api/users?page=2&perPage=10');
+  });
+
+  test('handles a bare sensitive key with no value (no = sign)', () => {
+    // `?inviteToken` with no value: still scrubbed (becomes inviteToken=REDACTED) so a
+    // malformed/edge query can never leak a partial token form downstream.
+    expect(redactUrl('/x?inviteToken')).toBe('/x?inviteToken=REDACTED');
+  });
+
+  test('does not redact a key that merely CONTAINS the sensitive name as a substring', () => {
+    expect(redactUrl('/x?notinviteTokenish=keepme')).toBe('/x?notinviteTokenish=keepme');
+  });
+
+  test('is tolerant of falsy / non-string input', () => {
+    expect(redactUrl('')).toBe('');
+    expect(redactUrl(undefined)).toBeUndefined();
+    expect(redactUrl(null)).toBeNull();
+  });
+
+  test('exports inviteToken as a sensitive key', () => {
+    expect(SENSITIVE_QUERY_KEYS).toContain('inviteToken');
+  });
+});

--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -19,6 +19,7 @@ import redoc from 'redoc-express';
 
 import config from '../../config/index.js';
 import guidesHelper from '../helpers/guides.js';
+import redactUrl from '../helpers/redactUrl.js';
 import logger from './logger.js';
 import requestId from '../middlewares/requestId.js';
 import { posthogContextMiddleware } from '../middlewares/posthog-context.middleware.js';
@@ -238,6 +239,10 @@ const initMiddleware = (app) => {
     morgan.token('email', (req) => _.get(req, 'user.email') || 'Unknown email');
     morgan.token('requestId', (req) => req.id || '-');
     morgan.token('orgId', (req) => _.get(req, 'organization.id') || _.get(req, 'organization._id', '-'));
+    // Override the built-in :url token to scrub single-use secrets (e.g. inviteToken)
+    // from the query string before they hit the log stream. Both the dev and prod
+    // log patterns interpolate :url, so the override covers every logged request.
+    morgan.token('url', (req) => redactUrl(req.originalUrl || req.url));
     app.use(morgan(logger.getLogFormat(), logger.getMorganOptions()));
   }
   // Request body parsing middleware should be above methodOverride

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -70,17 +70,32 @@ const signup = async (req, res) => {
     // invited users included; (2) eligibility — public signup open OR a valid
     // invite token. The eligibility check is supplied by optional modules via the
     // generic registry (auth never imports invitation code). The invitations
-    // checker resolves the email-pinned invite and RETURNS `{ invite, consume }`,
-    // which auth relays back here verbatim (opaque result) so this controller can
-    // canonicalize the account email + consume it below.
-    // Short-circuit count() when cap is not set (null = unlimited) to avoid a
-    // collection-wide count on every signup request for uncapped deployments.
-    const cap = config.sign.cap != null ? Number(config.sign.cap) : null;
-    const capReached = cap != null && Number.isFinite(cap) && (await UserService.count()) >= cap;
-    const eligibility = await Eligibility.assertSignupEligible({ email: req.body.email, body: req.body, req });
+    // checker resolves the email-pinned invite, atomically CLAIMS it (the replay
+    // guard, E2), and RETURNS `{ invite, finalize, release }`, which auth relays
+    // back here verbatim (opaque result) so this controller can canonicalize the
+    // account email + finalize/release the invite below.
+    // E4: cap is computed by computeSignupCapacity (single source of truth shared
+    // with getConfig) — a BLANK cap ('') means UNCAPPED. The old inline Number('')→0
+    // hard-rejected everyone while getConfig advertised the deployment as open.
+    // remaining<=0 (and cap>0) ⇒ the ceiling is reached. Accepted TOCTOU: cap is
+    // checked then the user created non-atomically, so a burst of concurrent signups
+    // can overshoot the cap by a few accounts (a small beta overshoot, tolerated).
+    const { cap, remaining } = await computeSignupCapacity(config.sign?.cap, UserService.count);
+    const capReached = cap != null && cap > 0 && remaining <= 0;
+    // `signupOpen` tells the checker whether the invite is REQUIRED to open the gate.
+    // When public signup is open a token may be PRESENTED but is not required — the
+    // checker must then resolve WITHOUT claiming (E2), so an open-signup signup never
+    // burns / locks a presented token (preserves the P2 `!config.sign.up` gating).
+    const eligibility = await Eligibility.assertSignupEligible({ email: req.body.email, body: req.body, req, signupOpen: !!config.sign.up });
     // null when no optional module opened the gate (registry empty or no valid invite).
     const invite = eligibility?.invite || null;
     if (capReached || (!config.sign.up && !invite)) {
+      // On the closed-signup path the eligibility checker CLAIMED the invite (E2)
+      // before the cap was found exhausted — release it so a cap bump later does not
+      // leave it stuck mid-claim (the lazy sweep would also recover it; this is
+      // immediate). Only the closed-signup path claims, so gate the release on it to
+      // avoid a no-op release (+ misleading log) on an open-signup presented token.
+      if (invite && !config.sign.up) await eligibility?.release?.();
       return responses.error(res, 404, 'Signup error', 'Registration is currently deactivated')();
     }
     // Force default role on public signup — clients must not self-assign admin
@@ -104,14 +119,22 @@ const signup = async (req, res) => {
         }, 'recover');
         // Send verification email (best-effort, do not block signup)
         sendVerificationEmail(user, verificationToken).catch((err) => logger.warn('auth.signup: verification email failed', { message: err?.message, stack: err?.stack }));
-      } else {
-        // No mailer configured — auto-verify so dev/test are not blocked
+      } else if (!invite) {
+        // No mailer configured — auto-verify so dev/test are not blocked.
+        // E6: do NOT auto-verify an INVITE-created account even with the mailer off.
+        // The token proves the INVITER knew the address, not that the SIGNER controls
+        // it — an invited account must follow the normal verification path (it just
+        // won't receive the email when the mailer is off, same as any account).
         const brutUser = await UserService.getBrut({ id: user.id });
         await UserService.update(brutUser, { emailVerified: true }, 'recover');
         user.emailVerified = true;
       }
     } catch (verifyErr) {
       try { await UserService.remove(user); } catch (_cleanupErr) { /* best-effort */ }
+      // E2: a claimed invite must be released on a pre-response failure so the token
+      // is reusable (it was only claimed, never finalized). Only the closed-signup
+      // path claimed, so gate the release on it (open signup never claimed).
+      if (invite && !config.sign.up) { try { await eligibility?.release?.(); } catch (_releaseErr) { /* best-effort */ } }
       throw verifyErr;
     }
 
@@ -127,6 +150,9 @@ const signup = async (req, res) => {
       } catch (_cleanupErr) {
         // Best-effort cleanup; log but don't mask original error
       }
+      // E2: release the claimed invite on org-provisioning failure so it can retry
+      // (only the closed-signup path claimed — open signup never did).
+      if (invite && !config.sign.up) { try { await eligibility?.release?.(); } catch (_releaseErr) { /* best-effort */ } }
       throw orgErr;
     }
 
@@ -145,12 +171,14 @@ const signup = async (req, res) => {
       });
     } catch (_) { /* analytics must not break auth */ }
 
-    // Single-use: consume only when the invite actually opened the gate (signup
-    // was closed, so the invite was required). When signup is open, a token can
-    // be presented but is not required — consuming it would silently burn it.
-    // Consume runs through the closure returned by the eligibility checker
-    // (invitations module owns consume; auth never imports invitation code).
-    if (invite && !config.sign.up) await eligibility?.consume?.();
+    // E2 single-use: FINALIZE only when the invite actually opened the gate (signup
+    // was closed, so the invite was required). When signup is open, a token can be
+    // presented but is not required — and the checker never claimed it, so there is
+    // nothing to finalize. finalize burns single-use (usedAt + status:'accepted')
+    // and records the user; it runs through the closure returned by the eligibility
+    // checker (invitations module owns it; auth never imports invitation code). This
+    // is the last pre-response step, so by here every earlier failure already released.
+    if (invite && !config.sign.up) await eligibility?.finalize?.(user._id || user.id);
 
     const token = jwt.sign({ userId: user.id }, config.jwt.secret, {
       expiresIn: config.jwt.expiresIn,
@@ -437,9 +465,12 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
   try {
     // Same two gates as local signup. OAuth can't carry an invite token through
     // the redirect, so the invite is matched on the provider's verified email.
-    // Short-circuit count() when cap is not set (null = unlimited).
-    const oauthCap = config.sign.cap != null ? Number(config.sign.cap) : null;
-    const capReached = oauthCap != null && Number.isFinite(oauthCap) && (await UserService.count()) >= oauthCap;
+    // E4: cap via computeSignupCapacity (single source of truth shared with getConfig
+    // and the local signup path) — a BLANK cap ('') means UNCAPPED, not 0. The old
+    // inline Number('')→0 hard-rejected every OAuth signup while getConfig advertised
+    // the deployment as open. Same accepted small-beta TOCTOU overshoot as local signup.
+    const { cap: oauthCap, remaining: oauthRemaining } = await computeSignupCapacity(config.sign?.cap, UserService.count);
+    const capReached = oauthCap != null && oauthCap > 0 && oauthRemaining <= 0;
     // Only honor an OAuth invite when the provider verified the email — otherwise a
     // provider returning an arbitrary unverified email could open the gate on an
     // invite meant for someone else.
@@ -449,7 +480,7 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
     // provider-verified email — the checker honors it only when emailVerifiedByProvider.
     // Skip the hook entirely when signup is open: a token/invite is presented but not
     // required, and resolving one would silently burn it (preserves prior short-circuit).
-    // The checker returns `{ invite, consume }` (opaque to auth); no synthetic req carrier.
+    // The checker returns `{ invite, finalize, release }` (opaque to auth); no synthetic req carrier.
     let oauthEligibility = null;
     if (!config.sign.up) {
       oauthEligibility = await Eligibility.assertSignupEligible({
@@ -482,8 +513,13 @@ const checkOAuthUserProfile = async (profil, key, provider) => {
     // else return req.body with the data after Zod validation
     if (oauthInvite) result.value.email = oauthInvite.email;
     const createdUser = await UserService.create(result.value);
-    // Consume through the returned closure (invitations owns consume; auth stays import-free).
-    if (oauthInvite) await oauthEligibility?.consume?.();
+    // E2: FINALIZE through the returned closure (invitations owns it; auth stays
+    // import-free). OAuth resolves the invite by the provider-verified email and
+    // never CLAIMS it (no token on the redirect), so there is no consumingAt to
+    // release on failure here — finalize marks it accepted+used (single-use). The
+    // finalize filter (acceptedAt:null) + the unique-email index are the single-use
+    // backstop against two concurrent OAuth signups for the same invited email.
+    if (oauthInvite) await oauthEligibility?.finalize?.(createdUser._id || createdUser.id);
     return createdUser;
   } catch (err) {
     if (err instanceof AppError) throw err;

--- a/modules/auth/controllers/auth.controller.js
+++ b/modules/auth/controllers/auth.controller.js
@@ -81,6 +81,12 @@ const signup = async (req, res) => {
     // checked then the user created non-atomically, so a burst of concurrent signups
     // can overshoot the cap by a few accounts (a small beta overshoot, tolerated).
     const { cap, remaining } = await computeSignupCapacity(config.sign?.cap, UserService.count);
+    // Note the `cap > 0` guard: a `cap:0` deployment is NOT `capReached` here. cap:0
+    // ({cap:0, remaining:0} per computeSignupCapacity) means "closed to the public",
+    // and its rejection rides the `!sign.up && !invite` arm below — invites intentionally
+    // bypass a zero cap (computeSignupCapacity short-circuits the count for cap<=0), so an
+    // invited signup under cap:0 still passes the gate. capReached is only for a real
+    // positive ceiling that filled up (which DOES reject invites — they count in the cap).
     const capReached = cap != null && cap > 0 && remaining <= 0;
     // `signupOpen` tells the checker whether the invite is REQUIRED to open the gate.
     // When public signup is open a token may be PRESENTED but is not required — the
@@ -105,7 +111,20 @@ const signup = async (req, res) => {
     // unique-email index a reliable single-use backstop — concurrent case-variant
     // signups on the same invite collide on the index instead of creating two accounts.
     if (invite) safeBody.email = invite.email;
-    const user = await UserService.create(safeBody);
+    // E2: the invite was atomically CLAIMED (consumingAt stamped) before we got here,
+    // so a throw FROM create itself must release the claim too — otherwise the invite
+    // stays locked until the 15-min sweep. The most realistic throw is an E11000 from
+    // the case-sensitive unique-email index when two case-variant signups race the same
+    // invited email (validation/transient errors land here as well). Mirror the three
+    // release sites below + the same `!config.sign.up` gating (only the closed-signup
+    // path claimed). Best-effort: a release failure must not mask the create error.
+    let user;
+    try {
+      user = await UserService.create(safeBody);
+    } catch (createErr) {
+      if (invite && !config.sign.up) { try { await eligibility?.release?.(); } catch (_releaseErr) { /* best-effort */ } }
+      throw createErr;
+    }
 
     // Handle email verification — rollback user on failure to avoid orphaned accounts
     try {
@@ -177,7 +196,9 @@ const signup = async (req, res) => {
     // nothing to finalize. finalize burns single-use (usedAt + status:'accepted')
     // and records the user; it runs through the closure returned by the eligibility
     // checker (invitations module owns it; auth never imports invitation code). This
-    // is the last pre-response step, so by here every earlier failure already released.
+    // is the last pre-response step, and every earlier failure path (create-throw,
+    // verify-failure, org-failure) already released the claim, so reaching finalize
+    // means the claim is still ours to burn.
     if (invite && !config.sign.up) await eligibility?.finalize?.(user._id || user.id);
 
     const token = jwt.sign({ userId: user.id }, config.jwt.secret, {

--- a/modules/auth/services/auth.eligibility.js
+++ b/modules/auth/services/auth.eligibility.js
@@ -32,7 +32,7 @@ export const registerSignupEligibility = (fn) => {
  * Returns the FIRST non-null result collected across all checks (in registration
  * order), or null when no check returned one. The result is opaque to auth: it is
  * handed straight back to the caller (e.g. the invitations checker returns
- * `{ invite, consume }`, which auth relays without importing any invitation code).
+ * `{ invite, finalize, release }`, which auth relays without importing any invitation code).
  *
  * NOTE for future check authors (P5/P8 will register more): a THROW from ANY
  * check aborts the whole chain and blocks signup — even a check that runs AFTER

--- a/modules/invitations/invitations.init.js
+++ b/modules/invitations/invitations.init.js
@@ -10,26 +10,41 @@ import logger from '../../lib/services/logger.js';
  * Invitations module initialisation.
  *
  * Plugs the platform-invite gate into auth via the generic eligibility registry
- * (invitations → auth; auth never imports us). The checker RESOLVES the invite
- * that opens the closed-signup gate and RETURNS `{ invite, consume }` — auth
- * relays that result back so the signup controller can canonicalize the account
- * email + consume the invite, without importing any invitation code (the
- * dependency inversion). The `consume` closure keeps the consume logic owned by
- * this module.
+ * (invitations → auth; auth never imports us). The checker RESOLVES + atomically
+ * CLAIMS the invite that opens the closed-signup gate and RETURNS
+ * `{ invite, finalize, release }` — auth relays that result back so the signup
+ * controller can canonicalize the account email and, on the way out, finalize the
+ * invite (full success) or release it (any failure), without importing any
+ * invitation code (the dependency inversion).
+ *
+ * Two-phase claim (E2): the CLAIM happens here (inside the eligibility check, before
+ * the user is created) so a replay / double-accept races on the atomic stamp and
+ * loses (throws 422). The invite is only burned (usedAt + status:'accepted') by the
+ * `finalize` closure once signup fully succeeds; `release` clears the claim so a
+ * later-step failure does not permanently burn the token.
  *
  * @returns {Promise<void>}
  */
 export default async () => {
+  // E2 boot-time stale-claim sweep: release any invite left mid-claim by a crash in
+  // a prior process (consumingAt older than the staleness window, never finalized).
+  // Best-effort (the service swallows + logs errors) so a sweep failure never blocks
+  // boot. The read paths (findValid/findValidByEmail) also sweep lazily — this is the
+  // belt to their suspenders, since the stack has NO in-process scheduler/cron.
+  await InvitationsService.sweepStaleClaims();
+
   // Plug the platform-invite gate into auth (invitations → auth; auth never imports us).
   // One checker covers both signup methods, discriminated by ctx.oauth:
-  //   - local signup: invite resolved by the `?inviteToken=` query (email-pinned).
+  //   - local signup: invite resolved by the `?inviteToken=` query (email-pinned),
+  //     then atomically CLAIMED (the replay guard).
   //   - OAuth signup: no token rides the redirect, so the invite is matched on the
   //     provider-verified email — and ONLY when the provider vouches for it (E7).
+  //     No token to claim; the consumingAt exclusion on the email lookup is the guard.
   // The throw decision (closed-signup AND no invite ⇒ block) stays in auth.controller
-  // (cap + sign.up gate). We RESOLVE the invite and return it paired with a bound
-  // single-use `consume` closure (the return-value seam); auth hands that result
-  // back to whoever opened the gate so it can pin the account email + burn the
-  // invite without importing any invitation code (the dependency inversion).
+  // (cap + sign.up gate). We RESOLVE the invite, CLAIM it (local), and return it paired
+  // with `finalize`/`release` closures (the return-value seam); auth hands that result
+  // back to whoever opened the gate so it can pin the account email + finalize/release
+  // the invite without importing any invitation code (the dependency inversion).
   // Returns undefined (no result) when no eligible invite — auth then sees null.
   registerSignupEligibility(async (ctx = {}) => {
     let invite = null;
@@ -38,6 +53,8 @@ export default async () => {
       if (ctx.oauth.emailVerifiedByProvider) {
         invite = await InvitationsService.assertInvitedByEmail({ email: ctx.email });
       }
+      // OAuth has no token to claim; the consumingAt exclusion on findValidByEmail
+      // already hides a claimed-but-unfinalized invite. No two-phase claim here.
     } else {
       const carrier = ctx.req;
       if (!carrier) return undefined;
@@ -49,11 +66,26 @@ export default async () => {
       const token = carrier.query?.inviteToken ?? carrier.body?.inviteToken;
       // E5: "no email supplied with a token ⇒ no eligibility" lives in assertInvited.
       invite = await InvitationsService.assertInvited({ token, email: ctx.email });
+      // E2: atomically CLAIM the resolved invite BEFORE the user is created — BUT ONLY
+      // when the invite is REQUIRED to open the gate (closed signup). When public
+      // signup is open the token is presented but not required, so we resolve WITHOUT
+      // claiming: auth won't finalize it either (it gates finalize behind !sign.up), so
+      // claiming would only lock the token mid-claim for no reason (preserves P2 gating).
+      // A replay / concurrent accept on the closed-signup path races here and loses
+      // (claim throws 422). assertInvited already enforced the email pin (E5); the claim
+      // filters token+pending+unclaimed.
+      if (invite && !ctx.signupOpen) {
+        await InvitationsService.claim(token); // throws AppError(422) if not claimable
+      }
     }
     if (!invite) return undefined;
-    // Return the resolved invite + a single-use consume closure bound to its id.
-    // consume logic stays in this module; auth just relays the result.
-    return { invite, consume: () => InvitationsService.consume(invite.id) };
+    // Return the resolved (+claimed, local) invite plus finalize/release closures
+    // bound to its id. finalize/release logic stays in this module; auth just relays.
+    return {
+      invite,
+      finalize: (userId) => InvitationsService.finalize(invite.id, userId),
+      release: () => InvitationsService.release(invite.id),
+    };
   });
 
   // Mandatory: an unhandled 'error' emit would crash the process (mirrors billing.init.js).

--- a/modules/invitations/lib/constants.js
+++ b/modules/invitations/lib/constants.js
@@ -9,6 +9,15 @@
 export const DEFAULT_INVITE_EXPIRES_IN_DAYS = 14;
 
 /**
+ * E2 two-phase claim staleness window (minutes). A signup that CLAIMS an invite
+ * (stamps `consumingAt`) but crashes before finalize/release leaves the invite
+ * in-flight; after this many minutes with no `acceptedAt` it is swept (released)
+ * and becomes reusable. Generous vs. the synchronous signup path (sub-second) so
+ * a legitimately in-flight signup is never swept out from under itself.
+ */
+export const STALE_CLAIM_MINUTES = 15;
+
+/**
  * Canonical admin/public mount for the invitations module.
  */
 export const INVITATIONS_PATH_PREFIX = '/api/invitations';

--- a/modules/invitations/models/invitations.model.mongoose.js
+++ b/modules/invitations/models/invitations.model.mongoose.js
@@ -8,6 +8,17 @@ const Schema = mongoose.Schema;
 /**
  * Signup Invitation Schema — a single-use, expiring invite that re-opens signup
  * for a specific email when public signup is disabled or capped.
+ *
+ * Lifecycle (status):
+ *   - `pending`  — issued, not yet consumed (the only state that opens the gate).
+ *   - `accepted` — a signup finalized against it (acceptedAt/acceptedUserId set).
+ *   - `revoked`  — soft-deleted by an admin (revokedAt set); never re-opens the gate.
+ *
+ * Two-phase claim (E2): `consumingAt` is set when a signup atomically CLAIMS the
+ * invite (before the user is created) and cleared on release if that signup fails.
+ * A claimed-but-unfinalized invite (consumingAt set, acceptedAt null) must read as
+ * INVALID — otherwise a concurrent path or the email-resolved OAuth path could
+ * re-accept it and bypass single-use (see findValid/findValidByEmail).
  */
 const InvitationMongoose = new Schema(
   {
@@ -16,6 +27,18 @@ const InvitationMongoose = new Schema(
     invitedBy: { type: Schema.ObjectId, ref: 'User', default: null },
     expiresAt: { type: Date, required: true },
     usedAt: { type: Date, default: null },
+    // E2 two-phase claim/finalize — timestamp the in-flight claim (set before the
+    // user is created, cleared on release if the signup fails). A stale claim (no
+    // acceptedAt after N min) is swept lazily so a crash between claim and finalize
+    // never permanently burns the invite.
+    consumingAt: { type: Date, default: null },
+    // E2 finalize — who/when the signup completed (also read by the P8 referral phase).
+    acceptedAt: { type: Date, default: null },
+    acceptedUserId: { type: Schema.ObjectId, ref: 'User', default: null },
+    // E8 soft-delete revoke — preserve invitedBy/acceptedUserId for referral tracking
+    // instead of hard-deleting; a revoked invite never re-opens the gate.
+    revokedAt: { type: Date, default: null },
+    status: { type: String, enum: ['pending', 'accepted', 'revoked'], default: 'pending' },
   },
   { timestamps: true },
 );

--- a/modules/invitations/repositories/invitations.repository.js
+++ b/modules/invitations/repositories/invitations.repository.js
@@ -13,29 +13,85 @@ const Invitation = mongoose.model('Invitation');
 const create = (doc) => new Invitation(doc).save();
 
 /**
- * @desc Find an invitation by its token
+ * @desc Find an invitation by its token (raw read — no validity filter).
  * @param {String} token
  * @returns {Promise<Object|null>}
  */
 const findByToken = (token) => Invitation.findOne({ token }).exec();
 
 /**
- * @desc Find the most recent unused, unexpired invitation for an email
+ * @desc Find the most recent VALID (pending, unconsumed, unexpired, not in-flight)
+ * invitation for an email. Excludes rows with `consumingAt` set (a claimed-but-
+ * unfinalized invite must NOT read as valid — otherwise the OAuth email-resolved
+ * path could re-accept it and bypass single-use, E2). Only `status: 'pending'`
+ * invites can open the gate (E8 revoke/accept are excluded).
  * @param {String} email - already-lowercased email
  * @returns {Promise<Object|null>}
  */
 const findByEmail = (email) =>
-  Invitation.findOne({ email, usedAt: null, expiresAt: { $gt: new Date() } })
+  Invitation.findOne({ email, status: 'pending', usedAt: null, consumingAt: null, expiresAt: { $gt: new Date() } })
     .sort('-createdAt')
     .exec();
 
 /**
- * @desc Atomically mark an invitation used (single-use guard via usedAt: null filter)
- * @param {String} id
- * @returns {Promise<Object|null>} updated doc, or null if already consumed
+ * @desc E2 — atomically CLAIM a pending, unclaimed invite by token. Stamps
+ * `consumingAt` so a concurrent claim (or the email-resolved path) sees it as
+ * in-flight/invalid. Returns the claimed doc, or null when nothing matched
+ * (already claimed / used / revoked / accepted) — the replay/double-accept guard.
+ * @param {String} token
+ * @returns {Promise<Object|null>} the claimed invite, or null if not claimable
  */
-const consume = (id) =>
-  Invitation.findOneAndUpdate({ _id: id, usedAt: null }, { $set: { usedAt: new Date() } }, { returnDocument: 'after' }).exec();
+const claim = (token) =>
+  Invitation.findOneAndUpdate(
+    { token, status: 'pending', consumingAt: null },
+    { $set: { consumingAt: new Date() } },
+    { returnDocument: 'after' },
+  ).exec();
+
+/**
+ * @desc E2 — finalize an invite on full signup success: mark accepted + record the
+ * user, and burn single-use (usedAt). Guarded on `acceptedAt:null` so finalize is
+ * idempotent and cannot accept twice. Works for BOTH paths: the local path that
+ * atomically CLAIMED first (consumingAt set — the claim is its replay guard) AND
+ * the OAuth path that resolves by email without a claim (consumingAt null). It
+ * intentionally does NOT require consumingAt to be set, so the unclaimed OAuth
+ * accept still burns the invite. Also clears any consumingAt left by the claim.
+ * @param {String} id
+ * @param {String} userId - the just-created user's id
+ * @returns {Promise<Object|null>} the finalized doc, or null if already accepted/missing
+ */
+const finalize = (id, userId) =>
+  Invitation.findOneAndUpdate(
+    { _id: id, acceptedAt: null, status: { $ne: 'revoked' } },
+    { $set: { status: 'accepted', acceptedAt: new Date(), acceptedUserId: userId, usedAt: new Date() }, $unset: { consumingAt: 1 } },
+    { returnDocument: 'after' },
+  ).exec();
+
+/**
+ * @desc E2 — release a claimed-but-unfinalized invite so it can be retried
+ * (clears `consumingAt`). No-ops on an already-finalized invite (acceptedAt guard).
+ * @param {String} id
+ * @returns {Promise<Object|null>} the released doc, or null if not releasable
+ */
+const release = (id) =>
+  Invitation.findOneAndUpdate(
+    { _id: id, acceptedAt: null },
+    { $unset: { consumingAt: 1 } },
+    { returnDocument: 'after' },
+  ).exec();
+
+/**
+ * @desc E2 — lazily sweep stale claims: release any invite whose `consumingAt`
+ * is older than `cutoff` and was never finalized (acceptedAt null). Recovers
+ * invites orphaned by a crash between claim and finalize so they become reusable.
+ * @param {Date} cutoff - claims older than this are released
+ * @returns {Promise<Object>} bulk update result
+ */
+const releaseStaleClaims = (cutoff) =>
+  Invitation.updateMany(
+    { consumingAt: { $ne: null, $lt: cutoff }, acceptedAt: null },
+    { $unset: { consumingAt: 1 } },
+  ).exec();
 
 /**
  * @desc List all invitations (admin), newest first
@@ -51,10 +107,18 @@ const list = () => Invitation.find({}).select('-token').populate('invitedBy', 'e
 const get = (id) => (mongoose.Types.ObjectId.isValid(id) ? Invitation.findById(id).exec() : null);
 
 /**
- * @desc Remove an invitation by id
+ * @desc E8 — soft-delete (revoke) an invitation by id: set status:'revoked' +
+ * revokedAt instead of deleting, so invitedBy/acceptedUserId survive for the
+ * referral phase. A revoked invite never re-opens the gate (findValid filters
+ * on status:'pending').
  * @param {String} id
- * @returns {Promise<Object>} delete result
+ * @returns {Promise<Object|null>} the revoked doc, or null when no such id
  */
-const remove = (id) => Invitation.deleteOne({ _id: id }).exec();
+const revoke = (id) =>
+  Invitation.findOneAndUpdate(
+    { _id: id },
+    { $set: { status: 'revoked', revokedAt: new Date() } },
+    { returnDocument: 'after' },
+  ).exec();
 
-export default { create, findByToken, findByEmail, consume, list, get, remove };
+export default { create, findByToken, findByEmail, claim, finalize, release, releaseStaleClaims, list, get, revoke };

--- a/modules/invitations/repositories/invitations.repository.js
+++ b/modules/invitations/repositories/invitations.repository.js
@@ -37,13 +37,16 @@ const findByEmail = (email) =>
  * @desc E2 — atomically CLAIM a pending, unclaimed invite by token. Stamps
  * `consumingAt` so a concurrent claim (or the email-resolved path) sees it as
  * in-flight/invalid. Returns the claimed doc, or null when nothing matched
- * (already claimed / used / revoked / accepted) — the replay/double-accept guard.
+ * (already claimed / used / revoked / accepted / expired) — the replay/double-accept guard.
+ * Filter includes `usedAt:null` and `expiresAt:{$gt:now}` so the CAS step is
+ * self-contained: even if a concurrent path accepted or the invite expired between
+ * the caller's findValid and this claim, the CAS returns null and the caller throws.
  * @param {String} token
  * @returns {Promise<Object|null>} the claimed invite, or null if not claimable
  */
 const claim = (token) =>
   Invitation.findOneAndUpdate(
-    { token, status: 'pending', consumingAt: null },
+    { token, status: 'pending', consumingAt: null, usedAt: null, expiresAt: { $gt: new Date() } },
     { $set: { consumingAt: new Date() } },
     { returnDocument: 'after' },
   ).exec();

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -28,10 +28,10 @@ const create = async (email, invitedBy) => {
   // E9: an already-registered email must not be invited — they are already a user.
   const existing = await UserService.findByEmail(normalizedEmail);
   if (existing) {
-    throw new AppError('user already exists — add them to the organization directly', {
+    throw new AppError('user already exists — this email is already registered', {
       status: 422,
       code: 'VALIDATION_ERROR',
-      details: { message: 'A user with this email already exists. Add them to the organization directly.' },
+      details: { message: 'A user with this email already exists.' },
     });
   }
   const token = crypto.randomBytes(20).toString('hex');

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -4,25 +4,41 @@
 import crypto from 'crypto';
 
 import InvitationRepository from '../repositories/invitations.repository.js';
-import { DEFAULT_INVITE_EXPIRES_IN_DAYS } from '../lib/constants.js';
+import { DEFAULT_INVITE_EXPIRES_IN_DAYS, STALE_CLAIM_MINUTES } from '../lib/constants.js';
+import UserService from '../../users/services/users.service.js';
 import config from '../../../config/index.js';
 import mails from '../../../lib/helpers/mailer/index.js';
 import getBaseUrl from '../../../lib/helpers/getBaseUrl.js';
 import logger from '../../../lib/services/logger.js';
+import AppError from '../../../lib/helpers/AppError.js';
 
 /**
  * @desc Create an invitation for an email, generate a single-use token, persist,
  * and (best-effort) email the signup link. Token/expiry are server-controlled.
+ *
+ * E9: rejects (422) when a user with this email already exists — an existing user
+ * should be added to the org directly, not re-invited through the signup gate.
  * @param {String} email - invitee email (any case)
  * @param {Object} invitedBy - the admin user creating the invite
  * @returns {Promise<Object>} created invitation
+ * @throws {AppError} 422 when a user already exists for this email
  */
 const create = async (email, invitedBy) => {
+  const normalizedEmail = String(email).toLowerCase().trim();
+  // E9: an already-registered email must not be invited — they are already a user.
+  const existing = await UserService.findByEmail(normalizedEmail);
+  if (existing) {
+    throw new AppError('user already exists — add them to the organization directly', {
+      status: 422,
+      code: 'VALIDATION_ERROR',
+      details: { message: 'A user with this email already exists. Add them to the organization directly.' },
+    });
+  }
   const token = crypto.randomBytes(20).toString('hex');
   const days = config.sign?.inviteExpiresInDays || DEFAULT_INVITE_EXPIRES_IN_DAYS;
   const expiresAt = new Date(Date.now() + days * 24 * 3600000);
   const invitation = await InvitationRepository.create({
-    email: String(email).toLowerCase().trim(),
+    email: normalizedEmail,
     token,
     expiresAt,
     invitedBy: invitedBy?.id || invitedBy?._id || null,
@@ -45,31 +61,83 @@ const create = async (email, invitedBy) => {
 };
 
 /**
- * @desc Resolve a valid (unused, unexpired) invitation by token. When `email`
- * is supplied, the invite's pinned email must match (case-insensitive).
+ * @desc E2 — lazily release stale claims (consumingAt older than STALE_CLAIM_MINUTES,
+ * never finalized). Called at boot and before any validity read so a crash between
+ * claim and finalize cannot permanently burn an invite. Best-effort: a sweep error
+ * is logged, never thrown (it must not break a signup/read).
+ * @returns {Promise<void>}
+ */
+const sweepStaleClaims = async () => {
+  try {
+    const cutoff = new Date(Date.now() - STALE_CLAIM_MINUTES * 60 * 1000);
+    await InvitationRepository.releaseStaleClaims(cutoff);
+  } catch (err) {
+    logger.warn('invitations: stale-claim sweep failed', { message: err?.message });
+  }
+};
+
+/**
+ * @desc Predicate — is this invitation document currently valid (gate-opening)?
+ * A valid invite is `pending`, unconsumed, unexpired, and NOT mid-claim
+ * (consumingAt null unless already accepted). Shared by token + email resolution.
+ * @param {Object|null} invite
+ * @returns {Boolean}
+ */
+const isUsable = (invite) => {
+  if (!invite) return false;
+  if (invite.status && invite.status !== 'pending') return false; // E8: revoked/accepted never re-open
+  if (invite.usedAt) return false;
+  // E2: a claimed-but-unfinalized invite must NOT read as valid (else the OAuth
+  // email-resolved path or a concurrent token path could re-accept it → bypass).
+  if (invite.consumingAt && !invite.acceptedAt) return false;
+  if (invite.expiresAt && invite.expiresAt.getTime() <= Date.now()) return false;
+  return true;
+};
+
+/**
+ * @desc Resolve a valid (pending, unused, unexpired, not in-flight) invitation by
+ * token. When `email` is supplied, the invite's pinned email must match
+ * (case-insensitive). Lazily sweeps stale claims first so a crashed prior signup
+ * cannot leave the invite permanently unusable (E2 recovery).
  * @param {String} token
  * @param {String} [email]
  * @returns {Promise<Object|null>}
  */
 const findValid = async (token, email) => {
   if (!token) return null;
+  await sweepStaleClaims();
   const invite = await InvitationRepository.findByToken(token);
-  if (!invite || invite.usedAt) return null;
-  if (invite.expiresAt && invite.expiresAt.getTime() <= Date.now()) return null;
+  if (!isUsable(invite)) return null;
   if (email && invite.email && invite.email.toLowerCase() !== String(email).toLowerCase()) return null;
   return invite;
 };
 
 /**
+ * @desc E2 — resolve a valid pending invite by email (no token), applying the SAME
+ * validity rules as findValid (incl. the consumingAt exclusion). Used by the OAuth
+ * path, which has no token to claim. A claimed-but-unfinalized invite is invisible
+ * here too — the bypass guard. Lazily sweeps stale claims first.
+ * @param {String} email - the (provider-verified) email
+ * @returns {Promise<Object|null>} the valid pending invite for this email, or null
+ */
+const findValidByEmail = async (email) => {
+  if (!email) return null;
+  await sweepStaleClaims();
+  // The repository query already filters status:'pending' + consumingAt:null +
+  // usedAt:null + unexpired, but re-check via isUsable for a single source of truth.
+  const invite = await InvitationRepository.findByEmail(String(email).toLowerCase().trim());
+  return isUsable(invite) ? invite : null;
+};
+
+/**
  * @desc Signup eligibility resolver — reproduces the exact local-signup invite gate.
- * Resolves a valid invite for `token` (email-pinned) and enforces the controller's
- * "an invite bound to an email must not be honored when the signup supplies no email
- * to match" rule. Returns the resolved invite (so the caller can canonicalize the
- * account email + consume it) or null when no invite opens the gate.
+ * Resolves a valid invite for `token` (email-pinned) and enforces the "an invite
+ * bound to an email must not be honored when the signup supplies no email to match"
+ * rule (E5). Returns the resolved invite or null when no invite opens the gate.
  *
- * NOTE: this resolves; it does NOT throw. The eligibility hook composes the throw
- * decision (closed signup AND no invite ⇒ block) in auth — keeping the gate policy
- * (cap + sign.up) owned by auth, and only the invite lookup owned by this module.
+ * NOTE: this RESOLVES; it does NOT claim or throw. The eligibility hook composes the
+ * throw decision (closed signup AND no invite ⇒ block) in auth; the atomic CLAIM
+ * (the replay guard) happens in `claim()` once auth decides to proceed.
  * @param {Object} args
  * @param {String} [args.token] - invite token from the signup request (query/body)
  * @param {String} [args.email] - email supplied on the signup request body
@@ -80,31 +148,72 @@ const assertInvited = async ({ token, email } = {}) => {
   const invite = await findValid(token, email);
   // An invite is bound to its email; never honor it for a signup that supplies no
   // email to match. findValid stays lenient on a falsy email because the public
-  // verify endpoint reuses it, so enforce the pin here (mirrors auth.controller).
+  // verify endpoint reuses it, so enforce the pin here (E5 — owned by this module).
   if (invite && invite.email && !email) return null;
   return invite;
 };
 
 /**
  * @desc OAuth signup eligibility resolver — resolves a valid pending invite by the
- * provider-verified email (no token rides the OAuth redirect). Matches the email
- * against a pending invite (lowercased, trimmed); the OAuth gate decision (whether
- * to honor it) stays in auth.controller.
+ * provider-verified email (no token rides the OAuth redirect). Delegates to
+ * findValidByEmail so it inherits the consumingAt exclusion (E2 bypass guard); the
+ * OAuth gate decision (whether to honor it) stays in auth.controller.
  * @param {Object} args
  * @param {String} [args.email] - the provider-verified email
  * @returns {Promise<Object|null>} the pending invite for this email, or null
  */
-const assertInvitedByEmail = async ({ email } = {}) => {
-  if (!email) return null;
-  return InvitationRepository.findByEmail(String(email).toLowerCase().trim());
+const assertInvitedByEmail = async ({ email } = {}) => findValidByEmail(email);
+
+/**
+ * @desc E2 — atomically CLAIM the invite that opened the gate, BEFORE the user is
+ * created. Stamps `consumingAt` so a replay / concurrent accept / email-resolved
+ * path sees it as in-flight (invalid). Throws 422 when the invite is no longer
+ * claimable (already claimed/used/revoked) — the replay / double-accept guard.
+ * @param {String} token - the token whose invite was resolved by assertInvited
+ * @returns {Promise<Object>} the claimed invite document
+ * @throws {AppError} 422 when the invite cannot be claimed
+ */
+const claim = async (token) => {
+  const claimed = await InvitationRepository.claim(token);
+  if (!claimed) {
+    throw new AppError('invitation is no longer valid', {
+      status: 422,
+      code: 'VALIDATION_ERROR',
+      details: { message: 'This invitation has already been used or is no longer valid.' },
+    });
+  }
+  return claimed;
 };
 
 /**
- * @desc Atomically consume (mark used) an invitation. Best-effort single-use.
- * @param {String} id
- * @returns {Promise<Object|null>}
+ * @desc E2 — finalize a claimed invite on FULL signup success: mark accepted, record
+ * the user, burn single-use. Checks the repository return (a null means the invite
+ * was not in a finalizable state — surfaced as a warning, never silently ignored).
+ * @param {String} id - the claimed invite id
+ * @param {String} userId - the just-created user's id
+ * @returns {Promise<Object|null>} the finalized invite, or null
  */
-const consume = (id) => InvitationRepository.consume(id);
+const finalize = async (id, userId) => {
+  const result = await InvitationRepository.finalize(id, userId);
+  if (!result) {
+    logger.warn('invitations: finalize found no in-flight claim to accept', { id: String(id) });
+  }
+  return result;
+};
+
+/**
+ * @desc E2 — release a claimed-but-unfinalized invite (on any pre-response signup
+ * failure) so it can be retried. Checks the repository return.
+ * @param {String} id - the claimed invite id
+ * @returns {Promise<Object|null>} the released invite, or null
+ */
+const release = async (id) => {
+  const result = await InvitationRepository.release(id);
+  if (!result) {
+    logger.warn('invitations: release found no claim to clear', { id: String(id) });
+  }
+  return result;
+};
 
 /**
  * @desc List all invitations (admin)
@@ -120,10 +229,24 @@ const list = () => InvitationRepository.list();
 const get = (id) => InvitationRepository.get(id);
 
 /**
- * @desc Revoke (delete) an invitation by id
+ * @desc E8 — soft-delete (revoke) an invitation by id (status:'revoked' + revokedAt,
+ * NOT a hard delete), preserving invitedBy/acceptedUserId for the referral phase.
  * @param {String} id
- * @returns {Promise<Object>}
+ * @returns {Promise<Object|null>} the revoked invitation
  */
-const revoke = (id) => InvitationRepository.remove(id);
+const revoke = (id) => InvitationRepository.revoke(id);
 
-export default { create, findValid, assertInvited, assertInvitedByEmail, consume, list, get, revoke };
+export default {
+  create,
+  findValid,
+  findValidByEmail,
+  assertInvited,
+  assertInvitedByEmail,
+  claim,
+  finalize,
+  release,
+  sweepStaleClaims,
+  list,
+  get,
+  revoke,
+};

--- a/modules/invitations/tests/invitations.init.unit.tests.js
+++ b/modules/invitations/tests/invitations.init.unit.tests.js
@@ -6,9 +6,10 @@ import { jest } from '@jest/globals';
  *       (init() is intentionally not idempotent — each call appends a checker —
  *       so it must be called exactly once at startup, which this asserts),
  *   (b) it wires an 'error' listener on the invitation events emitter (crash guard),
- *   (c) the registered checker resolves the invite and RETURNS `{ invite, consume }`
- *       (the return-value seam — no stashing) for the local-signup and OAuth paths,
- *       honoring E13/E5/E7.
+ *   (c) the registered checker resolves the invite, atomically CLAIMS it (local),
+ *       and RETURNS `{ invite, finalize, release }` (the return-value seam — no
+ *       stashing) for the local-signup and OAuth paths, honoring E13/E5/E7/E2,
+ *   (d) init() runs the boot-time stale-claim sweep (E2 crash recovery).
  *
  * The auth eligibility registry is the REAL module (the integration surface under
  * test); the invitations service is mocked so no DB is touched.
@@ -17,7 +18,10 @@ import { jest } from '@jest/globals';
 const mockService = {
   assertInvited: jest.fn(),
   assertInvitedByEmail: jest.fn(),
-  consume: jest.fn(),
+  claim: jest.fn(),
+  finalize: jest.fn(),
+  release: jest.fn(),
+  sweepStaleClaims: jest.fn(),
 };
 const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() };
 
@@ -32,6 +36,8 @@ beforeEach(async () => {
   jest.clearAllMocks();
   Eligibility._reset();
   invitationEvents.removeAllListeners('error');
+  mockService.sweepStaleClaims.mockResolvedValue(undefined);
+  mockService.claim.mockResolvedValue({ id: 'claimed' });
   await init();
 });
 
@@ -41,11 +47,6 @@ afterEach(() => {
 
 describe('invitations.init', () => {
   test('(a) one init() registers exactly one checker', async () => {
-    // beforeEach ran _reset() then init() once. If init had registered the checker
-    // more than once, a SINGLE assertSignupEligible would run it >1× (assertInvited
-    // called >1×). One resolver call ⇒ exactly one checker registered per init().
-    // (init() is intentionally not idempotent — each call appends a checker — so the
-    // module is wired exactly once at boot via a single init(), which this asserts.)
     mockService.assertInvited.mockResolvedValue({ id: 'i1', email: 'a@b.co' });
     const req = { query: { inviteToken: 'tok' }, body: { email: 'a@b.co' } };
     await Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req });
@@ -55,43 +56,69 @@ describe('invitations.init', () => {
   test('(b) wires an error listener on the events emitter (no unhandled crash)', () => {
     expect(invitationEvents.listenerCount('error')).toBe(1);
     const err = new Error('boom');
-    // Without a listener Node would throw here; with the listener it logs instead.
     expect(() => invitationEvents.emit('error', err)).not.toThrow();
     expect(mockLogger.error).toHaveBeenCalledWith('[invitationEvents] uncaught error', { err });
   });
 
-  test('(c) local signup: reads ?inviteToken= (E13) and returns { invite, consume }', async () => {
+  test('(d) init() runs the boot-time stale-claim sweep (E2 crash recovery)', () => {
+    // beforeEach called init() once; the boot sweep must have fired exactly once.
+    expect(mockService.sweepStaleClaims).toHaveBeenCalledTimes(1);
+  });
+
+  test('(c) closed signup: reads ?inviteToken= (E13), CLAIMS (E2), returns { invite, finalize, release }', async () => {
     const invite = { id: 'i7', email: 'a@b.co' };
     mockService.assertInvited.mockResolvedValue(invite);
     const req = { query: { inviteToken: 'tok' }, body: { email: 'a@b.co' } };
-    const result = await Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req });
+    const result = await Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req, signupOpen: false });
     expect(mockService.assertInvited).toHaveBeenCalledWith({ token: 'tok', email: 'a@b.co' });
+    // E2: the resolved invite was atomically claimed by token before returning.
+    expect(mockService.claim).toHaveBeenCalledWith('tok');
     expect(result.invite).toBe(invite);
-    // returned consume closure burns exactly this invite id
-    await result.consume();
-    expect(mockService.consume).toHaveBeenCalledWith('i7');
+    // returned finalize/release closures bind exactly this invite id
+    await result.finalize('u9');
+    expect(mockService.finalize).toHaveBeenCalledWith('i7', 'u9');
+    await result.release();
+    expect(mockService.release).toHaveBeenCalledWith('i7');
   });
 
-  test('(c) checker honors a body token when called directly (HTTP signup strips it — query is the real source)', async () => {
-    // On the real HTTP signup path the model middleware strips unknown body keys
-    // (incl. inviteToken) BEFORE this checker runs, so query is the effective source.
-    // This asserts only the checker's isolated contract: when invoked directly (non-HTTP /
-    // future-whitelisted callers) with a body token and no query token, it reads the body.
+  test('(c) OPEN signup: a presented token is RESOLVED but NOT claimed (preserves P2 gating, E2)', async () => {
+    const invite = { id: 'i8', email: 'a@b.co' };
+    mockService.assertInvited.mockResolvedValue(invite);
+    const req = { query: { inviteToken: 'tok' }, body: { email: 'a@b.co' } };
+    const result = await Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req, signupOpen: true });
+    expect(mockService.assertInvited).toHaveBeenCalledWith({ token: 'tok', email: 'a@b.co' });
+    // Open signup: the invite is presented but not required — it must NOT be claimed
+    // (else it would be locked mid-claim, since auth never finalizes on open signup).
+    expect(mockService.claim).not.toHaveBeenCalled();
+    expect(result.invite).toBe(invite);
+  });
+
+  test('(c) local signup: a lost claim race (E2 replay) propagates the 422 throw, blocks signup', async () => {
+    mockService.assertInvited.mockResolvedValue({ id: 'i7', email: 'a@b.co' });
+    mockService.claim.mockRejectedValue(Object.assign(new Error('gone'), { status: 422, code: 'VALIDATION_ERROR' }));
+    const req = { query: { inviteToken: 'tok' }, body: { email: 'a@b.co' } };
+    await expect(Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req })).rejects.toMatchObject({ status: 422 });
+  });
+
+  test('(c) local signup: no resolved invite ⇒ no claim, no result relayed', async () => {
     mockService.assertInvited.mockResolvedValue(null);
     const req = { query: {}, body: { email: 'a@b.co', inviteToken: 'btok' } };
     const result = await Eligibility.assertSignupEligible({ email: 'a@b.co', body: req.body, req });
     expect(mockService.assertInvited).toHaveBeenCalledWith({ token: 'btok', email: 'a@b.co' });
-    expect(result).toBeNull(); // no eligible invite ⇒ no result relayed to auth
+    expect(mockService.claim).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
-  test('(c) OAuth: resolves by email only when provider verified it (E7), returns { invite, consume }', async () => {
+  test('(c) OAuth: resolves by email only when provider verified it (E7), NO claim, returns { invite, finalize, release }', async () => {
     const invite = { id: 'o1', email: 'v@b.co' };
     mockService.assertInvitedByEmail.mockResolvedValue(invite);
     const result = await Eligibility.assertSignupEligible({ email: 'v@b.co', oauth: { emailVerifiedByProvider: true } });
     expect(mockService.assertInvitedByEmail).toHaveBeenCalledWith({ email: 'v@b.co' });
+    // OAuth has no token to claim — claim must NOT be invoked on this path.
+    expect(mockService.claim).not.toHaveBeenCalled();
     expect(result.invite).toBe(invite);
-    await result.consume();
-    expect(mockService.consume).toHaveBeenCalledWith('o1');
+    await result.finalize('u2');
+    expect(mockService.finalize).toHaveBeenCalledWith('o1', 'u2');
   });
 
   test('(c) OAuth: does NOT resolve an invite when the provider email is unverified (E7)', async () => {

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -395,4 +395,193 @@ describe('Signup invitations:', () => {
       expect(recheck.body.data.valid).toBe(false);
     });
   });
+
+  describe('E2 two-phase claim/finalize hardening', () => {
+    let InvitationService;
+    let InvitationRepository;
+    let originalUp; let originalCap;
+
+    beforeAll(async () => {
+      InvitationService = (await import(path.resolve('./modules/invitations/services/invitations.service.js'))).default;
+      InvitationRepository = (await import(path.resolve('./modules/invitations/repositories/invitations.repository.js'))).default;
+    });
+
+    beforeEach(() => { originalUp = config.sign.up; originalCap = config.sign.cap; });
+    afterEach(async () => {
+      config.sign.up = originalUp; config.sign.cap = originalCap;
+      for (const email of ['e2-replay@example.com', 'e2-claimed@example.com', 'e2-stale@example.com']) {
+        try {
+          const existing = await UserService.getBrut({ email });
+          if (existing) await UserService.remove(existing);
+        } catch (_) { /* cleanup */ }
+      }
+    });
+
+    test('replay: a 2nd signup with the same token is rejected (the invite was finalized) ', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'e2-replay@example.com' });
+      const { token } = created.body.data;
+      config.sign.up = false; config.sign.cap = null;
+
+      const first = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email: 'e2-replay@example.com', password: 'Sup3rStr0ng!' });
+      expect(first.status).toBe(200);
+
+      // Replay the SAME token (even after deleting the user) — the invite is now
+      // accepted/used, so the claim finds nothing pending and signup is blocked.
+      const replayUser = await UserService.getBrut({ email: 'e2-replay@example.com' });
+      if (replayUser) await UserService.remove(replayUser);
+      const second = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email: 'e2-replay@example.com', password: 'Sup3rStr0ng!' });
+      expect(second.status).not.toBe(200);
+    });
+
+    test('a claimed-but-unfinalized invite is INVISIBLE to BOTH findValid and findValidByEmail (bypass guard)', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const email = 'e2-claimed@example.com';
+      const created = await adminAgent.post('/api/invitations').send({ email });
+      const { token } = created.body.data;
+
+      // Pre-state: both resolvers see it as valid.
+      expect(await InvitationService.findValid(token, email)).not.toBeNull();
+      expect(await InvitationService.findValidByEmail(email)).not.toBeNull();
+
+      // Atomically CLAIM it (simulating an in-flight signup that has not finalized).
+      const claimed = await InvitationRepository.claim(token);
+      expect(claimed).not.toBeNull();
+
+      // Now it must be invisible to BOTH paths — otherwise the OAuth email-resolved
+      // path (or a concurrent token signup) could re-accept it → single-use bypass.
+      expect(await InvitationService.findValid(token, email)).toBeNull();
+      expect(await InvitationService.findValidByEmail(email)).toBeNull();
+      // The public verify endpoint (which uses findValid) also reports invalid.
+      const verify = await request(app).get(`/api/invitations/verify/${token}`);
+      expect(verify.body.data.valid).toBe(false);
+    });
+
+    test('OPEN signup + presented token: the token is NOT claimed/burned, invite stays valid (P2 gating preserved)', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const email = 'e2-opensignup@example.com';
+      const created = await adminAgent.post('/api/invitations').send({ email });
+      const { token } = created.body.data;
+
+      // Public signup OPEN: a token may be presented but is not required.
+      config.sign.up = true; config.sign.cap = null;
+      const res = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email, password: 'Sup3rStr0ng!' });
+      expect(res.status).toBe(200);
+
+      // The invite must remain VALID (presented, not consumed) — not stuck mid-claim.
+      const verify = await request(app).get(`/api/invitations/verify/${token}`);
+      expect(verify.body.data.valid).toBe(true);
+
+      try {
+        const u = await UserService.getBrut({ email });
+        if (u) await UserService.remove(u);
+      } catch (_) { /* cleanup */ }
+    });
+
+    test('crash recovery: a stale claim (older than the window) is swept and the invite becomes reusable', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const email = 'e2-stale@example.com';
+      const created = await adminAgent.post('/api/invitations').send({ email });
+      const { token } = created.body.data;
+
+      // Claim, then SIMULATE A CRASH between claim and finalize by back-dating
+      // consumingAt past the staleness window (no acceptedAt was ever set).
+      const claimed = await InvitationRepository.claim(token);
+      const Invitation = (await import('mongoose')).default.model('Invitation');
+      await Invitation.updateOne(
+        { _id: claimed._id },
+        { $set: { consumingAt: new Date(Date.now() - 60 * 60 * 1000) } }, // 1h ago » 15min window
+      ).exec();
+
+      // While still stale-claimed (before any sweep read), it is invalid.
+      // findValid itself sweeps lazily, so call the sweep explicitly first to assert
+      // the recovery mechanism, THEN confirm the invite reads valid again.
+      await InvitationService.sweepStaleClaims();
+      const swept = await Invitation.findById(claimed._id).exec();
+      expect(swept.consumingAt == null).toBe(true); // claim released
+      expect(await InvitationService.findValid(token, email)).not.toBeNull(); // reusable again
+    });
+  });
+
+  describe('E6 no auto-verify on invite (mailer off)', () => {
+    let originalUp; let originalCap;
+    beforeEach(() => { originalUp = config.sign.up; originalCap = config.sign.cap; });
+    afterEach(async () => {
+      config.sign.up = originalUp; config.sign.cap = originalCap;
+      try {
+        const existing = await UserService.getBrut({ email: 'e6-invite@example.com' });
+        if (existing) await UserService.remove(existing);
+      } catch (_) { /* cleanup */ }
+    });
+
+    test('mailer off + invite ⇒ account created but NOT emailVerified (token proves inviter, not signer)', async () => {
+      // The test env has no mailer configured (isMailerConfigured() is false), so the
+      // mailer-off branch runs. An OPEN public signup auto-verifies in that branch,
+      // but an INVITE-gated account must NOT be auto-verified (E6).
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'e6-invite@example.com' });
+      const { token } = created.body.data;
+      config.sign.up = false; config.sign.cap = null;
+
+      const res = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email: 'e6-invite@example.com', password: 'Sup3rStr0ng!' });
+      expect(res.status).toBe(200);
+
+      const brut = await UserService.getBrut({ email: 'e6-invite@example.com' });
+      expect(brut).not.toBeNull();
+      expect(!!brut.emailVerified).toBe(false); // invited account follows normal verification
+    });
+  });
+
+  describe('E9 already-registered guard', () => {
+    afterEach(async () => {
+      try {
+        const existing = await UserService.getBrut({ email: 'e9-existing@example.com' });
+        if (existing) await UserService.remove(existing);
+      } catch (_) { /* cleanup */ }
+    });
+
+    test('inviting an already-registered email is rejected (422)', async () => {
+      // Create the user first (open signup), then try to invite the same email.
+      const savedUp = config.sign.up; config.sign.up = true;
+      await request(app).post('/api/auth/signup').send({ email: 'e9-existing@example.com', password: 'Sup3rStr0ng!' });
+      config.sign.up = savedUp;
+
+      const adminAgent = await createAdminAndSignin();
+      const res = await adminAgent.post('/api/invitations').send({ email: 'e9-existing@example.com' });
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('E4 cap unify — blank cap means UNCAPPED at the signup gate', () => {
+    let originalUp; let originalCap;
+    beforeEach(() => { originalUp = config.sign.up; originalCap = config.sign.cap; });
+    afterEach(async () => {
+      config.sign.up = originalUp; config.sign.cap = originalCap;
+      try {
+        const existing = await UserService.getBrut({ email: 'e4-blankcap@example.com' });
+        if (existing) await UserService.remove(existing);
+      } catch (_) { /* cleanup */ }
+    });
+
+    test("cap:'' + open signup ⇒ signup SUCCEEDS (blank is uncapped, not everyone-blocked)", async () => {
+      // The pre-fix inline `Number('')→0→count>=0` hard-rejected EVERY signup while
+      // getConfig advertised the deployment as open. The unify routes the gate through
+      // computeSignupCapacity, which treats '' as uncapped. This asserts the gate no
+      // longer rejects under a blank cap.
+      config.sign.up = true;
+      config.sign.cap = '';
+      const res = await request(app)
+        .post('/api/auth/signup')
+        .send({ email: 'e4-blankcap@example.com', password: 'Sup3rStr0ng!' });
+      expect(res.status).toBe(200);
+    });
+  });
 });

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -4,7 +4,7 @@
 import request from 'supertest';
 import path from 'path';
 
-import { beforeAll, afterAll, beforeEach, afterEach, describe, test, expect } from '@jest/globals';
+import { beforeAll, afterAll, beforeEach, afterEach, describe, test, expect, jest } from '@jest/globals';
 import { bootstrap } from '../../../lib/app.js';
 import config from '../../../config/index.js';
 
@@ -409,7 +409,8 @@ describe('Signup invitations:', () => {
     beforeEach(() => { originalUp = config.sign.up; originalCap = config.sign.cap; });
     afterEach(async () => {
       config.sign.up = originalUp; config.sign.cap = originalCap;
-      for (const email of ['e2-replay@example.com', 'e2-claimed@example.com', 'e2-stale@example.com']) {
+      jest.restoreAllMocks();
+      for (const email of ['e2-replay@example.com', 'e2-claimed@example.com', 'e2-stale@example.com', 'e2-createthrow@example.com', 'e2-concurrent@example.com']) {
         try {
           const existing = await UserService.getBrut({ email });
           if (existing) await UserService.remove(existing);
@@ -436,6 +437,68 @@ describe('Signup invitations:', () => {
         .post(`/api/auth/signup?inviteToken=${token}`)
         .send({ email: 'e2-replay@example.com', password: 'Sup3rStr0ng!' });
       expect(second.status).not.toBe(200);
+    });
+
+    test('concurrent double-claim: two parallel claim() on the same token → EXACTLY ONE wins (the atomic CAS)', async () => {
+      // The replay test above is sequential (signup #1 finalizes the invite, then the
+      // 2nd attempt finds nothing pending). This is the genuine atomicity proof: fire
+      // two claim() at the SAME pending invite concurrently against real Mongo. The
+      // findOneAndUpdate CAS ({token,status:'pending',consumingAt:null}) must let exactly
+      // one stamp consumingAt — the loser gets null (which the service surfaces as 422).
+      const adminAgent = await createAdminAndSignin();
+      const email = 'e2-concurrent@example.com';
+      const created = await adminAgent.post('/api/invitations').send({ email });
+      const { token } = created.body.data;
+
+      const [a, b] = await Promise.all([
+        InvitationRepository.claim(token),
+        InvitationRepository.claim(token),
+      ]);
+
+      // Exactly one non-null winner; the other is null (the double-claim guard).
+      const winners = [a, b].filter((r) => r != null);
+      expect(winners.length).toBe(1);
+      expect([a, b].filter((r) => r == null).length).toBe(1);
+      // The winner is the in-flight claim — consumingAt stamped, not yet finalized.
+      expect(winners[0].consumingAt).toBeTruthy();
+      expect(winners[0].acceptedAt == null).toBe(true);
+    });
+
+    test('create-throw release: UserService.create throwing releases the claim so the invite is immediately reusable (not locked 15min)', async () => {
+      // Fix-1 regression: the invite is atomically CLAIMED before UserService.create
+      // runs, so a throw FROM create (e.g. an E11000 case-variant race, or any
+      // transient error) must release the claim too — otherwise it stays consumingAt-
+      // stamped and unusable until the 15-min stale sweep. Force create to reject once
+      // and assert the claim was cleared (immediately reusable), NOT left in-flight.
+      const adminAgent = await createAdminAndSignin();
+      const email = 'e2-createthrow@example.com';
+      const created = await adminAgent.post('/api/invitations').send({ email });
+      const { token } = created.body.data;
+      config.sign.up = false; config.sign.cap = null;
+
+      // Make the create after the claim blow up exactly once.
+      const createSpy = jest.spyOn(UserService, 'create').mockRejectedValueOnce(new Error('DB error on create'));
+
+      const res = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email, password: 'Sup3rStr0ng!' });
+      // The signup failed (create threw → 422).
+      expect(res.status).not.toBe(200);
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // The claim must have been RELEASED: consumingAt cleared (not stuck for 15min),
+      // never finalized (no acceptedAt), and the invite reads valid + reusable again.
+      const raw = await InvitationRepository.findByToken(token);
+      expect(raw.consumingAt == null).toBe(true); // released, not locked
+      expect(raw.acceptedAt == null).toBe(true); // never finalized
+      expect(raw.status).toBe('pending');
+      expect(await InvitationService.findValid(token, email)).not.toBeNull(); // immediately reusable
+
+      // And a real retry (create now works) succeeds end-to-end on the same token.
+      const retry = await request(app)
+        .post(`/api/auth/signup?inviteToken=${token}`)
+        .send({ email, password: 'Sup3rStr0ng!' });
+      expect(retry.status).toBe(200);
     });
 
     test('a claimed-but-unfinalized invite is INVISIBLE to BOTH findValid and findValidByEmail (bypass guard)', async () => {

--- a/modules/invitations/tests/invitations.repository.unit.tests.js
+++ b/modules/invitations/tests/invitations.repository.unit.tests.js
@@ -69,11 +69,17 @@ describe('InvitationRepository', () => {
     expect(chain.sort).toHaveBeenCalledWith('-createdAt');
   });
 
-  test('claim atomically stamps consumingAt with a token+pending+unclaimed guard (E2)', async () => {
+  test('claim atomically stamps consumingAt with a token+pending+unclaimed+unused+unexpired guard (E2)', async () => {
     exec.mockResolvedValue({ id: 'i1', consumingAt: new Date() });
     await InvitationRepository.claim('tok');
     const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
-    expect(filter).toEqual({ token: 'tok', status: 'pending', consumingAt: null });
+    // Self-contained CAS: the filter rejects already-used, expired, or in-flight invites
+    // so a race between findValid and claim cannot bypass expiry or single-use (E2).
+    expect(filter.token).toBe('tok');
+    expect(filter.status).toBe('pending');
+    expect(filter.consumingAt).toBeNull();
+    expect(filter.usedAt).toBeNull();
+    expect(filter.expiresAt).toHaveProperty('$gt'); // unexpired guard
     expect(update).toHaveProperty('$set.consumingAt');
   });
 

--- a/modules/invitations/tests/invitations.repository.unit.tests.js
+++ b/modules/invitations/tests/invitations.repository.unit.tests.js
@@ -21,6 +21,7 @@ InvitationModel.findOneAndUpdate = jest.fn(() => chain);
 InvitationModel.find = jest.fn(() => chain);
 InvitationModel.findById = jest.fn(() => chain);
 InvitationModel.deleteOne = jest.fn(() => chain);
+InvitationModel.updateMany = jest.fn(() => chain);
 
 const isValid = jest.fn(() => true);
 
@@ -56,22 +57,58 @@ describe('InvitationRepository', () => {
     expect(result).toEqual({ id: 'i1', token: 't' });
   });
 
-  test('findByEmail queries unused + unexpired, newest first', async () => {
+  test('findByEmail queries pending + unconsumed + not-in-flight + unexpired, newest first (E2/E8)', async () => {
     exec.mockResolvedValue(null);
     await InvitationRepository.findByEmail('a@b.co');
     const filter = InvitationModel.findOne.mock.calls.at(-1)[0];
     expect(filter.email).toBe('a@b.co');
+    expect(filter.status).toBe('pending'); // E8: only pending opens the gate
     expect(filter.usedAt).toBeNull();
+    expect(filter.consumingAt).toBeNull(); // E2: exclude claimed-but-unfinalized
     expect(filter.expiresAt).toHaveProperty('$gt');
     expect(chain.sort).toHaveBeenCalledWith('-createdAt');
   });
 
-  test('consume atomically marks used with a usedAt:null guard', async () => {
-    exec.mockResolvedValue({ id: 'i1', usedAt: new Date() });
-    await InvitationRepository.consume('i1');
+  test('claim atomically stamps consumingAt with a token+pending+unclaimed guard (E2)', async () => {
+    exec.mockResolvedValue({ id: 'i1', consumingAt: new Date() });
+    await InvitationRepository.claim('tok');
     const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
-    expect(filter).toEqual({ _id: 'i1', usedAt: null });
-    expect(update).toHaveProperty('$set.usedAt');
+    expect(filter).toEqual({ token: 'tok', status: 'pending', consumingAt: null });
+    expect(update).toHaveProperty('$set.consumingAt');
+  });
+
+  test('finalize marks accepted+used guarded on not-yet-accepted, works claimed OR unclaimed (E2)', async () => {
+    exec.mockResolvedValue({ id: 'i1', status: 'accepted' });
+    await InvitationRepository.finalize('i1', 'u1');
+    const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
+    expect(filter._id).toBe('i1');
+    expect(filter.acceptedAt).toBeNull(); // idempotent single-accept guard
+    expect(filter.status).toEqual({ $ne: 'revoked' });
+    // Intentionally does NOT require consumingAt — the OAuth path never claims.
+    expect(filter.consumingAt).toBeUndefined();
+    expect(update.$set.status).toBe('accepted');
+    expect(update.$set.acceptedUserId).toBe('u1');
+    expect(update.$set).toHaveProperty('acceptedAt');
+    expect(update.$set).toHaveProperty('usedAt');
+    expect(update.$unset).toEqual({ consumingAt: 1 }); // clears any claim stamp
+  });
+
+  test('release clears consumingAt guarded on not-yet-accepted (E2)', async () => {
+    exec.mockResolvedValue({ id: 'i1' });
+    await InvitationRepository.release('i1');
+    const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
+    expect(filter).toEqual({ _id: 'i1', acceptedAt: null });
+    expect(update).toEqual({ $unset: { consumingAt: 1 } });
+  });
+
+  test('releaseStaleClaims clears consumingAt for stale, never-finalized claims (E2 sweep)', async () => {
+    exec.mockResolvedValue({ modifiedCount: 3 });
+    const cutoff = new Date(Date.now() - 999000);
+    await InvitationRepository.releaseStaleClaims(cutoff);
+    const [filter, update] = InvitationModel.updateMany.mock.calls.at(-1);
+    expect(filter.consumingAt).toEqual({ $ne: null, $lt: cutoff });
+    expect(filter.acceptedAt).toBeNull();
+    expect(update).toEqual({ $unset: { consumingAt: 1 } });
   });
 
   test('list omits the token and populates invitedBy, newest first', async () => {
@@ -98,10 +135,14 @@ describe('InvitationRepository', () => {
     expect(result).toEqual({ id: 'i1' });
   });
 
-  test('remove deletes by id', async () => {
-    exec.mockResolvedValue({ deletedCount: 1 });
-    const result = await InvitationRepository.remove('i1');
-    expect(InvitationModel.deleteOne).toHaveBeenCalledWith({ _id: 'i1' });
-    expect(result).toEqual({ deletedCount: 1 });
+  test('revoke soft-deletes by id (status:revoked + revokedAt), not deleteOne (E8)', async () => {
+    exec.mockResolvedValue({ id: 'i1', status: 'revoked' });
+    const result = await InvitationRepository.revoke('i1');
+    const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
+    expect(filter).toEqual({ _id: 'i1' });
+    expect(update.$set.status).toBe('revoked');
+    expect(update.$set).toHaveProperty('revokedAt');
+    expect(InvitationModel.deleteOne).not.toHaveBeenCalled();
+    expect(result).toEqual({ id: 'i1', status: 'revoked' });
   });
 });

--- a/modules/invitations/tests/invitations.service.unit.tests.js
+++ b/modules/invitations/tests/invitations.service.unit.tests.js
@@ -5,12 +5,19 @@ jest.unstable_mockModule('../repositories/invitations.repository.js', () => ({
     create: jest.fn(),
     findByToken: jest.fn(),
     findByEmail: jest.fn(),
-    consume: jest.fn(),
+    claim: jest.fn(),
+    finalize: jest.fn(),
+    release: jest.fn(),
+    releaseStaleClaims: jest.fn(),
     list: jest.fn(),
     remove: jest.fn(),
+    revoke: jest.fn(),
     get: jest.fn(),
   },
 }));
+
+const mockUserService = { findByEmail: jest.fn() };
+jest.unstable_mockModule('../../users/services/users.service.js', () => ({ default: mockUserService }));
 
 const mockMailer = { isConfigured: jest.fn(() => false), sendMail: jest.fn() };
 jest.unstable_mockModule('../../../lib/helpers/mailer/index.js', () => ({
@@ -35,6 +42,12 @@ jest.unstable_mockModule('../../../lib/services/logger.js', () => ({
 const InvitationRepository = (await import('../repositories/invitations.repository.js')).default;
 const InvitationService = (await import('../services/invitations.service.js')).default;
 
+beforeEach(() => {
+  // Default: no stale claims to sweep, no pre-existing user (E9).
+  InvitationRepository.releaseStaleClaims.mockResolvedValue({ modifiedCount: 0 });
+  mockUserService.findByEmail.mockResolvedValue(null);
+});
+
 describe('InvitationService.findValid', () => {
   const future = new Date(Date.now() + 3600000);
   test('returns null when token missing', async () => {
@@ -45,42 +58,78 @@ describe('InvitationService.findValid', () => {
     expect(await InvitationService.findValid('tok')).toBeNull();
   });
   test('returns null when used', async () => {
-    InvitationRepository.findByToken.mockResolvedValue({ usedAt: new Date(), expiresAt: future, email: 'a@b.co' });
+    InvitationRepository.findByToken.mockResolvedValue({ status: 'pending', usedAt: new Date(), expiresAt: future, email: 'a@b.co' });
     expect(await InvitationService.findValid('tok')).toBeNull();
   });
   test('returns null when expired', async () => {
-    InvitationRepository.findByToken.mockResolvedValue({ usedAt: null, expiresAt: new Date(Date.now() - 1000), email: 'a@b.co' });
+    InvitationRepository.findByToken.mockResolvedValue({ status: 'pending', usedAt: null, expiresAt: new Date(Date.now() - 1000), email: 'a@b.co' });
     expect(await InvitationService.findValid('tok')).toBeNull();
   });
   test('returns null when email pin mismatches', async () => {
-    InvitationRepository.findByToken.mockResolvedValue({ usedAt: null, expiresAt: future, email: 'a@b.co' });
+    InvitationRepository.findByToken.mockResolvedValue({ status: 'pending', usedAt: null, expiresAt: future, email: 'a@b.co' });
     expect(await InvitationService.findValid('tok', 'other@b.co')).toBeNull();
   });
   test('returns invite when valid (no email arg)', async () => {
-    const inv = { usedAt: null, expiresAt: future, email: 'a@b.co' };
+    const inv = { status: 'pending', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' };
     InvitationRepository.findByToken.mockResolvedValue(inv);
     expect(await InvitationService.findValid('tok')).toBe(inv);
   });
   test('returns invite when email matches case-insensitively', async () => {
-    const inv = { usedAt: null, expiresAt: future, email: 'a@b.co' };
+    const inv = { status: 'pending', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' };
     InvitationRepository.findByToken.mockResolvedValue(inv);
     expect(await InvitationService.findValid('tok', 'A@B.CO')).toBe(inv);
   });
+  test('E2: a claimed-but-unfinalized invite (consumingAt set, no acceptedAt) is INVISIBLE', async () => {
+    InvitationRepository.findByToken.mockResolvedValue({ status: 'pending', usedAt: null, consumingAt: new Date(), acceptedAt: null, expiresAt: future, email: 'a@b.co' });
+    expect(await InvitationService.findValid('tok', 'a@b.co')).toBeNull();
+  });
+  test('E8: a revoked invite is INVISIBLE even if otherwise valid', async () => {
+    InvitationRepository.findByToken.mockResolvedValue({ status: 'revoked', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' });
+    expect(await InvitationService.findValid('tok', 'a@b.co')).toBeNull();
+  });
+  test('lazily sweeps stale claims before reading', async () => {
+    InvitationRepository.findByToken.mockResolvedValue(null);
+    await InvitationService.findValid('tok');
+    expect(InvitationRepository.releaseStaleClaims).toHaveBeenCalledTimes(1);
+  });
 });
 
-describe('InvitationService.assertInvited (signup eligibility resolver)', () => {
+describe('InvitationService.findValidByEmail (E2 bypass guard)', () => {
+  const future = new Date(Date.now() + 3600000);
+  test('returns null when email is falsy', async () => {
+    expect(await InvitationService.findValidByEmail('')).toBeNull();
+  });
+  test('resolves a valid pending invite by lowercased email', async () => {
+    const inv = { status: 'pending', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' };
+    InvitationRepository.findByEmail.mockResolvedValue(inv);
+    expect(await InvitationService.findValidByEmail('A@B.CO')).toBe(inv);
+    expect(InvitationRepository.findByEmail).toHaveBeenCalledWith('a@b.co');
+  });
+  test('E2: a claimed-but-unfinalized invite is INVISIBLE to findValidByEmail (OAuth bypass blocked)', async () => {
+    // Even if the repo handed one back, isUsable re-filters it. Belt + suspenders.
+    InvitationRepository.findByEmail.mockResolvedValue({ status: 'pending', usedAt: null, consumingAt: new Date(), acceptedAt: null, expiresAt: future, email: 'a@b.co' });
+    expect(await InvitationService.findValidByEmail('a@b.co')).toBeNull();
+  });
+  test('lazily sweeps stale claims before reading', async () => {
+    InvitationRepository.findByEmail.mockResolvedValue(null);
+    await InvitationService.findValidByEmail('a@b.co');
+    expect(InvitationRepository.releaseStaleClaims).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InvitationService.assertInvited (E5 pin)', () => {
   const future = new Date(Date.now() + 3600000);
   test('returns null when no token supplied', async () => {
     expect(await InvitationService.assertInvited({ token: '', email: 'a@b.co' })).toBeNull();
     expect(await InvitationService.assertInvited({})).toBeNull();
   });
   test('returns the resolved invite when token + matching email', async () => {
-    const inv = { id: 'i1', usedAt: null, expiresAt: future, email: 'a@b.co' };
+    const inv = { id: 'i1', status: 'pending', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' };
     InvitationRepository.findByToken.mockResolvedValue(inv);
     expect(await InvitationService.assertInvited({ token: 'tok', email: 'A@B.CO' })).toBe(inv);
   });
   test('E5: rejects (null) a pinned invite when the signup supplies no email', async () => {
-    const inv = { id: 'i2', usedAt: null, expiresAt: future, email: 'a@b.co' };
+    const inv = { id: 'i2', status: 'pending', usedAt: null, consumingAt: null, expiresAt: future, email: 'a@b.co' };
     InvitationRepository.findByToken.mockResolvedValue(inv);
     expect(await InvitationService.assertInvited({ token: 'tok' })).toBeNull();
     expect(await InvitationService.assertInvited({ token: 'tok', email: '' })).toBeNull();
@@ -97,11 +146,58 @@ describe('InvitationService.assertInvitedByEmail (OAuth eligibility resolver)', 
     expect(await InvitationService.assertInvitedByEmail({})).toBeNull();
   });
   test('resolves a pending invite by email (lowercased, trimmed) when email present', async () => {
-    const inv = { id: 'i3', email: 'a@b.co', usedAt: null, expiresAt: new Date(Date.now() + 3600000) };
+    const inv = { id: 'i3', status: 'pending', email: 'a@b.co', usedAt: null, consumingAt: null, expiresAt: new Date(Date.now() + 3600000) };
     InvitationRepository.findByEmail.mockResolvedValue(inv);
     const result = await InvitationService.assertInvitedByEmail({ email: 'A@B.CO' });
     expect(InvitationRepository.findByEmail).toHaveBeenCalledWith('a@b.co');
     expect(result).toBe(inv);
+  });
+});
+
+describe('InvitationService.claim (E2 replay guard)', () => {
+  test('returns the claimed invite when the repo claim succeeds', async () => {
+    const claimed = { id: 'i1', consumingAt: new Date() };
+    InvitationRepository.claim.mockResolvedValue(claimed);
+    expect(await InvitationService.claim('tok')).toBe(claimed);
+    expect(InvitationRepository.claim).toHaveBeenCalledWith('tok');
+  });
+  test('throws AppError(422) when the invite is no longer claimable (replay / double-accept)', async () => {
+    InvitationRepository.claim.mockResolvedValue(null);
+    await expect(InvitationService.claim('tok')).rejects.toMatchObject({ status: 422, code: 'VALIDATION_ERROR' });
+  });
+});
+
+describe('InvitationService.finalize / release (E2)', () => {
+  test('finalize delegates to repo with id + userId and returns the doc', async () => {
+    const doc = { id: 'i1', status: 'accepted' };
+    InvitationRepository.finalize.mockResolvedValue(doc);
+    expect(await InvitationService.finalize('i1', 'u1')).toBe(doc);
+    expect(InvitationRepository.finalize).toHaveBeenCalledWith('i1', 'u1');
+  });
+  test('finalize returns null (logged) when no in-flight claim matched', async () => {
+    InvitationRepository.finalize.mockResolvedValue(null);
+    expect(await InvitationService.finalize('i1', 'u1')).toBeNull();
+  });
+  test('release delegates to repo and returns the doc', async () => {
+    const doc = { id: 'i1' };
+    InvitationRepository.release.mockResolvedValue(doc);
+    expect(await InvitationService.release('i1')).toBe(doc);
+    expect(InvitationRepository.release).toHaveBeenCalledWith('i1');
+  });
+});
+
+describe('InvitationService.sweepStaleClaims (E2)', () => {
+  test('computes a cutoff and delegates to releaseStaleClaims', async () => {
+    InvitationRepository.releaseStaleClaims.mockResolvedValue({ modifiedCount: 2 });
+    await InvitationService.sweepStaleClaims();
+    expect(InvitationRepository.releaseStaleClaims).toHaveBeenCalledTimes(1);
+    const cutoff = InvitationRepository.releaseStaleClaims.mock.calls.at(-1)[0];
+    expect(cutoff instanceof Date).toBe(true);
+    expect(cutoff.getTime()).toBeLessThan(Date.now());
+  });
+  test('never throws — a sweep error is swallowed + logged', async () => {
+    InvitationRepository.releaseStaleClaims.mockRejectedValue(new Error('db down'));
+    await expect(InvitationService.sweepStaleClaims()).resolves.toBeUndefined();
   });
 });
 
@@ -117,13 +213,16 @@ describe('InvitationService.create', () => {
     expect(arg.invitedBy).toBe('admin1');
     expect(inv.email).toBe('user@example.com');
   });
-});
 
-describe('InvitationService.consume', () => {
-  test('delegates atomic consume to repository', async () => {
-    InvitationRepository.consume.mockResolvedValue({ id: '1', usedAt: new Date() });
-    await InvitationService.consume('1');
-    expect(InvitationRepository.consume).toHaveBeenCalledWith('1');
+  test('E9: rejects (422) when a user already exists for the email', async () => {
+    mockUserService.findByEmail.mockResolvedValue({ id: 'u1', email: 'taken@example.com' });
+    await expect(InvitationService.create('Taken@Example.com', { id: 'admin1' })).rejects.toMatchObject({
+      status: 422,
+      code: 'VALIDATION_ERROR',
+    });
+    // checks the lowercased email + never persists an invite for an existing user
+    expect(mockUserService.findByEmail).toHaveBeenCalledWith('taken@example.com');
+    expect(InvitationRepository.create).not.toHaveBeenCalled();
   });
 });
 
@@ -153,9 +252,9 @@ describe('InvitationService.list / get / revoke', () => {
     await InvitationService.get('id-1');
     expect(InvitationRepository.get).toHaveBeenCalledWith('id-1');
   });
-  test('revoke delegates remove to repository', async () => {
-    InvitationRepository.remove.mockResolvedValue({ deletedCount: 1 });
+  test('E8: revoke delegates soft-delete to repository.revoke (not remove)', async () => {
+    InvitationRepository.revoke.mockResolvedValue({ id: 'id-1', status: 'revoked' });
     await InvitationService.revoke('id-1');
-    expect(InvitationRepository.remove).toHaveBeenCalledWith('id-1');
+    expect(InvitationRepository.revoke).toHaveBeenCalledWith('id-1');
   });
 });

--- a/modules/users/migrations/20260610120000-users-email-ci-unique-index.js
+++ b/modules/users/migrations/20260610120000-users-email-ci-unique-index.js
@@ -55,13 +55,14 @@ export async function up() {
     .toArray();
 
   if (duplicates.length > 0) {
+    // Emit only IDs/counts — never log raw emails (PII) in operator-facing errors.
     const sample = duplicates
       .slice(0, 10)
-      .map((d) => `${d._id} (${d.count} docs: ${d.emails.join(', ')})`)
+      .map((d) => `group:${d._id.slice(0, 6)}… (${d.count} docs, ids: ${d.ids.slice(0, 3).join(',')}${d.ids.length > 3 ? ',…' : ''})`)
       .join('; ');
     throw new Error(
       `[migration] users-email-ci-unique-index ABORTED: ${duplicates.length} case-variant duplicate email group(s) would violate the unique collation index. ` +
-        `Remediate (merge/delete the duplicate accounts) before re-running — this migration will NOT auto-merge accounts. Sample: ${sample}`,
+        `Remediate (merge/delete the duplicate accounts) before re-running — this migration will NOT auto-merge accounts. Sample (IDs only): ${sample}`,
     );
   }
 
@@ -78,7 +79,17 @@ export async function up() {
     }
     throw err;
   }
-  const hasCi = existing.some((ix) => ix.name === CI_INDEX || (ix.collation && ix.key && ix.key.email === 1 && ix.unique));
+  // Require the exact expected shape: name, key, uniqueness, AND collation spec.
+  // A spec-matching index with the wrong name would still conflict on re-creation
+  // (Mongo rejects two indexes on the same key pattern) — guard both to be explicit.
+  const hasCi = existing.some(
+    (ix) =>
+      ix.name === CI_INDEX &&
+      ix.key?.email === 1 &&
+      ix.unique === true &&
+      ix.collation?.locale === 'en' &&
+      ix.collation?.strength === 2,
+  );
   const hasPlain = existing.some((ix) => ix.name === PLAIN_INDEX);
 
   // ── (b) Create the collation unique index FIRST (idempotent) ──

--- a/modules/users/migrations/20260610120000-users-email-ci-unique-index.js
+++ b/modules/users/migrations/20260610120000-users-email-ci-unique-index.js
@@ -1,0 +1,113 @@
+/**
+ * Module dependencies
+ */
+import mongoose from 'mongoose';
+
+const PLAIN_INDEX = 'email_1';
+// MUST match the schema's explicit index name (users.model.mongoose.js) so autoIndex
+// /syncIndexes see this exact index and stay idempotent — and MUST differ from the
+// legacy default `email_1` so the collation index and the legacy plain index can
+// coexist transiently (Mongo rejects two indexes sharing a name).
+const CI_INDEX = 'email_ci_unique';
+
+/**
+ * Migration: case-insensitive unique email index (E3).
+ *
+ * Replaces the legacy case-SENSITIVE `email_1` unique index with a collation
+ * (`{ locale:'en', strength:2 }`) unique index so `User@x.com` and `user@x.com`
+ * can never coexist. This backs the invite single-use backstop (case-variant
+ * concurrent signups collide instead of creating two accounts) and OAuth
+ * account-linking by email.
+ *
+ * Safety / ordering:
+ *   (a) Pre-check for existing case-variant duplicate emails. If any exist we
+ *       ABORT (throw) WITHOUT touching indexes — auto-merging accounts is a
+ *       destructive product decision, not a migration's call. The thrown error
+ *       lists the colliding groups so an operator can remediate, then re-run.
+ *   (b) Create the collation unique index FIRST, THEN drop the plain `email_1`.
+ *       There is never a window without a unique constraint on email.
+ *   (c) Idempotent: re-running after success is a no-op (the CI index already
+ *       exists; the plain index is already gone).
+ *
+ * autoIndex race: Mongoose `autoIndex:true` (the default — db.options sets no
+ * override) begins building the schema-declared index on connect, which can race
+ * this migration. The schema declares the SAME collation index, so whichever wins
+ * the race the end state is identical and `syncIndexes()` stays idempotent (it
+ * sees one matching index, nothing to create/drop). This migration is the
+ * AUTHORITATIVE creator and additionally drops the legacy plain index that the
+ * schema no longer declares.
+ *
+ * @returns {Promise<void>}
+ */
+export async function up() {
+  const User = mongoose.model('User');
+  const collection = User.collection;
+
+  // ── (a) Pre-check: refuse to run if case-variant duplicate emails exist ──
+  // Group by the lowercased email; any group with >1 distinct stored email (or
+  // >1 document) is a collision the unique collation index would reject.
+  const duplicates = await collection
+    .aggregate([
+      { $match: { email: { $type: 'string' } } },
+      { $group: { _id: { $toLower: '$email' }, count: { $sum: 1 }, ids: { $push: '$_id' }, emails: { $addToSet: '$email' } } },
+      { $match: { count: { $gt: 1 } } },
+    ])
+    .toArray();
+
+  if (duplicates.length > 0) {
+    const sample = duplicates
+      .slice(0, 10)
+      .map((d) => `${d._id} (${d.count} docs: ${d.emails.join(', ')})`)
+      .join('; ');
+    throw new Error(
+      `[migration] users-email-ci-unique-index ABORTED: ${duplicates.length} case-variant duplicate email group(s) would violate the unique collation index. ` +
+        `Remediate (merge/delete the duplicate accounts) before re-running — this migration will NOT auto-merge accounts. Sample: ${sample}`,
+    );
+  }
+
+  // Snapshot existing indexes once (listIndexes throws if the collection does not
+  // exist yet — tolerate that: a fresh DB has no users collection and autoIndex /
+  // syncIndexes will create the CI index from the schema declaration).
+  let existing = [];
+  try {
+    existing = await collection.listIndexes().toArray();
+  } catch (err) {
+    if (err?.codeName === 'NamespaceNotFound' || err?.code === 26) {
+      console.info('[migration] users-email-ci-unique-index: users collection does not exist yet — nothing to migrate');
+      return;
+    }
+    throw err;
+  }
+  const hasCi = existing.some((ix) => ix.name === CI_INDEX || (ix.collation && ix.key && ix.key.email === 1 && ix.unique));
+  const hasPlain = existing.some((ix) => ix.name === PLAIN_INDEX);
+
+  // ── (b) Create the collation unique index FIRST (idempotent) ──
+  if (!hasCi) {
+    await collection.createIndex({ email: 1 }, { unique: true, name: CI_INDEX, collation: { locale: 'en', strength: 2 } });
+    console.info('[migration] users-email-ci-unique-index: created collation unique index on email');
+  } else {
+    console.info('[migration] users-email-ci-unique-index: collation unique index already present — skipping create');
+  }
+
+  // ── (b) THEN drop the legacy plain `email_1` (only after the CI index exists) ──
+  if (hasPlain) {
+    await collection.dropIndex(PLAIN_INDEX);
+    console.info('[migration] users-email-ci-unique-index: dropped legacy plain email_1 index');
+  } else {
+    console.info('[migration] users-email-ci-unique-index: legacy email_1 index already absent — skipping drop');
+  }
+}
+
+/**
+ * Down: no-op (warn). Reverting to a case-sensitive unique index could fail if
+ * case-variant rows were created under the CI index, and it would re-introduce
+ * the original bug. Rollback requires reverting the code (schema declaration +
+ * repository email normalization) deliberately, not an automated down-migration.
+ *
+ * @returns {void}
+ */
+export function down() {
+  console.warn(
+    '[migration] users-email-ci-unique-index DOWN: no-op; revert the case-insensitive email index by reverting the code (schema + repository) deliberately',
+  );
+}

--- a/modules/users/models/users.model.mongoose.js
+++ b/modules/users/models/users.model.mongoose.js
@@ -17,7 +17,12 @@ const UserMongoose = new Schema(
     position: String,
     email: {
       type: String,
-      unique: true,
+      // E3: store emails lowercased and enforce uniqueness case-INSENSITIVELY via a
+      // collation index (declared below), not the inline `unique:true` (which is
+      // case-sensitive — `User@x` and `user@x` would coexist and break the invite
+      // single-use backstop + OAuth account-linking). lowercase:true normalizes on
+      // write; the collation index is the read/uniqueness guard.
+      lowercase: true,
     },
     avatar: String,
     roles: [String],
@@ -52,6 +57,22 @@ const UserMongoose = new Schema(
   {
     timestamps: true,
   },
+);
+
+// E3: case-insensitive unique email. strength:2 = case- + diacritic-insensitive
+// equality, so `User@x.com` and `user@x.com` collide on insert. The migration
+// (modules/users/migrations/*-users-email-ci-unique-index.js) is the AUTHORITATIVE
+// creator of this index; declaring the IDENTICAL index here (same key, options,
+// AND explicit name) keeps autoIndex / syncIndexes idempotent (not divergent).
+// The explicit name MUST differ from the legacy default `email_1` so the collation
+// index and the legacy plain index can coexist transiently — otherwise autoIndex
+// tries to (re)create `email_1` with a collation while a plain `email_1` already
+// exists, which Mongo rejects ("Index already exists with a different name").
+// Both schema + migration converge on a single `email_ci_unique` (collation) index
+// with no stray plain `email_1` left behind.
+UserMongoose.index(
+  { email: 1 },
+  { unique: true, name: 'email_ci_unique', collation: { locale: 'en', strength: 2 } },
 );
 
 function addID() {

--- a/modules/users/repositories/users.repository.js
+++ b/modules/users/repositories/users.repository.js
@@ -15,11 +15,13 @@ const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
  * (schema `lowercase:true`) and uniqueness is enforced case-insensitively (E3
  * collation index), but Mongoose's `lowercase` setter does NOT apply to query
  * filters — so every exact-match lookup must lowercase the term itself, otherwise
- * a `User@x.com` lookup misses the stored `user@x.com` row. No-op for non-strings.
+ * a `User@x.com` lookup misses the stored `user@x.com` row.
+ * Returns null for non-strings so callers can bail out safely instead of
+ * accidentally embedding an operator object into a Mongo filter.
  * @param {String} email
- * @returns {String} the lowercased, trimmed email (or the input unchanged if not a string)
+ * @returns {String|null} the lowercased, trimmed email, or null if not a string
  */
-const normalizeEmail = (email) => (typeof email === 'string' ? email.toLowerCase().trim() : email);
+const normalizeEmail = (email) => (typeof email === 'string' ? email.toLowerCase().trim() : null);
 
 const User = mongoose.model('User');
 
@@ -63,7 +65,11 @@ const create = (user) => new User(user).save();
  */
 const get = (user = {}) => {
   if (user.id && mongoose.Types.ObjectId.isValid(user.id)) return User.findOne({ _id: user.id }).exec();
-  if (user.email) return User.findOne({ email: normalizeEmail(user.email) }).exec();
+  if (user.email) {
+    const email = normalizeEmail(user.email);
+    if (!email) return Promise.resolve(null);
+    return User.findOne({ email }).exec();
+  }
   if (user.resetPasswordToken) {
     return User.findOne({
       resetPasswordToken: user.resetPasswordToken,
@@ -108,7 +114,11 @@ const update = (user) => {
  */
 const remove = async (user) => {
   if (user && user.id && mongoose.Types.ObjectId.isValid(user.id)) return User.deleteOne({ _id: user.id }).exec();
-  if (user && user.email) return User.deleteOne({ email: normalizeEmail(user.email) }).exec();
+  if (user && user.email) {
+    const email = normalizeEmail(user.email);
+    if (!email) return Promise.resolve({ deletedCount: 0 });
+    return User.deleteOne({ email }).exec();
+  }
   return { deletedCount: 0 };
 };
 
@@ -173,7 +183,11 @@ const searchByNameOrEmail = (search) => {
  * @param {String} email - The email to search for
  * @returns {Promise<Object|null>} The matching user or null
  */
-const findByEmail = (email) => User.findOne({ email: normalizeEmail(email) }).exec();
+const findByEmail = (email) => {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return Promise.resolve(null);
+  return User.findOne({ email: normalized }).exec();
+};
 
 /**
  * @desc Function to update a user by ID with a partial update object
@@ -222,12 +236,15 @@ const updateMany = (filter, data) => User.updateMany(filter, data, { runValidato
  *   to follow up with findByEmail to distinguish the two cases if it needs to
  *   return a specific error.
  */
-const linkProviderByEmail = (email, provider, providerData) =>
-  User.findOneAndUpdate(
-    { email: normalizeEmail(email), emailVerified: true },
+const linkProviderByEmail = (email, provider, providerData) => {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return Promise.resolve(null);
+  return User.findOneAndUpdate(
+    { email: normalized, emailVerified: true },
     { $set: { [`additionalProvidersData.${provider}`]: providerData } },
     { returnDocument: 'after', runValidators: true },
   ).exec();
+};
 
 export default {
   list,

--- a/modules/users/repositories/users.repository.js
+++ b/modules/users/repositories/users.repository.js
@@ -10,6 +10,17 @@ import mongoose from 'mongoose';
  */
 const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+/**
+ * @desc Normalize an email for an EXACT-MATCH query. Emails are stored lowercased
+ * (schema `lowercase:true`) and uniqueness is enforced case-insensitively (E3
+ * collation index), but Mongoose's `lowercase` setter does NOT apply to query
+ * filters — so every exact-match lookup must lowercase the term itself, otherwise
+ * a `User@x.com` lookup misses the stored `user@x.com` row. No-op for non-strings.
+ * @param {String} email
+ * @returns {String} the lowercased, trimmed email (or the input unchanged if not a string)
+ */
+const normalizeEmail = (email) => (typeof email === 'string' ? email.toLowerCase().trim() : email);
+
 const User = mongoose.model('User');
 
 /**
@@ -52,7 +63,7 @@ const create = (user) => new User(user).save();
  */
 const get = (user = {}) => {
   if (user.id && mongoose.Types.ObjectId.isValid(user.id)) return User.findOne({ _id: user.id }).exec();
-  if (user.email) return User.findOne({ email: user.email }).exec();
+  if (user.email) return User.findOne({ email: normalizeEmail(user.email) }).exec();
   if (user.resetPasswordToken) {
     return User.findOne({
       resetPasswordToken: user.resetPasswordToken,
@@ -97,7 +108,7 @@ const update = (user) => {
  */
 const remove = async (user) => {
   if (user && user.id && mongoose.Types.ObjectId.isValid(user.id)) return User.deleteOne({ _id: user.id }).exec();
-  if (user && user.email) return User.deleteOne({ email: user.email }).exec();
+  if (user && user.email) return User.deleteOne({ email: normalizeEmail(user.email) }).exec();
   return { deletedCount: 0 };
 };
 
@@ -162,7 +173,7 @@ const searchByNameOrEmail = (search) => {
  * @param {String} email - The email to search for
  * @returns {Promise<Object|null>} The matching user or null
  */
-const findByEmail = (email) => User.findOne({ email }).exec();
+const findByEmail = (email) => User.findOne({ email: normalizeEmail(email) }).exec();
 
 /**
  * @desc Function to update a user by ID with a partial update object
@@ -213,7 +224,7 @@ const updateMany = (filter, data) => User.updateMany(filter, data, { runValidato
  */
 const linkProviderByEmail = (email, provider, providerData) =>
   User.findOneAndUpdate(
-    { email, emailVerified: true },
+    { email: normalizeEmail(email), emailVerified: true },
     { $set: { [`additionalProvidersData.${provider}`]: providerData } },
     { returnDocument: 'after', runValidators: true },
   ).exec();

--- a/modules/users/tests/users.email.ci.index.integration.tests.js
+++ b/modules/users/tests/users.email.ci.index.integration.tests.js
@@ -41,9 +41,9 @@ describe('E3 case-insensitive unique email index:', () => {
   });
 
   afterAll(async () => {
-    // Belt: drop any leftover variant rows by lowercased match.
+    // Belt: drop any leftover rows by lowercased match (mirrors afterEach targets).
     try {
-      await User.deleteMany({ email: { $in: ['ci-base@example.com', 'user@ci.example.com'] } }).exec();
+      await User.deleteMany({ email: { $in: ['ci-base@example.com', 'ci-variant@example.com'] } }).exec();
     } catch (_) { /* cleanup */ }
   });
 

--- a/modules/users/tests/users.email.ci.index.integration.tests.js
+++ b/modules/users/tests/users.email.ci.index.integration.tests.js
@@ -1,0 +1,92 @@
+/**
+ * Module dependencies.
+ */
+import path from 'path';
+import mongoose from 'mongoose';
+
+import { beforeAll, afterAll, afterEach, describe, test, expect } from '@jest/globals';
+import { bootstrap } from '../../../lib/app.js';
+
+/**
+ * E3 — case-insensitive unique email index integration tests.
+ *
+ * Asserts the END STATE the schema declaration + migration converge on:
+ *   - exactly ONE unique index on { email:1 } with a collation, and NO stray plain
+ *     `email_1` after syncIndexes();
+ *   - `User@x.com` and `user@x.com` collide (cannot coexist) under that index.
+ *
+ * Uses the REAL bootstrapped app (migrations + autoIndex already ran) and the real
+ * User model against the test Mongo.
+ */
+describe('E3 case-insensitive unique email index:', () => {
+  let UserService;
+  let User;
+
+  beforeAll(async () => {
+    await bootstrap();
+    UserService = (await import(path.resolve('./modules/users/services/users.service.js'))).default;
+    User = mongoose.model('User');
+    // Make sure indexes are reconciled to the schema declaration (idempotent vs the
+    // migration + autoIndex — this is the assertion's whole point).
+    await User.syncIndexes();
+  });
+
+  afterEach(async () => {
+    for (const email of ['ci-base@example.com', 'ci-variant@example.com']) {
+      try {
+        const existing = await UserService.getBrut({ email });
+        if (existing) await UserService.remove(existing);
+      } catch (_) { /* cleanup */ }
+    }
+  });
+
+  afterAll(async () => {
+    // Belt: drop any leftover variant rows by lowercased match.
+    try {
+      await User.deleteMany({ email: { $in: ['ci-base@example.com', 'user@ci.example.com'] } }).exec();
+    } catch (_) { /* cleanup */ }
+  });
+
+  test('after syncIndexes the users collection has the collation unique email index and NO stray plain email_1', async () => {
+    const indexes = await User.collection.listIndexes().toArray();
+    const emailIndexes = indexes.filter((ix) => ix.key && ix.key.email === 1);
+
+    // Exactly one index keyed on { email:1 }.
+    expect(emailIndexes.length).toBe(1);
+    const emailIx = emailIndexes[0];
+    // It is unique AND carries a collation (case-insensitive).
+    expect(emailIx.unique).toBe(true);
+    expect(emailIx.collation).toBeDefined();
+    expect(emailIx.collation.strength).toBe(2);
+    // No stray PLAIN (collation-less) email_1 left behind.
+    const strayPlain = indexes.find((ix) => ix.name === 'email_1' && !ix.collation);
+    expect(strayPlain).toBeUndefined();
+  });
+
+  test('User@x.com and user@x.com collide — the case-variant cannot create a 2nd account', async () => {
+    // First account (mixed case input — stored lowercased by the schema setter).
+    const first = await UserService.create({ email: 'CI-Base@Example.com', password: 'Sup3rStr0ng!', provider: 'local' });
+    expect(first).toBeDefined();
+
+    // A different-case variant of the SAME address must be rejected by the unique
+    // collation index (duplicate key), not silently create a 2nd account.
+    await expect(
+      UserService.create({ email: 'ci-base@example.com', password: 'Sup3rStr0ng!', provider: 'local' }),
+    ).rejects.toMatchObject({ code: 11000 });
+
+    // And only one row exists for the address.
+    const count = await User.countDocuments({ email: 'ci-base@example.com' }).exec();
+    expect(count).toBe(1);
+  });
+
+  test('emails are stored lowercased and resolvable case-insensitively via the repository', async () => {
+    await UserService.create({ email: 'CI-Variant@Example.com', password: 'Sup3rStr0ng!', provider: 'local' });
+    // Stored lowercased.
+    const stored = await User.findOne({ email: 'ci-variant@example.com' }).exec();
+    expect(stored).not.toBeNull();
+    // Repository findByEmail lowercases the query term, so a mixed-case lookup hits.
+    const found = await UserService.getBrut({ email: 'CI-Variant@Example.com' });
+    expect(found).not.toBeNull();
+    expect(found.email).toBe('ci-variant@example.com');
+  });
+});


### PR DESCRIPTION
## Phase 3 — invitations ↔ org decouple (epic #3808)

Security-relevant hardening of the `invitations` module (built in P2). Behavior of the signup/OAuth gate stays correct; this closes replay/race/consent/bypass gaps.

- **E2 two-phase claim/finalize/release** — atomic CLAIM (`findOneAndUpdate` CAS) before `UserService.create` → replay/double-accept guard (422 on lost claim); `finalize(userId)` on full success, `release()` on ANY pre-response failure (incl. the `UserService.create` throw path). New `consumingAt` field. **Bypass guard:** `findValid` AND `findValidByEmail` exclude claimed-unfinalized invites (else the OAuth no-claim path → user-create bypass). **Lazy stale-sweep** (boot + at read time, 15 min, NO scheduler — the stack has none).
- **E3 case-insensitive unique email index** — `lowercase:true` + collation index `email_ci_unique`; inputs normalized in all email repo queries; migration `modules/users/migrations/20260610120000-…` pre-checks case-variant dupes (ABORTS boot if any) → creates CI index FIRST then drops `email_1` (no window without a unique index); autoIndex race resolved via the distinct index name. `errors.js` friendly-message now keyPattern-derived.
- **E4 cap unify** — both gates route through `computeSignupCapacity`; fixes a live `Number('')→0→everyone-blocked` divergence (blank ⇒ uncapped).
- **Token-log redaction** — `inviteToken` scrubbed from the morgan `:url` log (no-regex `redactUrl`).
- **E5** pin-in-checker, **E6** no auto-verify on invite (even mailer-off), **E8** soft-delete revoke (`revokedAt`, preserves `invitedBy`), **E9** already-registered 422 guard.

### Verification
- Lint clean; **2289+ tests green** (1848 unit + 431 integration + e2e), incl. real-Mongo integration for the bypass guard, concurrent double-claim CAS, crash→sweep recovery, CI-index collision, E4 `cap:''`, E6/E8/E9.
- Independent **spec-compliance** review ✅ (both merge-blocker invariants — claim atomicity + dual-resolver bypass guard — verified in code + tests) + **adversarial code-quality** review (found + fixed a leaked-claim window on the `create`-throw path; the fix's test proven non-tautological by temporary revert).

### Downstream (P9 / #3815)
MIGRATIONS.md documents the boot-time email-CI-index migration — **downstream must pre-check prod for case-variant duplicate emails before deploy** (else the migration aborts boot). `consumingAt` is additive (no data migration).

### [doc-sync ack]
The `legacy email_1` comments in the migration/model are intentional (they describe the index being dropped), not stale drift.

Closes #3811. Part of #3808.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Two-phase invite verification mechanism for improved single-use invite security and concurrency handling
  * Enhanced sign-up capacity handling with blank cap treated as uncapped

* **Bug Fixes**
  * Case-insensitive email uniqueness enforcement with improved duplicate-key error messaging
  * Fixed invite account verification behavior when mail is disabled
  * Sensitive query parameters now redacted from application logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->