### PR TITLE
chore(skills): /feature claim flips board status to In progress

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -53,6 +53,17 @@ gh issue comment <N> --body "WIP — session $(date -u +%Y%m%dT%H%M%SZ)-$(uuidge
 
 Where `<branch-name>` is the branch this `/feature` invocation will use (planned name, even if not yet created). If the branch isn't decided yet, use `branch TBD`. Posting a follow-up comment with the real branch name after `/pull-request` creates it is best-effort manual — the linked PR superseding the WIP comment is what matters in practice.
 
+### 3b. Board status → In progress (best-effort)
+
+After a successful claim, flip the issue's board item — and, if it's a sub-issue, its parent epic — to **In progress**:
+
+```bash
+_bs=/Users/pierrebrisorgueil/Documents/Dev/github/pierreb-projects/infra/marketplace/shared/board-status.sh
+[ -f "$_bs" ] && bash "$_bs" "$(gh repo view --json nameWithOwner -q .nameWithOwner)#<N>" "In progress" || true
+```
+
+Best-effort by design: script missing (machine without the infra checkout), org without a board (comes/montaine), or issue not yet on the board → silent no-op; `/dev:roadmap` in-progress-sync is the safety net. Never set Ready or Done from here.
+
 ### 4. Proceed to Phase 0
 
 Continue to scope analysis below.


### PR DESCRIPTION
## Summary

- What changed: Added Phase 0.0 step 3b to `.claude/skills/feature/SKILL.md` — after a successful `/feature #N` claim (assignee set + WIP comment posted), a best-effort call to `infra/marketplace/shared/board-status.sh` flips the corresponding GitHub Project board item to **In progress**.
- Why: Devkit half of the infra board auto-lifecycle. Infra commit `58a076c` (pierreb-projects/infra) ships `board-status.sh`; this PR wires the call into the Node `/feature` skill. Phase 0.0 step 3b is best-effort: silent no-op when running off-machine or in a boardless org, so the claim flow is never blocked. `/dev:roadmap` in-progress-sync remains the safety net for any gaps.
- Related issues: none (chore)

## Scope

- Module(s) impacted: `.claude/skills/feature/SKILL.md` (docs/skill only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [ ] `npm run lint` — N/A (markdown only, no code changed)
- [ ] `npm test` — N/A (no code changed)
- [ ] Manual checks done (if applicable) — skill text verified against infra `board-status.sh` interface

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed — N/A (docs-only)

## Notes for reviewers

- Pure markdown/docs change — zero runtime impact on the Node stack itself.
- The Vue side ships the byte-identical edit in a sibling PR (`pierreb-devkit/Vue`).
- The `board-status.sh` script is best-effort by design: it exits 0 silently if the infra repo is not accessible or the project board is not configured, so downstream projects are never affected.
- Mergeability: no conflicts expected; docs-only patch.