### PR TITLE
docs(invitations): module README — referral substrate + reward architectures (#5 prep)

### DIFF
--- a/modules/billing/billing.init.js
+++ b/modules/billing/billing.init.js
@@ -60,7 +60,14 @@ export default async (app) => {
    */
   // eslint-disable-next-line no-unused-vars
   invitationEvents.on('invitation.accepted', (payload) => {
-    // TODO(#5): grant referral credits to payload.invitedBy (skip when invitedBy is null).
+    // TODO(#5): implement the STANDARD grant HERE, in the stack, entirely CONFIG-GATED:
+    //   config.billing.referral = { enabled: false, referrerUnits: 0, refereeUnits: 0 }
+    //   if (!config.billing?.referral?.enabled) return;  → grant idempotently
+    //   (key on `referral:${payload.invitationId}:referrer|referee`).
+    // Downstream projects NEVER edit this file (drift gate + ISO-merge) — they flip the
+    // config in their {project}.config.js. Custom rewards (cashback, webhooks) live in a
+    // project-only module listening to the same event. See modules/invitations/README.md.
+    // TODO(#5): grant credits to payload.invitedBy (skip null) + optionally acceptedUserId.
     // TODO(#5): async grant listener must self-guard rejections — the emit-site try/catch only catches sync throws.
     // No-op for P8a — the seam is the deliverable, not the grant.
   });

--- a/modules/invitations/README.md
+++ b/modules/invitations/README.md
@@ -39,18 +39,36 @@ from the payload — reward either side, or both.
 
 ## Implementing rewards — two architectures (pick per product)
 
-### A. Event-driven grant (recommended for usage-based / credit-ledger billing)
+> **⚠️ Downstream rule first:** stack files (`modules/billing/**`, this module, `lib/`)
+> stay **byte-identical** downstream — the drift gate blocks edits and `/update-stack`
+> would clobber them. A downstream project therefore NEVER wires a listener by editing
+> `billing.init.js`. The two sanctioned channels are: **config** (deep-merged
+> `{project}.config.js` — for the standard reward below) and **project-only modules**
+> (glob-discovered, e.g. `modules/trawl-rewards/` — for custom logic).
 
-Wire a listener in the consuming module's `*.init.js` (the no-op seam already exists in
-`modules/billing/billing.init.js` with a `TODO(#5)`):
+### A. Standard grant — ships IN the stack, downstream enables it by CONFIG
+
+The grant listener is implemented **once, upstream, in `billing.init.js`** (#5 — the
+no-op seam with the `TODO(#5)` is already there), entirely gated by config:
 
 ```js
-// billing.init.js — the grant listener (#5)
+// modules/billing/config/billing.development.config.js — stack default: OFF
+billing: { referral: { enabled: false, referrerUnits: 0, refereeUnits: 0 } }
+```
+
+```js
+// a downstream's config/defaults/{project}.config.js — the ONLY thing it touches:
+billing: { referral: { enabled: true, referrerUnits: 500, refereeUnits: 200 } }
+```
+
+The stack listener (#5 implementation sketch — lives upstream, never downstream):
+
+```js
 invitationEvents.on('invitation.accepted', async ({ invitationId, invitedBy, acceptedUserId }) => {
   try {
-    const cfg = config.billing?.referral;                  // settings-driven amounts
-    if (!cfg?.enabled) return;
-    if (invitedBy) await grantCredits({ userId: invitedBy, units: cfg.referrerUnits, key: `referral:${invitationId}:referrer` });
+    const cfg = config.billing?.referral;
+    if (!cfg?.enabled) return;                              // downstream flips this
+    if (invitedBy && cfg.referrerUnits) await grantCredits({ userId: invitedBy, units: cfg.referrerUnits, key: `referral:${invitationId}:referrer` });
     if (cfg.refereeUnits) await grantCredits({ userId: acceptedUserId, units: cfg.refereeUnits, key: `referral:${invitationId}:referee` });
   } catch (err) {
     // ⚠️ MANDATORY self-guard: EventEmitter.emit is synchronous — the emit-site
@@ -63,26 +81,33 @@ invitationEvents.on('invitation.accepted', async ({ invitationId, invitedBy, acc
 
 Rules that make this production-grade:
 
-- **Idempotency** — key every grant on `invitationId` (a unique index on the ledger's
-  `key`): a replayed/duplicate event can never double-credit.
-- **Settings, not code** — amounts live in config, deep-merged per project:
-
-  ```js
-  // modules/billing/config/billing.development.config.js (default OFF)
-  billing: { referral: { enabled: false, referrerUnits: 0, refereeUnits: 0 } }
-  // a downstream's {project}.config.js simply overrides:
-  billing: { referral: { enabled: true, referrerUnits: 500, refereeUnits: 200 } }
-  ```
-
+- **Idempotency** — key every grant on `invitationId` (unique index on the ledger `key`):
+  a replayed/duplicate event can never double-credit.
 - **Reconcile cron (safety net)** — EventEmitter is in-process fire-and-forget; a crash
   between accept and grant loses the event. Pair the listener with a periodic script
   (k8s CronJob, pattern: `modules/billing/crons/`) that scans
   `invitations { status:'accepted', invitedBy: {$ne:null} }` vs the grant ledger keys and
-  back-fills misses. With the reconcile in place, the listener is latency, the cron is truth.
-- For a **cashback / external payout** (Stripe credit note, coupon, webhook to a partner
-  system) the listener body is the only thing that changes — same event, same idempotency
-  key, same self-guard. Anything can subscribe: `analytics`, a `webhooks` module, etc.
-  Multiple listeners are fine (the emitter is shared); each owns its own failure handling.
+  back-fills misses. The listener is latency; the cron is truth.
+
+### A'. Custom rewards (cashback, Stripe credit note, partner webhook) — project-only module
+
+When a downstream needs logic beyond units (cashback %, coupons, external payouts), it
+ships its OWN module — glob discovery means zero stack edits:
+
+```js
+// modules/{project}-rewards/{project}-rewards.init.js   (downstream-only module)
+import invitationEvents from '../invitations/lib/events.js';
+
+export default async () => {
+  invitationEvents.on('invitation.accepted', async (payload) => {
+    try { await myCashbackFlow(payload); }                 // same idempotency key rule
+    catch (err) { logger.error('[rewards] cashback failed', { err: err?.message, stack: err?.stack }); }
+  });
+};
+```
+
+Multiple listeners on the shared emitter are fine (the stack's standard grant + a
+project's custom one can coexist); each owns its own failure handling.
 
 ### B. Compute-on-read (no writes, simplest)
 

--- a/modules/invitations/README.md
+++ b/modules/invitations/README.md
@@ -1,0 +1,120 @@
+# Invitations module
+
+Optional, standalone module owning the **platform invitation** concept: invite a contact by
+email → single-use token + `invitedBy` + beta-gate eligibility. Depends only on `auth`
+(via the `registerSignupEligibility` hook — `auth` never imports this module). Knows nothing
+about organizations: getting an invited person into an org is the 2-step flow
+*platform invite → `org.addMember(userId)`*.
+
+- Routes: `/api/invitations` (admin CRUD) + `/api/invitations/verify/:token` (public).
+- Model `Invitation` → collection `invitations` (`email`, `token`, `invitedBy`, `status`,
+  `expiresAt`, `consumingAt`, `acceptedAt`, `acceptedUserId`, `revokedAt`, `usedAt`).
+- Signup gate: two-phase claim/finalize (`consumingAt` CAS + lazy 15-min stale sweep),
+  email pin, soft revoke. See `services/invitations.service.js`.
+
+## The referral substrate (what "Referral rewards — coming soon" hooks into)
+
+The reward **seam** ships; the reward **logic** is deliberately deferred (#5, gates in #3833).
+Two primitives are written on every accepted invite — on **both** the token-signup path and
+the OAuth path (shared `accept(invite, userId)`):
+
+1. **`user.referredBy`** — the inviter's userId, stamped server-side on the created account
+   (never client-writable: absent from the Zod schemas + update whitelists; written via the
+   raw repository path only). This is the durable referral edge — it supports
+   *compute-on-read* forever, even if an event was missed.
+2. **`invitation.accepted` event** — emitted by this module's singleton
+   (`lib/events.js`):
+
+   ```js
+   invitationEvents.emit('invitation.accepted', {
+     invitationId,    // ← natural IDEMPOTENCY KEY for any grant
+     email,           // invitee email (lowercased)
+     invitedBy,       // inviter userId — null for admin-created invites with no inviter
+     acceptedUserId,  // the REFEREE — double-sided rewards need no schema change
+   });
+   ```
+
+Both the **referrer** (`invitedBy`) and the **referee** (`acceptedUserId`) are identifiable
+from the payload — reward either side, or both.
+
+## Implementing rewards — two architectures (pick per product)
+
+### A. Event-driven grant (recommended for usage-based / credit-ledger billing)
+
+Wire a listener in the consuming module's `*.init.js` (the no-op seam already exists in
+`modules/billing/billing.init.js` with a `TODO(#5)`):
+
+```js
+// billing.init.js — the grant listener (#5)
+invitationEvents.on('invitation.accepted', async ({ invitationId, invitedBy, acceptedUserId }) => {
+  try {
+    const cfg = config.billing?.referral;                  // settings-driven amounts
+    if (!cfg?.enabled) return;
+    if (invitedBy) await grantCredits({ userId: invitedBy, units: cfg.referrerUnits, key: `referral:${invitationId}:referrer` });
+    if (cfg.refereeUnits) await grantCredits({ userId: acceptedUserId, units: cfg.refereeUnits, key: `referral:${invitationId}:referee` });
+  } catch (err) {
+    // ⚠️ MANDATORY self-guard: EventEmitter.emit is synchronous — the emit-site
+    // try/catch in invitations.service only catches SYNC throws. An async
+    // listener's rejection escapes as an unhandledRejection. Never let it.
+    logger.error('[billing] referral grant failed', { err: err?.message, stack: err?.stack });
+  }
+});
+```
+
+Rules that make this production-grade:
+
+- **Idempotency** — key every grant on `invitationId` (a unique index on the ledger's
+  `key`): a replayed/duplicate event can never double-credit.
+- **Settings, not code** — amounts live in config, deep-merged per project:
+
+  ```js
+  // modules/billing/config/billing.development.config.js (default OFF)
+  billing: { referral: { enabled: false, referrerUnits: 0, refereeUnits: 0 } }
+  // a downstream's {project}.config.js simply overrides:
+  billing: { referral: { enabled: true, referrerUnits: 500, refereeUnits: 200 } }
+  ```
+
+- **Reconcile cron (safety net)** — EventEmitter is in-process fire-and-forget; a crash
+  between accept and grant loses the event. Pair the listener with a periodic script
+  (k8s CronJob, pattern: `modules/billing/crons/`) that scans
+  `invitations { status:'accepted', invitedBy: {$ne:null} }` vs the grant ledger keys and
+  back-fills misses. With the reconcile in place, the listener is latency, the cron is truth.
+- For a **cashback / external payout** (Stripe credit note, coupon, webhook to a partner
+  system) the listener body is the only thing that changes — same event, same idempotency
+  key, same self-guard. Anything can subscribe: `analytics`, a `webhooks` module, etc.
+  Multiple listeners are fine (the emitter is shared); each owns its own failure handling.
+
+### B. Compute-on-read (no writes, simplest)
+
+Derive the reward at quota/entitlement time instead of granting:
+
+```js
+const accepted = await InvitationRepository.countAccepted({ invitedBy: userId });
+const bonus = accepted * config.billing.referral.referrerUnits;
+```
+
+Always consistent (survives missed events), zero ledger. Costs a query on the hot
+entitlement path (index `referredBy`/`invitedBy` first — see the in-code `TODO(#5)`),
+and hard to cap/expire/audit ("when was this credited?"). Good for simple boosts
+(e.g. "+1 project slot per referral"), wrong for money-shaped balances.
+
+> Recommended: **A + reconcile cron** for credit/cashback economies; **B** for static
+> entitlement boosts. The substrate supports both simultaneously.
+
+## Gates before shipping rewards (#3833 — read it first)
+
+1. **Scope the list**: `GET /api/invitations` is platform-global today (admin-only by
+   CASL). Before widening `create Invitation` to regular users, add an `invitedBy`-scoped
+   `/mine` (PII: invitee emails).
+2. **Self-referral guard** — alternate-email self-invites become valuable once credits exist.
+3. **Open-signup hole** — claim/finalize are gated on `!config.sign.up`: with public signup
+   open the event never fires. Resolve (finalize-without-claim) or hide the Referrals tab
+   before any open deployment enables rewards.
+4. **Index `referredBy`** alongside the first real referral query.
+
+## UI
+
+The Vue module (`src/modules/invitations/` in Devkit Vue) ships the admin beta-gate tab and
+the account **Referrals** tab (invite a contact, my invites + status chips, a referral
+summary, and the "Referral rewards — coming soon" placeholder where #5's balance lands —
+the placeholder is contractually digit-free until real numbers exist).

--- a/modules/invitations/README.md
+++ b/modules/invitations/README.md
@@ -6,7 +6,8 @@ email → single-use token + `invitedBy` + beta-gate eligibility. Depends only o
 about organizations: getting an invited person into an org is the 2-step flow
 *platform invite → `org.addMember(userId)`*.
 
-- Routes: `/api/invitations` (admin CRUD) + `/api/invitations/verify/:token` (public).
+- Routes: `/api/invitations` (admin list/create + revoke via `DELETE /:invitationId` — no
+  update endpoint) + `/api/invitations/verify/:token` (public).
 - Model `Invitation` → collection `invitations` (`email`, `token`, `invitedBy`, `status`,
   `expiresAt`, `consumingAt`, `acceptedAt`, `acceptedUserId`, `revokedAt`, `usedAt`).
 - Signup gate: two-phase claim/finalize (`consumingAt` CAS + lazy 15-min stale sweep),
@@ -29,7 +30,8 @@ the OAuth path (shared `accept(invite, userId)`):
    invitationEvents.emit('invitation.accepted', {
      invitationId,    // ← natural IDEMPOTENCY KEY for any grant
      email,           // invitee email (lowercased)
-     invitedBy,       // inviter userId — null for admin-created invites with no inviter
+     invitedBy,       // inviter userId — the admin API always stamps the creating admin;
+                      // null only for actor-less inserts (legacy/scripted data)
      acceptedUserId,  // the REFEREE — double-sided rewards need no schema change
    });
    ```
@@ -53,6 +55,7 @@ no-op seam with the `TODO(#5)` is already there), entirely gated by config:
 
 ```js
 // modules/billing/config/billing.development.config.js — stack default: OFF
+// (this block does NOT exist yet — #5 adds it together with the listener impl)
 billing: { referral: { enabled: false, referrerUnits: 0, refereeUnits: 0 } }
 ```
 
@@ -86,8 +89,10 @@ Rules that make this production-grade:
 - **Reconcile cron (safety net)** — EventEmitter is in-process fire-and-forget; a crash
   between accept and grant loses the event. Pair the listener with a periodic script
   (k8s CronJob, pattern: `modules/billing/crons/`) that scans
-  `invitations { status:'accepted', invitedBy: {$ne:null} }` vs the grant ledger keys and
-  back-fills misses. The listener is latency; the cron is truth.
+  ALL `invitations { status:'accepted' }` vs the grant ledger keys and back-fills misses
+  (scan all accepted, not just `invitedBy:{$ne:null}` — referee grants exist even when
+  `invitedBy` is null, so a referrer-only scan would miss referee-only back-fills).
+  The listener is latency; the cron is truth.
 
 ### A'. Custom rewards (cashback, Stripe credit note, partner webhook) — project-only module
 
@@ -114,12 +119,14 @@ project's custom one can coexist); each owns its own failure handling.
 Derive the reward at quota/entitlement time instead of granting:
 
 ```js
+// illustrative — a countAccepted helper does not exist yet; #5 adds it (or an equivalent query)
 const accepted = await InvitationRepository.countAccepted({ invitedBy: userId });
 const bonus = accepted * config.billing.referral.referrerUnits;
 ```
 
 Always consistent (survives missed events), zero ledger. Costs a query on the hot
-entitlement path (index `referredBy`/`invitedBy` first — see the in-code `TODO(#5)`),
+entitlement path (index `invitations.invitedBy` first — the field this query hits;
+`users.referredBy` gets its own index only if referral lists query it),
 and hard to cap/expire/audit ("when was this credited?"). Good for simple boosts
 (e.g. "+1 project slot per referral"), wrong for money-shaped balances.
 


### PR DESCRIPTION
User-requested doc (2026-06-11): explains the "Referral rewards — coming soon" seam — the 2 primitives written on accept (`referredBy` + the `invitation.accepted` event with `invitationId` as idempotency key, referrer AND referee identifiable), the 2 reward architectures (event-driven idempotent grant + reconcile cron for usage-based/cashback economies vs compute-on-read for static boosts), the settings-driven config pattern, the mandatory async-listener self-guard, and the #3833 gates. Docs-only. Part of #3808, preps #5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for the invitations module: admin CRUD, public token verification, and the two-step signup/claim flow.
  * Described referral behavior on acceptance (server-stamped referral link between users and an acceptance event) and pre-shipping gating requirements for rewards.
  * Documented two reward architectures (event-driven grants vs. compute-on-read) and outlined admin/account referral UI surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->