### PR TITLE
fix(invitations): revoke/duplicate guards + resend endpoint

### DIFF
--- a/modules/auth/routes/auth.routes.js
+++ b/modules/auth/routes/auth.routes.js
@@ -10,7 +10,7 @@ import UsersSchema from '../../users/models/users.schema.js';
 import auth from '../controllers/auth.controller.js';
 import authPassword from '../controllers/auth.password.controller.js';
 // TODO(P9, pierreb-devkit/Node#3815): Remove these two imports and the four routes
-// below ONLY after (a) downstream (Trawl) has absorbed Vue P6 via /update-stack AND
+// below ONLY after (a) the downstream consumer has absorbed Vue P6 via /update-stack AND
 // (b) Vue auth.store `verifyInvite` is repointed to the canonical
 // /api/invitations/verify/:token (Vue pre-P9 fix PR) — it still calls the alias.
 // Deprecation alias only — the invitations feature lives in modules/invitations.

--- a/modules/auth/routes/auth.routes.js
+++ b/modules/auth/routes/auth.routes.js
@@ -9,7 +9,7 @@ import policy from '../../../lib/middlewares/policy.js';
 import UsersSchema from '../../users/models/users.schema.js';
 import auth from '../controllers/auth.controller.js';
 import authPassword from '../controllers/auth.password.controller.js';
-// TODO(P9, pierreb-devkit/Node#3815): Remove these two imports and the three routes
+// TODO(P9, pierreb-devkit/Node#3815): Remove these two imports and the four routes
 // below ONLY after (a) downstream (Trawl) has absorbed Vue P6 via /update-stack AND
 // (b) Vue auth.store `verifyInvite` is repointed to the canonical
 // /api/invitations/verify/:token (Vue pre-P9 fix PR) — it still calls the alias.
@@ -47,6 +47,10 @@ export default (app) => {
     .route('/api/auth/invitations/:invitationId')
     .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
     .delete(invitations.remove);
+  app
+    .route('/api/auth/invitations/:invitationId/resend')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(invitations.resend);
 
   // Auth config — optional JWT: public fields for everyone, org details for authenticated users
   /**

--- a/modules/invitations/controllers/invitations.controller.js
+++ b/modules/invitations/controllers/invitations.controller.js
@@ -40,16 +40,23 @@ const list = async (req, res) => {
 };
 
 /**
- * @desc Admin: revoke an invitation
+ * @desc Admin: revoke a PENDING invitation (pending-only guard in the repository)
  * @param {Object} req - Express request object
  * @param {Object} req.invitation - Loaded invitation document (set by invitationByID middleware)
  * @param {string} req.invitation.id - Invitation id
  * @param {Object} res - Express response object
- * @returns {Promise<void>} Sends HTTP 200 with deleted id or 422 on error
+ * @returns {Promise<void>} Sends HTTP 200 with deleted id, 409 when not pending, or 422 on error
  */
 const remove = async (req, res) => {
   try {
-    await InvitationService.revoke(req.invitation.id);
+    const revoked = await InvitationService.revoke(req.invitation.id);
+    if (!revoked) {
+      // The invitation EXISTS (invitationByID loaded it) but the guarded CAS
+      // matched nothing → it is no longer pending (accepted or already
+      // revoked). Refuse: revoking an accepted invite would silently drop it
+      // from the accepted set used for referral attribution.
+      return responses.error(res, 409, 'Conflict', 'Only pending invitations can be revoked')();
+    }
     responses.success(res, 'invitation deleted')({ id: req.invitation.id });
   } catch (err) {
     responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);

--- a/modules/invitations/controllers/invitations.controller.js
+++ b/modules/invitations/controllers/invitations.controller.js
@@ -11,14 +11,19 @@ import InvitationService from '../services/invitations.service.js';
  * @param {string} req.body.email - Email address to invite
  * @param {Object} req.user - Authenticated admin user
  * @param {Object} res - Express response object
- * @returns {Promise<void>} Sends HTTP 200 with created invitation or 422 on error
+ * @returns {Promise<void>} Sends HTTP 200 with created invitation, 409 on duplicate pending, or 422 on error
  */
 const create = async (req, res) => {
   try {
     const invitation = await InvitationService.create(req.body.email, req.user);
     responses.success(res, 'invitation created')(invitation);
   } catch (err) {
-    responses.error(res, 422, 'Unprocessable Entity', errors.getMessage(err))(err);
+    // Thread the service-thrown status — a 409 (duplicate pending) must not
+    // flatten to the legacy hardcoded 422. Anything else keeps the
+    // historical 422 mapping (same style as the billing admin controller).
+    const status = err.status === 409 ? 409 : 422;
+    const title = status === 409 ? 'Conflict' : 'Unprocessable Entity';
+    responses.error(res, status, title, errors.getMessage(err))(err);
   }
 };
 

--- a/modules/invitations/controllers/invitations.controller.js
+++ b/modules/invitations/controllers/invitations.controller.js
@@ -69,6 +69,25 @@ const remove = async (req, res) => {
 };
 
 /**
+ * @desc Admin: re-send the invitation email for a pending invitation (existing token)
+ * @param {Object} req - Express request object
+ * @param {Object} req.invitation - Loaded invitation document (set by invitationByID middleware)
+ * @param {string} req.invitation.id - Invitation id
+ * @param {Object} res - Express response object
+ * @returns {Promise<void>} Sends HTTP 200 with the invitation, 409 when not pending, or 422 on error
+ */
+const resend = async (req, res) => {
+  try {
+    const invitation = await InvitationService.resend(req.invitation.id);
+    responses.success(res, 'invitation resent')(invitation);
+  } catch (err) {
+    const status = err.status === 409 ? 409 : 422;
+    const title = status === 409 ? 'Conflict' : 'Unprocessable Entity';
+    responses.error(res, status, title, errors.getMessage(err))(err);
+  }
+};
+
+/**
  * @desc Public: report whether a token is a valid invite (+ prefill email)
  * @param {Object} req - Express request object
  * @param {string} req.params.token - Invitation token to verify
@@ -103,4 +122,4 @@ const invitationByID = async (req, res, next, id) => {
   }
 };
 
-export default { create, list, remove, verify, invitationByID };
+export default { create, list, remove, resend, verify, invitationByID };

--- a/modules/invitations/controllers/invitations.controller.js
+++ b/modules/invitations/controllers/invitations.controller.js
@@ -18,11 +18,12 @@ const create = async (req, res) => {
     const invitation = await InvitationService.create(req.body.email, req.user);
     responses.success(res, 'invitation created')(invitation);
   } catch (err) {
-    // Thread the service-thrown status — a 409 (duplicate pending) must not
-    // flatten to the legacy hardcoded 422. Anything else keeps the
-    // historical 422 mapping (same style as the billing admin controller).
-    const status = err.status === 409 ? 409 : 422;
-    const title = status === 409 ? 'Conflict' : 'Unprocessable Entity';
+    // Thread ANY service-thrown AppError status (409 duplicate-pending, etc.)
+    // rather than flattening everything but 409 to 422 (same style as the
+    // billing admin controller). create() does not throw 404 today, but the
+    // shared form keeps it consistent with resend().
+    const status = err.status ?? 422;
+    const title = status === 409 ? 'Conflict' : status === 404 ? 'Not Found' : 'Unprocessable Entity';
     responses.error(res, status, title, errors.getMessage(err))(err);
   }
 };
@@ -81,8 +82,12 @@ const resend = async (req, res) => {
     const invitation = await InvitationService.resend(req.invitation.id);
     responses.success(res, 'invitation resent')(invitation);
   } catch (err) {
-    const status = err.status === 409 ? 409 : 422;
-    const title = status === 409 ? 'Conflict' : 'Unprocessable Entity';
+    // Thread ANY service-thrown AppError status (409 duplicate-pending, 404
+    // unknown id, etc.) rather than flattening everything but 409 to 422 — a
+    // 404 must not surface as Unprocessable Entity if a future caller reaches
+    // the service without the invitationByID param-loader's 404 guard.
+    const status = err.status ?? 422;
+    const title = status === 409 ? 'Conflict' : status === 404 ? 'Not Found' : 'Unprocessable Entity';
     responses.error(res, status, title, errors.getMessage(err))(err);
   }
 };

--- a/modules/invitations/repositories/invitations.repository.js
+++ b/modules/invitations/repositories/invitations.repository.js
@@ -129,12 +129,24 @@ const get = (id) => (mongoose.Types.ObjectId.isValid(id) ? Invitation.findById(i
  * revokedAt instead of deleting, so invitedBy/acceptedUserId survive for the
  * referral phase. A revoked invite never re-opens the gate (findValid filters
  * on status:'pending').
+ *
+ * Guarded on status:'pending': an ACCEPTED invite must never flip to 'revoked'
+ * — it would silently drop out of the accepted set findAccepted() scans for
+ * referral attribution. Returns null when the row exists but is no longer
+ * pending; the controller maps that to 409.
+ *
+ * Benign race (revoke-mid-claim): a signup can claim/finalize between the
+ * controller's param-load and this CAS — the filter then matches nothing and
+ * we return null (→ 409) instead of corrupting the just-accepted invite. The
+ * inverse interleaving (revoke lands first, mid-claim) is also safe: finalize
+ * is guarded on status:{$ne:'revoked'}, so the in-flight accept no-ops with a
+ * logged warning and the invite stays revoked.
  * @param {String} id
- * @returns {Promise<Object|null>} the revoked doc, or null when no such id
+ * @returns {Promise<Object|null>} the revoked doc, or null when missing / not pending
  */
 const revoke = (id) =>
   Invitation.findOneAndUpdate(
-    { _id: id },
+    { _id: id, status: 'pending' },
     { $set: { status: 'revoked', revokedAt: new Date() } },
     { returnDocument: 'after' },
   ).exec();

--- a/modules/invitations/routes/invitations.routes.js
+++ b/modules/invitations/routes/invitations.routes.js
@@ -36,5 +36,11 @@ export default (app) => {
     .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
     .delete(invitations.remove);
 
+  // Admin — re-send the invitation email (pending invites only, existing token).
+  app
+    .route('/api/invitations/:invitationId/resend')
+    .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
+    .post(invitations.resend);
+
   app.param('invitationId', invitations.invitationByID);
 };

--- a/modules/invitations/routes/invitations.routes.js
+++ b/modules/invitations/routes/invitations.routes.js
@@ -23,6 +23,11 @@ export default (app) => {
   // Public: report whether a token is a valid invite (+ prefill email).
   app.route('/api/invitations/verify/:token').get(authLimiter, invitations.verify);
 
+  // Param loader for :invitationId — anchored before the routes that use it
+  // (app.param is global regardless of position, but keeping it here is the
+  // house convention and avoids a future reader missing it for a new route).
+  app.param('invitationId', invitations.invitationByID);
+
   // Admin CRUD — list + create.
   app
     .route('/api/invitations')
@@ -41,6 +46,4 @@ export default (app) => {
     .route('/api/invitations/:invitationId/resend')
     .all(passport.authenticate('jwt', { session: false }), policy.isAllowed)
     .post(invitations.resend);
-
-  app.param('invitationId', invitations.invitationByID);
 };

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -339,7 +339,7 @@ const get = (id) => InvitationRepository.get(id);
  * @desc E8 — soft-delete (revoke) an invitation by id (status:'revoked' + revokedAt,
  * NOT a hard delete), preserving invitedBy/acceptedUserId for the referral phase.
  * @param {String} id
- * @returns {Promise<Object|null>} the revoked invitation
+ * @returns {Promise<Object|null>} the revoked invitation, or null when not pending
  */
 const revoke = (id) => InvitationRepository.revoke(id);
 

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -14,6 +14,24 @@ import logger from '../../../lib/services/logger.js';
 import AppError from '../../../lib/helpers/AppError.js';
 
 /**
+ * @desc Build the signup-invite email payload for an invitation. Shared by
+ * create() (fire-and-forget) and resend() (awaited) so the template, subject
+ * and link format can never drift between the two send sites.
+ * @param {Object} invitation - persisted invitation (email + token)
+ * @returns {Object} sendMail arguments
+ */
+const inviteMailPayload = (invitation) => ({
+  template: 'signup-invite',
+  to: invitation.email,
+  subject: `You're invited to ${config.app.title}`,
+  params: {
+    url: `${getBaseUrl()}/signup?inviteToken=${invitation.token}`,
+    appName: config.app.title,
+    appContact: config.app.contact,
+  },
+});
+
+/**
  * @desc Create an invitation for an email, generate a single-use token, persist,
  * and (best-effort) email the signup link. Token/expiry are server-controlled.
  *
@@ -76,16 +94,7 @@ const create = async (email, invitedBy) => {
   });
   if (mails.isConfigured()) {
     mails
-      .sendMail({
-        template: 'signup-invite',
-        to: invitation.email,
-        subject: `You're invited to ${config.app.title}`,
-        params: {
-          url: `${getBaseUrl()}/signup?inviteToken=${token}`,
-          appName: config.app.title,
-          appContact: config.app.contact,
-        },
-      })
+      .sendMail(inviteMailPayload(invitation))
       .catch((err) => logger.warn('invitations: email failed', { message: err?.message }));
   }
   return invitation;
@@ -357,6 +366,42 @@ const get = (id) => InvitationRepository.get(id);
  */
 const revoke = (id) => InvitationRepository.revoke(id);
 
+/**
+ * @desc Re-send the invitation email for a still-PENDING invitation, with the
+ * EXISTING token — never regenerated, so a previously emailed or copied link
+ * stays valid. Unlike create()'s best-effort send, the email here IS the
+ * operation: sendMail is awaited and a transport failure surfaces as an error.
+ * @param {String} id - invitation id
+ * @returns {Promise<Object>} the (unchanged) invitation
+ * @throws {AppError} 404 unknown id, 409 not pending, 422 mailer unconfigured
+ */
+const resend = async (id) => {
+  const invitation = await InvitationRepository.get(id);
+  if (!invitation) {
+    throw new AppError('no invitation with that identifier has been found', {
+      status: 404,
+      code: 'NOT_FOUND',
+      details: { message: 'No invitation with that identifier has been found.' },
+    });
+  }
+  if (invitation.status !== 'pending') {
+    throw new AppError('Only pending invitations can be resent', {
+      status: 409,
+      code: 'CONFLICT',
+      details: { message: 'Only pending invitations can be resent.' },
+    });
+  }
+  if (!mails.isConfigured()) {
+    throw new AppError('mailer is not configured', {
+      status: 422,
+      code: 'VALIDATION_ERROR',
+      details: { message: 'Email sending is not configured on this server.' },
+    });
+  }
+  await mails.sendMail(inviteMailPayload(invitation));
+  return invitation;
+};
+
 export default {
   create,
   findValid,
@@ -371,4 +416,5 @@ export default {
   list,
   get,
   revoke,
+  resend,
 };

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -51,6 +51,20 @@ const create = async (email, invitedBy) => {
       details: { message: 'A user with this email already exists.' },
     });
   }
+  // One LIVE invite per email. findByEmail is already pending-only
+  // (status:'pending', unused, unclaimed, unexpired), so an expired, revoked
+  // or accepted prior invite never blocks a re-invite — only a genuinely
+  // outstanding one does. Best-effort guard (no partial unique index on
+  // email+status): two racing creates can still both land; acceptable for an
+  // admin/owner surface, and any one resolved token still single-uses.
+  const outstanding = await InvitationRepository.findByEmail(normalizedEmail);
+  if (outstanding) {
+    throw new AppError('A pending invitation already exists for this email', {
+      status: 409,
+      code: 'CONFLICT',
+      details: { message: 'A pending invitation already exists for this email.' },
+    });
+  }
   const token = crypto.randomBytes(20).toString('hex');
   const days = config.sign?.inviteExpiresInDays || DEFAULT_INVITE_EXPIRES_IN_DAYS;
   const expiresAt = new Date(Date.now() + days * 24 * 3600000);

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -40,7 +40,7 @@ const inviteMailPayload = (invitation) => ({
  * @param {String} email - invitee email (any case)
  * @param {Object} invitedBy - the admin user creating the invite
  * @returns {Promise<Object>} created invitation
- * @throws {AppError} 422 when the invitee email is the inviter's own, or a user already exists for this email
+ * @throws {AppError} 409 when a pending invitation already exists for the email; 422 when the invitee email is the inviter's own, or a user already exists for this email
  */
 const create = async (email, invitedBy) => {
   const normalizedEmail = String(email).toLowerCase().trim();
@@ -378,7 +378,7 @@ const revoke = (id) => InvitationRepository.revoke(id);
 const resend = async (id) => {
   const invitation = await InvitationRepository.get(id);
   if (!invitation) {
-    throw new AppError('no invitation with that identifier has been found', {
+    throw new AppError('No invitation with that identifier has been found', {
       status: 404,
       code: 'NOT_FOUND',
       details: { message: 'No invitation with that identifier has been found.' },

--- a/modules/invitations/tests/invitations.controller.unit.tests.js
+++ b/modules/invitations/tests/invitations.controller.unit.tests.js
@@ -4,6 +4,7 @@ const mockService = {
   create: jest.fn(),
   list: jest.fn(),
   revoke: jest.fn(),
+  resend: jest.fn(),
   findValid: jest.fn(),
   get: jest.fn(),
 };
@@ -72,6 +73,26 @@ describe('invitations.controller.remove', () => {
     await controller.remove({ invitation: { id: 'i9' } }, makeRes());
     expect(error).toHaveBeenCalledWith(expect.anything(), 409, 'Conflict', 'Only pending invitations can be revoked');
     expect(success).not.toHaveBeenCalled();
+  });
+});
+
+describe('invitations.controller.resend', () => {
+  test('resends via the service and responds success', async () => {
+    mockService.resend.mockResolvedValue({ id: 'i1', status: 'pending' });
+    await controller.resend({ invitation: { id: 'i1' } }, makeRes());
+    expect(mockService.resend).toHaveBeenCalledWith('i1');
+    expect(success).toHaveBeenCalledWith(expect.anything(), 'invitation resent');
+    expect(successInner).toHaveBeenCalledWith({ id: 'i1', status: 'pending' });
+  });
+  test('threads a 409 (non-pending) as Conflict', async () => {
+    mockService.resend.mockRejectedValue(Object.assign(new Error('Only pending invitations can be resent'), { status: 409 }));
+    await controller.resend({ invitation: { id: 'i1' } }, makeRes());
+    expect(error).toHaveBeenCalledWith(expect.anything(), 409, 'Conflict', expect.any(String));
+  });
+  test('maps a 422 (mailer unconfigured) as Unprocessable Entity', async () => {
+    mockService.resend.mockRejectedValue(Object.assign(new Error('mailer is not configured'), { status: 422 }));
+    await controller.resend({ invitation: { id: 'i1' } }, makeRes());
+    expect(error).toHaveBeenCalledWith(expect.anything(), 422, 'Unprocessable Entity', expect.any(String));
   });
 });
 

--- a/modules/invitations/tests/invitations.controller.unit.tests.js
+++ b/modules/invitations/tests/invitations.controller.unit.tests.js
@@ -62,6 +62,12 @@ describe('invitations.controller.remove', () => {
     expect(mockService.revoke).toHaveBeenCalledWith('i9');
     expect(successInner).toHaveBeenCalledWith({ id: 'i9' });
   });
+  test('responds 409 Conflict when revoke matches no pending row (accepted / already revoked)', async () => {
+    mockService.revoke.mockResolvedValue(null);
+    await controller.remove({ invitation: { id: 'i9' } }, makeRes());
+    expect(error).toHaveBeenCalledWith(expect.anything(), 409, 'Conflict', 'Only pending invitations can be revoked');
+    expect(success).not.toHaveBeenCalled();
+  });
 });
 
 describe('invitations.controller.verify', () => {

--- a/modules/invitations/tests/invitations.controller.unit.tests.js
+++ b/modules/invitations/tests/invitations.controller.unit.tests.js
@@ -43,6 +43,11 @@ describe('invitations.controller.create', () => {
     await controller.create({ body: { email: 'a@b.co' }, user: {} }, makeRes());
     expect(error).toHaveBeenCalledWith(expect.anything(), 422, 'Unprocessable Entity', 'boom');
   });
+  test('threads a service 409 (duplicate pending) through as Conflict', async () => {
+    mockService.create.mockRejectedValue(Object.assign(new Error('A pending invitation already exists for this email'), { status: 409 }));
+    await controller.create({ body: { email: 'a@b.co' }, user: {} }, makeRes());
+    expect(error).toHaveBeenCalledWith(expect.anything(), 409, 'Conflict', 'A pending invitation already exists for this email');
+  });
 });
 
 describe('invitations.controller.list', () => {

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -814,4 +814,35 @@ describe('Signup invitations:', () => {
       expect(res.status).toBe(200);
     });
   });
+
+  describe('Invitation ops — revoke guard, duplicate-pending, resend', () => {
+    let mails;
+
+    beforeAll(async () => {
+      mails = (await import(path.resolve('./lib/helpers/mailer/index.js'))).default;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('revoking an ACCEPTED invitation is refused with 409 (referral attribution preserved)', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'ops-accepted@example.com' });
+      const id = created.body.data.id;
+
+      // Flip to accepted directly — the full signup-accept path is covered elsewhere.
+      const Invitation = (await import('mongoose')).default.model('Invitation');
+      await Invitation.updateOne({ _id: id }, { $set: { status: 'accepted', acceptedAt: new Date() } }).exec();
+
+      const res = await adminAgent.delete(`/api/invitations/${id}`);
+      expect(res.status).toBe(409);
+      expect(res.body.description).toBe('Only pending invitations can be revoked');
+
+      // The accepted row is untouched — still in the accepted set.
+      const after = await Invitation.findById(id).exec();
+      expect(after.status).toBe('accepted');
+      expect(after.revokedAt).toBeNull();
+    });
+  });
 });

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -861,5 +861,47 @@ describe('Signup invitations:', () => {
       const third = await adminAgent.post('/api/invitations').send({ email: 'ops-dup@example.com' });
       expect(third.status).toBe(200);
     });
+
+    test('resend re-sends the EXISTING token for a pending invite (no regeneration)', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'ops-resend@example.com' });
+      const { id, token } = created.body.data;
+
+      jest.spyOn(mails, 'isConfigured').mockReturnValue(true);
+      const sendSpy = jest.spyOn(mails, 'sendMail').mockResolvedValue({});
+
+      const res = await adminAgent.post(`/api/invitations/${id}/resend`);
+      expect(res.status).toBe(200);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const mail = sendSpy.mock.calls[0][0];
+      expect(mail.template).toBe('signup-invite');
+      expect(mail.to).toBe('ops-resend@example.com');
+      expect(mail.params.url).toContain(`inviteToken=${token}`); // SAME token
+    });
+
+    test('resend guards: 422 with the mailer unconfigured, 409 once non-pending', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'ops-resend-guards@example.com' });
+      const { id } = created.body.data;
+
+      // Test env mailer is unconfigured (placeholder `from`) → 422 with no mocks.
+      const unconfigured = await adminAgent.post(`/api/invitations/${id}/resend`);
+      expect(unconfigured.status).toBe(422);
+
+      // Revoke it, then resend → 409 (status guard fires before the mailer guard).
+      await adminAgent.delete(`/api/invitations/${id}`);
+      const conflicted = await adminAgent.post(`/api/invitations/${id}/resend`);
+      expect(conflicted.status).toBe(409);
+      expect(conflicted.body.description).toBe('Only pending invitations can be resent.');
+    });
+
+    test('resend resolves through the legacy /api/auth/invitations alias too (kept consistent)', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const created = await adminAgent.post('/api/invitations').send({ email: 'ops-resend-alias@example.com' });
+      jest.spyOn(mails, 'isConfigured').mockReturnValue(true);
+      jest.spyOn(mails, 'sendMail').mockResolvedValue({});
+      const res = await adminAgent.post(`/api/auth/invitations/${created.body.data.id}/resend`);
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -844,5 +844,22 @@ describe('Signup invitations:', () => {
       expect(after.status).toBe('accepted');
       expect(after.revokedAt).toBeNull();
     });
+
+    test('a second invite for the SAME email is refused with 409 while the first is pending', async () => {
+      const adminAgent = await createAdminAndSignin();
+      const first = await adminAgent.post('/api/invitations').send({ email: 'ops-dup@example.com' });
+      expect(first.status).toBe(200);
+
+      // Case-insensitive: the service lowercases before the guard.
+      const second = await adminAgent.post('/api/invitations').send({ email: 'OPS-DUP@example.com' });
+      expect(second.status).toBe(409);
+      expect(second.body.description).toBe('A pending invitation already exists for this email.');
+
+      // Revoking the pending invite re-opens creation (findByEmail is pending-only).
+      const revoked = await adminAgent.delete(`/api/invitations/${first.body.data.id}`);
+      expect(revoked.status).toBe(200);
+      const third = await adminAgent.post('/api/invitations').send({ email: 'ops-dup@example.com' });
+      expect(third.status).toBe(200);
+    });
   });
 });

--- a/modules/invitations/tests/invitations.repository.unit.tests.js
+++ b/modules/invitations/tests/invitations.repository.unit.tests.js
@@ -160,11 +160,13 @@ describe('InvitationRepository', () => {
     expect(result).toEqual({ id: 'i1' });
   });
 
-  test('revoke soft-deletes by id (status:revoked + revokedAt), not deleteOne (E8)', async () => {
+  test('revoke soft-deletes by id GUARDED on status:pending (E8 + revoke-guard), not deleteOne', async () => {
     exec.mockResolvedValue({ id: 'i1', status: 'revoked' });
     const result = await InvitationRepository.revoke('i1');
     const [filter, update] = InvitationModel.findOneAndUpdate.mock.calls.at(-1);
-    expect(filter).toEqual({ _id: 'i1' });
+    // An accepted invite must never flip to revoked — that would silently drop
+    // it out of the accepted set findAccepted() scans for referral attribution.
+    expect(filter).toEqual({ _id: 'i1', status: 'pending' });
     expect(update.$set.status).toBe('revoked');
     expect(update.$set).toHaveProperty('revokedAt');
     expect(InvitationModel.deleteOne).not.toHaveBeenCalled();

--- a/modules/invitations/tests/invitations.service.unit.tests.js
+++ b/modules/invitations/tests/invitations.service.unit.tests.js
@@ -407,3 +407,45 @@ describe('InvitationService.list / get / revoke', () => {
     expect(InvitationRepository.revoke).toHaveBeenCalledWith('id-1');
   });
 });
+
+describe('InvitationService.resend', () => {
+  const pending = { id: 'i1', email: 'a@b.co', token: 'tok-1', status: 'pending' };
+  beforeEach(() => {
+    mockMailer.isConfigured.mockReturnValue(true);
+    mockMailer.sendMail.mockResolvedValue({});
+  });
+  afterEach(() => {
+    mockMailer.isConfigured.mockReturnValue(false);
+  });
+
+  test('re-sends the signup-invite email with the EXISTING token and returns the invitation', async () => {
+    InvitationRepository.get.mockResolvedValue(pending);
+    const result = await InvitationService.resend('i1');
+    expect(result).toBe(pending);
+    expect(mockMailer.sendMail).toHaveBeenCalledTimes(1);
+    const mail = mockMailer.sendMail.mock.calls[0][0];
+    expect(mail.template).toBe('signup-invite');
+    expect(mail.to).toBe('a@b.co');
+    // No token regeneration: a previously emailed/shared link must stay valid.
+    expect(mail.params.url).toBe('http://localhost:3000/signup?inviteToken=tok-1');
+  });
+
+  test('404 when the invitation does not exist', async () => {
+    InvitationRepository.get.mockResolvedValue(null);
+    await expect(InvitationService.resend('missing')).rejects.toMatchObject({ status: 404 });
+    expect(mockMailer.sendMail).not.toHaveBeenCalled();
+  });
+
+  test('409 when the invitation is not pending (accepted/revoked never re-email)', async () => {
+    InvitationRepository.get.mockResolvedValue({ ...pending, status: 'accepted' });
+    await expect(InvitationService.resend('i1')).rejects.toMatchObject({ status: 409, code: 'CONFLICT' });
+    expect(mockMailer.sendMail).not.toHaveBeenCalled();
+  });
+
+  test('422 when the mailer is not configured (resend IS the email — fail loudly)', async () => {
+    mockMailer.isConfigured.mockReturnValue(false);
+    InvitationRepository.get.mockResolvedValue(pending);
+    await expect(InvitationService.resend('i1')).rejects.toMatchObject({ status: 422 });
+    expect(mockMailer.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/modules/invitations/tests/invitations.service.unit.tests.js
+++ b/modules/invitations/tests/invitations.service.unit.tests.js
@@ -45,8 +45,11 @@ const InvitationService = (await import('../services/invitations.service.js')).d
 const invitationEvents = (await import('../lib/events.js')).default;
 
 beforeEach(() => {
-  // Default: no stale claims to sweep, no pre-existing user (E9).
+  // Default: no stale claims to sweep, no pre-existing user (E9), no outstanding
+  // pending invite (the duplicate-pending guard). clearMocks resets calls but NOT
+  // mockResolvedValue, so a prior test's findByEmail value would otherwise leak in.
   InvitationRepository.releaseStaleClaims.mockResolvedValue({ modifiedCount: 0 });
+  InvitationRepository.findByEmail.mockResolvedValue(undefined);
   mockUserService.findByEmail.mockResolvedValue(null);
   mockUserService.updateById.mockResolvedValue({});
 });
@@ -315,6 +318,17 @@ describe('InvitationService.create', () => {
     });
     // checks the lowercased email + never persists an invite for an existing user
     expect(mockUserService.findByEmail).toHaveBeenCalledWith('taken@example.com');
+    expect(InvitationRepository.create).not.toHaveBeenCalled();
+  });
+
+  test('rejects (409 CONFLICT) when a PENDING invitation already exists for the email', async () => {
+    InvitationRepository.findByEmail.mockResolvedValue({ id: 'i0', email: 'dup@example.com', status: 'pending' });
+    await expect(InvitationService.create('Dup@Example.com', { id: 'admin1' })).rejects.toMatchObject({
+      status: 409,
+      code: 'CONFLICT',
+    });
+    // checks the lowercased email + never persists a second live invite
+    expect(InvitationRepository.findByEmail).toHaveBeenCalledWith('dup@example.com');
     expect(InvitationRepository.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Hardens the platform-invitation ops surface (admin tab + the `/api/invitations` API).

- **Revoke status-guard:** `revoke()` now filters `{ _id, status: 'pending' }`. Revoking an already-accepted invite (which corrupted referral attribution — it dropped out of `findAccepted()` used by the reconcile cron) now returns **409 Conflict** ("Only pending invitations can be revoked") instead of silently flipping `accepted → revoked`. A benign revoke-mid-claim race is documented.
- **Duplicate-pending guard:** `create()` rejects a second pending invite for the same email with **409** ("A pending invitation already exists for this email") — previously N zombie pending invites per email were possible.
- **Resend endpoint:** `POST /api/invitations/:invitationId/resend` (admin CASL) re-sends the **existing** token (no regeneration) so a failed invite email is recoverable from the UI. **409** if the invite is non-pending, **422** if the mailer is unconfigured. Registered on the canonical mount **and** the legacy `/api/auth/invitations` alias for consistency.

Error-string casing follows the house `errors.getMessage` convention (getMessage-routed descriptions carry a trailing period; literal-string descriptions do not) — asserted at both unit and integration layers.

## Test plan

- `invitations.repository/service/controller.unit` + `invitations.integration` — 132 tests, 7 suites green. New integration cases: revoke-accepted→409, duplicate-pending→409, resend re-sends existing token, resend guards (409 non-pending / 422 mailer-off), resend via the legacy alias.

## Guardrails check

- [x] `npm run lint` clean
- [x] Public-OSS clean (also neutralized a pre-existing downstream name in the touched `auth.routes.js` deprecation-alias comment)
- [x] Tests added for every new behavior

Closes #3834
