### PR TITLE
fix(home): precise readiness mail-warning wording (#4297 Node half)

### DIFF
--- a/modules/home/services/home.service.js
+++ b/modules/home/services/home.service.js
@@ -99,7 +99,7 @@ const getReadinessStatus = () => {
   checks.push({
     category: 'mail',
     status: mailConfigured ? 'ok' : 'warning',
-    message: mailConfigured ? 'Mail provider configured' : 'No mail provider configured',
+    message: mailConfigured ? 'Mail provider configured' : 'No mail provider configured — users register without email verification',
   });
 
   // billing — Stripe

--- a/modules/home/tests/home.service.unit.tests.js
+++ b/modules/home/tests/home.service.unit.tests.js
@@ -54,6 +54,25 @@ describe('HomeService.getReadinessStatus unit tests:', () => {
     expect(categories).not.toContain('monitoring');
   });
 
+  describe('mail row', () => {
+    test('warning message states the consequence when no mail provider is configured', async () => {
+      const HomeService = await withConfig({});
+      const checks = HomeService.getReadinessStatus();
+      const row = checks.find((c) => c.category === 'mail');
+      expect(row.status).toBe('warning');
+      expect(row.message).toBe('No mail provider configured — users register without email verification');
+    });
+
+    test('ok message is unchanged when a mail provider is configured', async () => {
+      mockMailerIsConfigured.mockReturnValue(true);
+      const HomeService = await withConfig({});
+      const checks = HomeService.getReadinessStatus();
+      const row = checks.find((c) => c.category === 'mail');
+      expect(row.status).toBe('ok');
+      expect(row.message).toBe('Mail provider configured');
+    });
+  });
+
   describe('errorTracking row', () => {
     test('ok when analytics.posthog.key is set AND errorTracking=true', async () => {
       const HomeService = await withConfig({


### PR DESCRIPTION
## Summary

Node half of #4297 (the Vue half — dropping the redundant admin mailer banner — ships in the Vue admin/account UX PR). The admin Readiness tab is now the single home for the "no mailer" signal, so its wording carries the consequence:

- `modules/home/services/home.service.js` — the mail readiness check's **warning** message becomes `No mail provider configured — users register without email verification` (the `ok`-branch message `Mail provider configured` is unchanged).

## Test plan

`home.service.unit` 12/12, full `home` module 31/31 (the integration test's pinned category order `['config','security','auth','mail','billing','analytics','errorTracking']` is untouched). Lint clean.

refs pierreb-devkit/Vue#4297
