### PR TITLE
docs(billing): genericize prod namespace + mongo pod in runbooks (OSS hygiene)

### DIFF
--- a/modules/billing/RUNBOOKS.md
+++ b/modules/billing/RUNBOOKS.md
@@ -100,7 +100,7 @@ Operational runbooks for the billing module. Each runbook references real endpoi
 1. Identify the divergence from the weekly reconciliation log:
 
    ```bash
-   kubectl logs -n pierreb-projects job/billing-reconcile-<timestamp>
+   kubectl logs -n <your-namespace> job/billing-reconcile-<timestamp>
    ```
 
    Look for lines containing `divergence detected` — they include `orgId`, `stripeStatus`, `dbStatus`, `stripePlan`, `dbPlan`.
@@ -212,7 +212,7 @@ db.cron_locks.deleteOne({ _id: "billing.extrasExpiration" })
 Or via `kubectl exec` on the mongo pod:
 
 ```bash
-kubectl exec -n pierreb-projects mongo-0 -- mongosh \
+kubectl exec -n <your-namespace> <your-mongo-pod> -- mongosh \
   "mongodb://localhost:27017/<your-db>" \
   --eval 'db.cron_locks.deleteOne({ _id: "billing.weeklyReset" })'
 ```

--- a/modules/billing/crons/README.md
+++ b/modules/billing/crons/README.md
@@ -35,7 +35,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: billing-weekly-reset
-  namespace: pierreb-projects
+  namespace: your-namespace  # replace with your namespace
 spec:
   schedule: "0 1 * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
The billing runbooks + cron README hardcoded a specific Kubernetes namespace and a specific Mongo pod name inside copy-paste operational examples. A consumer pasting these would target the wrong namespace/pod.

Replaced with placeholders consistent with the rest of the docs (which already use `<your-db>` / `your-org`):
- `RUNBOOKS.md` — `kubectl logs -n <your-namespace> …` and `kubectl exec -n <your-namespace> <your-mongo-pod> …`
- `crons/README.md` — `namespace: your-namespace  # replace with your namespace`

Docs-only, no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated billing module runbook and configuration examples to use parameterized placeholders instead of hardcoded environment values, enabling easier customization across different environments and setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->