### PR TITLE
feat(billing): add demo equivalences config for the nav compute gauge

### DIFF
--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -39,6 +39,23 @@ const config = {
      */
     upgradeUrl: '/billing/plans',
     /**
+     * Display-only capacity equivalences for the nav compute gauge
+     * (Vue billing.navComputeGauge.component). Each entry maps an operation "kind"
+     * to its unit cost; the gauge renders `floor(remaining / unitCost)` as a
+     * human-readable "~N easy / ~M heavy operations remaining" estimate. Served
+     * verbatim to the client via the auth config (serverConfig.billing.equivalences).
+     *
+     * DEVKIT DEMO VALUES — illustrative only. Downstream projects override with
+     * their own kinds / labels / unit costs (or omit the block → the gauge shows
+     * raw units only). null / absent / [] → no-op.
+     *
+     * Entry shape: { kind: 'easy' | 'hard', unitCost: number > 0, label: string }
+     */
+    equivalences: [
+      { kind: 'easy', unitCost: 200, label: 'easy operations' },
+      { kind: 'hard', unitCost: 2000, label: 'heavy operations' },
+    ],
+    /**
      * When true, mounts attachUsageContext on protected /api/billing/* routes.
      * Emits X-Meter-Remaining on billing responses. Off by default to avoid
      * extra DB reads on routes that do not need the header.

--- a/modules/billing/config/billing.development.config.js
+++ b/modules/billing/config/billing.development.config.js
@@ -42,12 +42,15 @@ const config = {
      * Display-only capacity equivalences for the nav compute gauge
      * (Vue billing.navComputeGauge.component). Each entry maps an operation "kind"
      * to its unit cost; the gauge renders `floor(remaining / unitCost)` as a
-     * human-readable "~N easy / ~M heavy operations remaining" estimate. Served
+     * human-readable "N easy / M heavy operations remaining" estimate. Served
      * verbatim to the client via the auth config (serverConfig.billing.equivalences).
+     * Only surfaces while `meterMode` is on (the gauge is hidden otherwise).
      *
-     * DEVKIT DEMO VALUES — illustrative only. Downstream projects override with
-     * their own kinds / labels / unit costs (or omit the block → the gauge shows
-     * raw units only). null / absent / [] → no-op.
+     * DEVKIT DEMO VALUES — illustrative, like the other billing defaults in this file.
+     * DOWNSTREAM-OVERRIDE: set your own kinds / labels / unit costs, or set
+     * `equivalences: []` (or `null`) to show raw units only. Because this ships as
+     * the billing base config, simply omitting the key downstream inherits these
+     * demo values — disable the chips explicitly with `[]` / `null`.
      *
      * Entry shape: { kind: 'easy' | 'hard', unitCost: number > 0, label: string }
      */


### PR DESCRIPTION
## What

Ship a neutral devkit demo `billing.equivalences` config so the Vue nav compute-gauge renders its capacity-chip estimate out of the box, and the `serverConfig.billing.equivalences` contract is documented in config.

## How

- Adds an illustrative `billing.equivalences` array (`easy operations` / `heavy operations`) to the billing module config.
- **No code change** — `modules/auth/controllers/auth.controller.js` already serves `config.billing?.equivalences ?? null` verbatim to the client.
- Downstream projects override with their own kinds / labels / unit costs (or omit the block → the gauge shows raw units only). Entry shape: `{ kind:'easy'|'hard', unitCost:number>0, label:string }`.

Supports pierreb-devkit/Vue#4349.
