### PR TITLE
feat(emails): bulletproof CTA buttons in transactional templates

### DIFF
--- a/config/templates/billing-payment-failed.html
+++ b/config/templates/billing-payment-failed.html
@@ -1,12 +1,16 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello,</p>
-  <p>We were unable to process the latest payment for your <b>{{appName}}</b> subscription.</p>
-  <p>Your account remains active for now. Please update your payment method before the grace period ends to avoid any service interruption.</p>
-  <p>Update your card on your <a href="{{billingPortalUrl}}">billing portal</a>.</p>
-  <br />
-  <p>The <b>{{appName}}</b> Team.</p>
-  <br/>
-  <i style="color:#9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello,</p>
+    <p>We were unable to process the latest payment for your <b>{{appName}}</b> subscription.</p>
+    <p>Your account remains active for now. Please update your payment method before the grace period ends to avoid any service interruption.</p>
+    <p>Update your card on your <a href="{{billingPortalUrl}}">billing portal</a>.</p>
+    <br />
+    <p>The <b>{{appName}}</b> Team.</p>
+    <br />
+    <i style="color: #9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
+  </body>
+</html>

--- a/config/templates/billing-quota-reached-100.html
+++ b/config/templates/billing-quota-reached-100.html
@@ -1,12 +1,19 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello,</p>
-  <p>Your <b>{{appName}}</b> weekly quota is now fully used ({{meterUsed}} / {{meterQuota}} units).</p>
-  <p>If you have an extras pack, your usage continues drawing from its remaining balance until it's used up. Otherwise it pauses until you add an extras pack or upgrade your plan — nothing is charged automatically.</p>
-  <p>Check your consumption or add an extras pack on your <a href="{{billingUrl}}">billing dashboard</a>.</p>
-  <br />
-  <p>The <b>{{appName}}</b> Team.</p>
-  <br/>
-  <i style="color:#9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello,</p>
+    <p>Your <b>{{appName}}</b> weekly quota is now fully used ({{meterUsed}} / {{meterQuota}} units).</p>
+    <p>
+      If you have an extras pack, your usage continues drawing from its remaining balance until it's used up. Otherwise it pauses until you add an
+      extras pack or upgrade your plan — nothing is charged automatically.
+    </p>
+    <p>Check your consumption or add an extras pack on your <a href="{{billingUrl}}">billing dashboard</a>.</p>
+    <br />
+    <p>The <b>{{appName}}</b> Team.</p>
+    <br />
+    <i style="color: #9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
+  </body>
+</html>

--- a/config/templates/billing-quota-warning-80.html
+++ b/config/templates/billing-quota-warning-80.html
@@ -1,12 +1,19 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello,</p>
-  <p>Your <b>{{appName}}</b> plan has reached <b>{{threshold}}%</b> of its weekly quota ({{meterUsed}} / {{meterQuota}} units used).</p>
-  <p>You still have room to keep going. Once you reach 100%, runs continue only while you have an extras-pack balance; without one they pause until you add an extras pack or upgrade your plan — nothing is charged automatically.</p>
-  <p>Review your usage, add an extras pack, or upgrade your plan on your <a href="{{billingUrl}}">billing dashboard</a>.</p>
-  <br />
-  <p>The <b>{{appName}}</b> Team.</p>
-  <br/>
-  <i style="color:#9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello,</p>
+    <p>Your <b>{{appName}}</b> plan has reached <b>{{threshold}}%</b> of its weekly quota ({{meterUsed}} / {{meterQuota}} units used).</p>
+    <p>
+      You still have room to keep going. Once you reach 100%, runs continue only while you have an extras-pack balance; without one they pause until
+      you add an extras pack or upgrade your plan — nothing is charged automatically.
+    </p>
+    <p>Review your usage, add an extras pack, or upgrade your plan on your <a href="{{billingUrl}}">billing dashboard</a>.</p>
+    <br />
+    <p>The <b>{{appName}}</b> Team.</p>
+    <br />
+    <i style="color: #9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
+  </body>
+</html>

--- a/config/templates/org-member-added.html
+++ b/config/templates/org-member-added.html
@@ -13,6 +13,7 @@
           <a
             href="{{url}}"
             target="_blank"
+            rel="noopener noreferrer"
             style="
               display: inline-block;
               padding: 12px 28px;

--- a/config/templates/org-member-added.html
+++ b/config/templates/org-member-added.html
@@ -1,8 +1,35 @@
-<!DOCTYPE html>
-<html lang="en"><head><title>{{appName}} invitation</title></head>
-<body>
-  <p>Hello {{displayName}},</p>
-  <p>You have been invited to join <b>{{orgName}}</b> on {{appName}}.</p>
-  <p>Review and accept the invitation here: {{url}}</p>
-  <p>The <b>{{appName}}</b> Team.</p>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>{{appName}} invitation</title>
+  </head>
+  <body>
+    <p>Hello {{displayName}},</p>
+    <p>You have been invited to join <b>{{orgName}}</b> on {{appName}}.</p>
+    <p>Review and accept the invitation:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0">
+      <tr>
+        <td align="center" bgcolor="#1a1a1a" style="border-radius: 6px">
+          <a
+            href="{{url}}"
+            target="_blank"
+            style="
+              display: inline-block;
+              padding: 12px 28px;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 16px;
+              font-weight: bold;
+              line-height: 20px;
+              color: #ffffff;
+              text-decoration: none;
+              border-radius: 6px;
+            "
+            >Accept invitation</a
+          >
+        </td>
+      </tr>
+    </table>
+    <p style="font-size: 13px; color: #9b9b9b">Button not working? <a href="{{url}}">{{url}}</a></p>
+    <p>The <b>{{appName}}</b> Team.</p>
+  </body>
+</html>

--- a/config/templates/org-request-approved.html
+++ b/config/templates/org-request-approved.html
@@ -1,8 +1,12 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello {{displayName}},</p>
-  <p>Your request to join <b>{{orgName}}</b> on {{appName}} has been approved.</p>
-  <p>You can now access the organization.</p>
-  <p>The <b>{{appName}}</b> Team.</p>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello {{displayName}},</p>
+    <p>Your request to join <b>{{orgName}}</b> on {{appName}} has been approved.</p>
+    <p>You can now access the organization.</p>
+    <p>The <b>{{appName}}</b> Team.</p>
+  </body>
+</html>

--- a/config/templates/org-request-new.html
+++ b/config/templates/org-request-new.html
@@ -1,8 +1,35 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello,</p>
-  <p><b>{{requesterName}}</b> ({{requesterEmail}}) has requested to join your organization <b>{{orgName}}</b> on {{appName}}.</p>
-  <p>Review this request in your dashboard: {{url}}</p>
-  <p>The <b>{{appName}}</b> Team.</p>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello,</p>
+    <p><b>{{requesterName}}</b> ({{requesterEmail}}) has requested to join your organization <b>{{orgName}}</b> on {{appName}}.</p>
+    <p>Review this request in your dashboard:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0">
+      <tr>
+        <td align="center" bgcolor="#1a1a1a" style="border-radius: 6px">
+          <a
+            href="{{url}}"
+            target="_blank"
+            style="
+              display: inline-block;
+              padding: 12px 28px;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 16px;
+              font-weight: bold;
+              line-height: 20px;
+              color: #ffffff;
+              text-decoration: none;
+              border-radius: 6px;
+            "
+            >Review request</a
+          >
+        </td>
+      </tr>
+    </table>
+    <p style="font-size: 13px; color: #9b9b9b">Button not working? <a href="{{url}}">{{url}}</a></p>
+    <p>The <b>{{appName}}</b> Team.</p>
+  </body>
+</html>

--- a/config/templates/org-request-new.html
+++ b/config/templates/org-request-new.html
@@ -13,6 +13,7 @@
           <a
             href="{{url}}"
             target="_blank"
+            rel="noopener noreferrer"
             style="
               display: inline-block;
               padding: 12px 28px;

--- a/config/templates/org-request-rejected.html
+++ b/config/templates/org-request-rejected.html
@@ -1,7 +1,11 @@
-<!DOCTYPE html>
-<html lang="en"><head><title></title></head>
-<body>
-  <p>Hello {{displayName}},</p>
-  <p>Your request to join <b>{{orgName}}</b> on {{appName}} has been declined.</p>
-  <p>The <b>{{appName}}</b> Team.</p>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Hello {{displayName}},</p>
+    <p>Your request to join <b>{{orgName}}</b> on {{appName}} has been declined.</p>
+    <p>The <b>{{appName}}</b> Team.</p>
+  </body>
+</html>

--- a/config/templates/reset-password-confirm-email.html
+++ b/config/templates/reset-password-confirm-email.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title></title>
@@ -6,15 +6,9 @@
 
   <body>
     <p>Dear {{displayName}},</p>
-    <p>
-      This is a confirmation that the password for your account has just been
-      changed
-    </p>
+    <p>This is a confirmation that the password for your account has just been changed</p>
     <p>The <b>{{appName}}</b> Support Team.</p>
     <br />
-    <i style="color: #9b9b9b"
-      >Please do not reply to this email, you can contact us
-      <a href="mailto:{{appContact}}">here</a>.</i
-    >
+    <i style="color: #9b9b9b">Please do not reply to this email, you can contact us <a href="mailto:{{appContact}}">here</a>.</i>
   </body>
 </html>

--- a/config/templates/reset-password-email.html
+++ b/config/templates/reset-password-email.html
@@ -7,7 +7,22 @@
   <body>
     <p>Dear {{displayName}},</p>
     <p>You have requested to reset your password on {{appName}}</p>
-    <p>Please visit this url to reset your password: {{url}}</p>
+    <p>Click the button below to choose a new password:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0">
+      <tr>
+        <td align="center" bgcolor="#1a1a1a" style="border-radius: 6px">
+          <a
+            href="{{url}}"
+            target="_blank"
+            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            >Reset password</a
+          >
+        </td>
+      </tr>
+    </table>
+    <p style="font-size: 13px; color: #9b9b9b">
+      Button not working? <a href="{{url}}">{{url}}</a>
+    </p>
     <p>The <b>{{appName}}</b> Support Team.</p>
     <br />
     <i style="color: #9b9b9b"

--- a/config/templates/reset-password-email.html
+++ b/config/templates/reset-password-email.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title></title>
@@ -14,20 +14,28 @@
           <a
             href="{{url}}"
             target="_blank"
-            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            rel="noopener noreferrer"
+            style="
+              display: inline-block;
+              padding: 12px 28px;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 16px;
+              font-weight: bold;
+              line-height: 20px;
+              color: #ffffff;
+              text-decoration: none;
+              border-radius: 6px;
+            "
             >Reset password</a
           >
         </td>
       </tr>
     </table>
-    <p style="font-size: 13px; color: #9b9b9b">
-      Button not working? <a href="{{url}}">{{url}}</a>
-    </p>
+    <p style="font-size: 13px; color: #9b9b9b">Button not working? <a href="{{url}}">{{url}}</a></p>
     <p>The <b>{{appName}}</b> Support Team.</p>
     <br />
     <i style="color: #9b9b9b"
-      >If you didn't make this request, you can ignore this email. Please do not
-      reply to this email, you can contact us
+      >If you didn't make this request, you can ignore this email. Please do not reply to this email, you can contact us
       <a href="mailto:{{appContact}}">here</a>.</i
     >
   </body>

--- a/config/templates/signup-invite.html
+++ b/config/templates/signup-invite.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>You've been invited — complete your signup</title>
@@ -13,20 +13,28 @@
           <a
             href="{{url}}"
             target="_blank"
-            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            rel="noopener noreferrer"
+            style="
+              display: inline-block;
+              padding: 12px 28px;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 16px;
+              font-weight: bold;
+              line-height: 20px;
+              color: #ffffff;
+              text-decoration: none;
+              border-radius: 6px;
+            "
             >Create your account</a
           >
         </td>
       </tr>
     </table>
-    <p style="font-size: 13px; color: #9b9b9b">
-      Button not working? <a href="{{url}}">{{url}}</a>
-    </p>
+    <p style="font-size: 13px; color: #9b9b9b">Button not working? <a href="{{url}}">{{url}}</a></p>
     <p>The <b>{{appName}}</b> Team.</p>
     <br />
     <i style="color: #9b9b9b"
-      >If you weren't expecting this invitation you can ignore this email. Please
-      do not reply to this email, you can contact us
+      >If you weren't expecting this invitation you can ignore this email. Please do not reply to this email, you can contact us
       <a href="mailto:{{appContact}}">here</a>.</i
     >
   </body>

--- a/config/templates/signup-invite.html
+++ b/config/templates/signup-invite.html
@@ -6,7 +6,22 @@
   <body>
     <p>Hello,</p>
     <p>You've been invited to join <b>{{appName}}</b>.</p>
-    <p>Click here to create your account: <a href="{{url}}">{{url}}</a></p>
+    <p>Click the button below to create your account:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0">
+      <tr>
+        <td align="center" bgcolor="#1a1a1a" style="border-radius: 6px">
+          <a
+            href="{{url}}"
+            target="_blank"
+            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            >Create your account</a
+          >
+        </td>
+      </tr>
+    </table>
+    <p style="font-size: 13px; color: #9b9b9b">
+      Button not working? <a href="{{url}}">{{url}}</a>
+    </p>
     <p>The <b>{{appName}}</b> Team.</p>
     <br />
     <i style="color: #9b9b9b"

--- a/config/templates/verify-email.html
+++ b/config/templates/verify-email.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title></title>
@@ -14,21 +14,29 @@
           <a
             href="{{url}}"
             target="_blank"
-            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            rel="noopener noreferrer"
+            style="
+              display: inline-block;
+              padding: 12px 28px;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 16px;
+              font-weight: bold;
+              line-height: 20px;
+              color: #ffffff;
+              text-decoration: none;
+              border-radius: 6px;
+            "
             >Verify email address</a
           >
         </td>
       </tr>
     </table>
-    <p style="font-size: 13px; color: #9b9b9b">
-      Button not working? <a href="{{url}}">{{url}}</a>
-    </p>
+    <p style="font-size: 13px; color: #9b9b9b">Button not working? <a href="{{url}}">{{url}}</a></p>
     <p>This link will expire in 24 hours.</p>
     <p>The <b>{{appName}}</b> Support Team.</p>
     <br />
     <i style="color: #9b9b9b"
-      >If you didn't create this account, you can ignore this email. Please do
-      not reply to this email, you can contact us
+      >If you didn't create this account, you can ignore this email. Please do not reply to this email, you can contact us
       <a href="mailto:{{appContact}}">here</a>.</i
     >
   </body>

--- a/config/templates/verify-email.html
+++ b/config/templates/verify-email.html
@@ -7,7 +7,22 @@
   <body>
     <p>Dear {{displayName}},</p>
     <p>Thank you for signing up on {{appName}}.</p>
-    <p>Please verify your email address by visiting this url: {{url}}</p>
+    <p>Please verify your email address by clicking the button below:</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 24px 0">
+      <tr>
+        <td align="center" bgcolor="#1a1a1a" style="border-radius: 6px">
+          <a
+            href="{{url}}"
+            target="_blank"
+            style="display: inline-block; padding: 12px 28px; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 20px; color: #ffffff; text-decoration: none; border-radius: 6px"
+            >Verify email address</a
+          >
+        </td>
+      </tr>
+    </table>
+    <p style="font-size: 13px; color: #9b9b9b">
+      Button not working? <a href="{{url}}">{{url}}</a>
+    </p>
     <p>This link will expire in 24 hours.</p>
     <p>The <b>{{appName}}</b> Support Team.</p>
     <br />


### PR DESCRIPTION
Transactional emails printed the action URL as raw inline text (reads as phishing, adds friction). Replace with a bulletproof (table-based, inline-CSS) CTA button + a small fallback 'paste this link' line, across all 5 templates with a bare {{url}}: verify-email, reset-password, signup-invite, org-request-new, org-member-added. Brand-neutral; placeholders intact.

Closes #3917