### PR TITLE
fix(auth): hash new password in updatePassword to stop plaintext storage (#3925)

### DIFF
--- a/modules/auth/controllers/auth.password.controller.js
+++ b/modules/auth/controllers/auth.password.controller.js
@@ -163,7 +163,8 @@ const updatePassword = async (req, res) => {
     if (!(await AuthService.comparePassword(req.body.currentPassword, user.password)))
       return responses.error(res, 422, 'Unprocessable Entity', 'Current password is incorrect')();
     if (req.body.newPassword !== req.body.verifyPassword) return responses.error(res, 422, 'Unprocessable Entity', 'Passwords do not match')();
-    password = AuthService.checkPassword(req.body.newPassword);
+    const checkedPassword = AuthService.checkPassword(req.body.newPassword);
+    password = await AuthService.hashPassword(checkedPassword);
     user = await UserService.update(user, { password }, 'recover');
     return res
       .status(200)

--- a/modules/users/tests/user.account.integration.tests.js
+++ b/modules/users/tests/user.account.integration.tests.js
@@ -76,17 +76,37 @@ describe('User integration tests:', () => {
     });
 
     test('should be able to change user own password successfully', async () => {
+      const newPassword = 'Waos.azs@^:SA3$&2';
       try {
         const result = await agent
           .post('/api/users/password')
           .send({
-            newPassword: 'Waos.azs@^:SA3$&2',
-            verifyPassword: 'Waos.azs@^:SA3$&2',
+            newPassword,
+            verifyPassword: newPassword,
             currentPassword: credentials[0].password,
           })
           .expect(200);
         expect(result.body.message).toBe('Password changed successfully');
       } catch (err) {
+        expect(err).toBeFalsy();
+      }
+
+      // Regression guard (#3925): the STORED password must be a bcrypt hash,
+      // never the raw plaintext. updatePassword previously persisted the
+      // plaintext verbatim (the model has no pre-save hash hook), which both
+      // stored credentials in the clear and locked the user out on next signin.
+      // This shipped undetected precisely because no test read the persisted
+      // value — assert the hash format at rest, then confirm via signin oracle.
+      try {
+        const stored = await UserService.getBrut({ id: user.id });
+        expect(stored.password).toMatch(/^\$2[aby]\$/);
+        expect(stored.password).not.toBe(newPassword);
+
+        // Runtime oracle: the NEW password authenticates, the OLD one does not.
+        await request(app).post('/api/auth/signin').send({ email: credentials[0].email, password: newPassword }).expect(200);
+        await request(app).post('/api/auth/signin').send({ email: credentials[0].email, password: credentials[0].password }).expect(401);
+      } catch (err) {
+        console.log(err);
         expect(err).toBeFalsy();
       }
     });


### PR DESCRIPTION
## Problem
The change-password endpoint validated strength then persisted the **raw** password — the User model has no pre-save hash hook, so the new password was stored in plaintext, and the next `bcrypt.compare` login failed against it (self-lockout). The sibling `reset()` in the same file hashes correctly.

## Fix
Hash before persisting, mirroring `reset()`: `checkPassword` → `hashPassword` → `UserService.update`. Inside the existing `try`, so the weak-password 422 path is unchanged; response still strips the password via `removeSensitive`.

## Test
Strengthened the success-path integration test to read the stored value (asserts it matches `/^$2[aby]$/`, not the plaintext) and round-trip a real signin with the new password (200) and the old (401). Verified red-green: reverting the fix makes the test fail on the plaintext value.

## Follow-up (out of scope, downstream ops)
Remediating any already-corrupted plaintext rows in a running deployment is a downstream-operations task, not part of this devkit fix.

Closes #3925

https://claude.ai/code/session_01V1mhCDsSUnn3WGtevd3YFX
