### PR TITLE
fix(log): redact single-use path tokens in the morgan access log

### DIFF
--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -40,18 +40,19 @@ const redactPathSecrets = (path) => {
 };
 
 /**
- * @desc Redact sensitive query-string parameters from a request URL for logging.
- * Preserves the path and every other query parameter; only the value of a
- * sensitive key is replaced with `REDACTED`. Tolerant of a missing/empty URL and
- * URLs with no query string (returned unchanged). Pure + synchronous so it is
- * safe to call on every logged request.
+ * @desc Redact single-use secrets from a request URL for logging: sensitive
+ * PATH segments (see `redactPathSecrets`) AND sensitive query-string
+ * parameters. Preserves every other path segment and query parameter; only
+ * matching path segments / query values are replaced with `REDACTED`.
+ * Tolerant of a missing/empty URL and URLs with no query string. Pure +
+ * synchronous so it is safe to call on every logged request.
  * @param {String} url - the raw request URL (path + optional query string)
- * @returns {String} the URL with sensitive query values redacted
+ * @returns {String} the URL with sensitive path segments and query values redacted
  */
 const redactUrl = (url) => {
   if (!url || typeof url !== 'string') return url;
   const queryStart = url.indexOf('?');
-  if (queryStart === -1) return url;
+  if (queryStart === -1) return redactPathSecrets(url);
 
   const pathPart = url.slice(0, queryStart);
   const queryPart = url.slice(queryStart + 1);
@@ -66,7 +67,7 @@ const redactUrl = (url) => {
     })
     .join('&');
 
-  return `${pathPart}?${redactedQuery}`;
+  return `${redactPathSecrets(pathPart)}?${redactedQuery}`;
 };
 
 export default redactUrl;

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -14,12 +14,41 @@ describe('redactUrl', () => {
     expect(redactUrl('/x?inviteToken=secret&bar=2')).toBe('/x?inviteToken=REDACTED&bar=2');
   });
 
-  test('leaves a URL without a query string unchanged', () => {
+  test('leaves a non-sensitive URL without a query string unchanged', () => {
     expect(redactUrl('/api/auth/signup')).toBe('/api/auth/signup');
   });
 
   test('leaves a URL whose query has no sensitive key unchanged', () => {
     expect(redactUrl('/api/users?page=2&perPage=10')).toBe('/api/users?page=2&perPage=10');
+  });
+
+  test('redacts a reset-token path with no query string', () => {
+    expect(redactUrl('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+  });
+
+  test('redacts a verify-email-token path with no query string', () => {
+    expect(redactUrl('/api/auth/verify-email/SECRETTOKEN')).toBe('/api/auth/verify-email/REDACTED');
+  });
+
+  test('redacts an invitation verify-token path with no query string', () => {
+    expect(redactUrl('/api/auth/invitations/verify/SECRETTOKEN')).toBe('/api/auth/invitations/verify/REDACTED');
+    expect(redactUrl('/api/invitations/verify/SECRETTOKEN')).toBe('/api/invitations/verify/REDACTED');
+  });
+
+  test('redacts a reset-token path when a query string is also present', () => {
+    expect(redactUrl('/api/auth/reset/SECRETTOKEN?foo=1')).toBe('/api/auth/reset/REDACTED?foo=1');
+  });
+
+  test('redacts a verify-email-token path when a query string is also present', () => {
+    expect(redactUrl('/api/auth/verify-email/SECRETTOKEN?foo=1')).toBe('/api/auth/verify-email/REDACTED?foo=1');
+  });
+
+  test('redacts an invitation verify-token path when a query string is also present', () => {
+    expect(redactUrl('/api/auth/invitations/verify/SECRETTOKEN?foo=1')).toBe('/api/auth/invitations/verify/REDACTED?foo=1');
+  });
+
+  test('redacts both a path secret and a query secret in the same URL', () => {
+    expect(redactUrl('/api/auth/reset/SECRETTOKEN?inviteToken=abc123')).toBe('/api/auth/reset/REDACTED?inviteToken=REDACTED');
   });
 
   test('handles a bare sensitive key with no value (no = sign)', () => {

--- a/lib/services/express.js
+++ b/lib/services/express.js
@@ -198,9 +198,10 @@ const initMiddleware = (app) => {
     morgan.token('email', (req) => _.get(req, 'user.email') || 'Unknown email');
     morgan.token('requestId', (req) => req.id || '-');
     morgan.token('orgId', (req) => _.get(req, 'organization.id') || _.get(req, 'organization._id', '-'));
-    // Override the built-in :url token to scrub single-use secrets (e.g. inviteToken)
-    // from the query string before they hit the log stream. Both the dev and prod
-    // log patterns interpolate :url, so the override covers every logged request.
+    // Override the built-in :url token to scrub single-use secrets — both path
+    // tokens (e.g. /auth/reset/:token) and query params (e.g. inviteToken) —
+    // before they hit the log stream. Both the dev and prod log patterns
+    // interpolate :url, so the override covers every logged request.
     morgan.token('url', (req) => redactUrl(req.originalUrl || req.url));
     app.use(morgan(logger.getLogFormat(), logger.getMorganOptions()));
   }


### PR DESCRIPTION
## Summary

- What changed: `redactPathSecrets()` now runs on **both** branches of `redactUrl()` (with and without a query string), so single-use tokens carried as PATH parameters — password-reset, email-verify and invitation links — are redacted before reaching the morgan access log.
- Why: `redactUrl()` only scrubbed the query string. A URL with no `?` (e.g. `GET /api/auth/reset/:token`) was returned verbatim, so a legitimate click on a reset/verify-email/invitation link wrote the still-valid, replayable token straight into the server access log. #3935 already redacted the analytics sink but missed this access-log path.
- Related issues: Closes #3951

## Scope

- Module(s) impacted: `lib/helpers/redactUrl.js`, `lib/services/express.js` (morgan `:url` token wiring, comment only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: 7 new unit tests added (red-green: each failed against the pre-fix `redactUrl()` before the fix, now pass) covering reset/verify-email/invitation path tokens, with and without a trailing query string, and a combined path+query redaction case.
- Mergeability considerations: none — additive, no downstream config surface changed.
- Follow-up tasks (optional): none.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive single-use tokens in URL paths are now redacted from logs.
  * Sensitive query parameters continue to be scrubbed, including when combined with secrets in the URL path.
  * Non-sensitive URLs and query parameters remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->