### PR TITLE
refactor(log): source sensitive redaction lists from config as pure extensions

### DIFF
--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -81,19 +81,22 @@ const config = {
       maxFiles: 2,
       json: false,
     },
-    // Path segments consumed by `lib/helpers/redactUrl.js` (`redactPathSecrets`)
-    // to redact single-use secrets carried as a PATH parameter (e.g.
-    // `/api/auth/reset/:token`). Extension-only: unioned with the built-in
-    // defaults in lib/helpers/redactUrl.js, so a module adds its own
-    // token-bearing route here without editing shared lib/ or duplicating
-    // ['reset', 'verify', 'verify-email'], which already apply unconditionally.
-    sensitivePathMarkers: [],
-    // Query-string parameter names consumed by `lib/helpers/redactUrl.js`
-    // (`redactUrl`) to redact single-use secrets carried in the query string
-    // (e.g. `POST /api/auth/signup?inviteToken=…`). Extension-only: unioned
-    // with the built-in defaults in lib/helpers/redactUrl.js (already
-    // includes 'inviteToken' unconditionally).
-    sensitiveQueryKeys: [],
+    // Redaction extension points (optional — do NOT declare either key here,
+    // not even as `[]`): a module or project config may set
+    // `log.sensitivePathMarkers` / `log.sensitiveQueryKeys` (array of
+    // strings) to extend the built-in redaction lists consumed by
+    // `lib/helpers/redactUrl.js` (`redactPathSecrets` for PATH segments e.g.
+    // `/api/auth/reset/:token`; `redactUrl` for query params e.g.
+    // `?inviteToken=…`). Values are UNIONED with the built-in defaults there
+    // (['reset', 'verify', 'verify-email'] / ['inviteToken']), never
+    // replacing them.
+    //
+    // These two keys are intentionally OMITTED from this file: `deepMerge`
+    // (config/index.js) replaces arrays wholesale rather than merging them,
+    // so an explicit value here (Layer 2: global defaults) would silently
+    // clobber a module's own extension of the same key (Layer 1: module
+    // config) instead of unioning with it. An omitted key lets a Layer-1
+    // value pass through untouched to redactUrl.js.
   },
   csrf: {
     csrf: false,

--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -83,13 +83,17 @@ const config = {
     },
     // Path segments consumed by `lib/helpers/redactUrl.js` (`redactPathSecrets`)
     // to redact single-use secrets carried as a PATH parameter (e.g.
-    // `/api/auth/reset/:token`). A module that adds its own token-bearing route
-    // extends this list from its own config instead of editing shared lib/.
-    sensitivePathMarkers: ['reset', 'verify', 'verify-email'],
+    // `/api/auth/reset/:token`). Extension-only: unioned with the built-in
+    // defaults in lib/helpers/redactUrl.js, so a module adds its own
+    // token-bearing route here without editing shared lib/ or duplicating
+    // ['reset', 'verify', 'verify-email'], which already apply unconditionally.
+    sensitivePathMarkers: [],
     // Query-string parameter names consumed by `lib/helpers/redactUrl.js`
     // (`redactUrl`) to redact single-use secrets carried in the query string
-    // (e.g. `POST /api/auth/signup?inviteToken=…`).
-    sensitiveQueryKeys: ['inviteToken'],
+    // (e.g. `POST /api/auth/signup?inviteToken=…`). Extension-only: unioned
+    // with the built-in defaults in lib/helpers/redactUrl.js (already
+    // includes 'inviteToken' unconditionally).
+    sensitiveQueryKeys: [],
   },
   csrf: {
     csrf: false,

--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -81,6 +81,15 @@ const config = {
       maxFiles: 2,
       json: false,
     },
+    // Path segments consumed by `lib/helpers/redactUrl.js` (`redactPathSecrets`)
+    // to redact single-use secrets carried as a PATH parameter (e.g.
+    // `/api/auth/reset/:token`). A module that adds its own token-bearing route
+    // extends this list from its own config instead of editing shared lib/.
+    sensitivePathMarkers: ['reset', 'verify', 'verify-email'],
+    // Query-string parameter names consumed by `lib/helpers/redactUrl.js`
+    // (`redactUrl`) to redact single-use secrets carried in the query string
+    // (e.g. `POST /api/auth/signup?inviteToken=…`).
+    sensitiveQueryKeys: ['inviteToken'],
   },
   csrf: {
     csrf: false,

--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -17,6 +17,28 @@ const DEFAULT_SENSITIVE_QUERY_KEYS = ['inviteToken'];
 const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
 
 /**
+ * @desc Sanitize a config-provided redaction list so it is always an array
+ * before it is spread into the union below. A config typo (an object, a
+ * number, a bare string, …) must never throw at module-eval time — that
+ * would crash the whole app on boot — and must never silently degrade into
+ * a per-character array either (spreading a string splits it into individual
+ * characters, which is not the extension list a config author intended and
+ * would slip straight past an `Array.isArray`-less spread). Falls back to
+ * an empty array, which is a no-op for the union below (identical to an
+ * absent/missing key — the built-in defaults still apply), and logs a
+ * warning identifying the offending config path so the typo gets noticed.
+ * @param {*} value - the raw `config.log.<key>` value
+ * @param {String} label - dotted config path for the warning message, e.g. 'log.sensitivePathMarkers'
+ * @returns {Array} `value` unchanged when it is already an array, otherwise `[]`
+ */
+const sanitizeConfigList = (value, label) => {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  console.warn(`[redactUrl] config.${label} ignored: expected an array, got ${typeof value}`);
+  return [];
+};
+
+/**
  * Sensitive query-string parameters that must never reach the request log.
  *
  * `inviteToken` rides the query string of `POST /api/auth/signup?inviteToken=…`
@@ -27,10 +49,11 @@ const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
  * Union of `DEFAULT_SENSITIVE_QUERY_KEYS` and `config.log.sensitiveQueryKeys`:
  * a module/downstream project extends the set purely additively from its own
  * config, without editing this shared helper. Deduplicated via `Set`. Missing
- * config, a missing key, or an explicit empty array all resolve to exactly the
- * built-in defaults — config can never shrink or clobber this list.
+ * config, a missing key, an explicit empty array, or a malformed (non-array)
+ * value all resolve to exactly the built-in defaults — config can never
+ * shrink or clobber this list.
  */
-const SENSITIVE_QUERY_KEYS = [...new Set([...DEFAULT_SENSITIVE_QUERY_KEYS, ...(config?.log?.sensitiveQueryKeys ?? [])])];
+const SENSITIVE_QUERY_KEYS = [...new Set([...DEFAULT_SENSITIVE_QUERY_KEYS, ...sanitizeConfigList(config?.log?.sensitiveQueryKeys, 'log.sensitiveQueryKeys')])];
 
 /**
  * Path segments that are immediately followed by a single-use secret carried as
@@ -43,10 +66,11 @@ const SENSITIVE_QUERY_KEYS = [...new Set([...DEFAULT_SENSITIVE_QUERY_KEYS, ...(c
  * Union of `DEFAULT_SENSITIVE_PATH_MARKERS` and `config.log.sensitivePathMarkers`:
  * a module/downstream project extends the set purely additively from its own
  * config, without editing this shared helper. Deduplicated via `Set`. Missing
- * config, a missing key, or an explicit empty array all resolve to exactly the
- * built-in defaults — config can never shrink or clobber this list.
+ * config, a missing key, an explicit empty array, or a malformed (non-array)
+ * value all resolve to exactly the built-in defaults — config can never
+ * shrink or clobber this list.
  */
-const SENSITIVE_PATH_MARKERS = [...new Set([...DEFAULT_SENSITIVE_PATH_MARKERS, ...(config?.log?.sensitivePathMarkers ?? [])])];
+const SENSITIVE_PATH_MARKERS = [...new Set([...DEFAULT_SENSITIVE_PATH_MARKERS, ...sanitizeConfigList(config?.log?.sensitivePathMarkers, 'log.sensitivePathMarkers')])];
 
 /**
  * @desc Redact single-use secrets embedded as PATH parameters. Any segment that

--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -1,12 +1,33 @@
 /**
+ * Module dependencies.
+ */
+import config from '../../config/index.js';
+
+/**
+ * Built-in fallback values. `lib/` must stay module-agnostic — the real source
+ * of truth is `config.log.sensitiveQueryKeys` / `config.log.sensitivePathMarkers`
+ * (see below), which a module extends from its own config without editing this
+ * shared helper. These literals are the ultimate fallback: if config is absent
+ * or does not define the key (e.g. an edge context that builds a partial config
+ * object), redaction still degrades safely to the current known-sensitive
+ * routes instead of silently redacting nothing.
+ */
+const DEFAULT_SENSITIVE_QUERY_KEYS = ['inviteToken'];
+const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
+
+/**
  * Sensitive query-string parameters that must never reach the request log.
  *
  * `inviteToken` rides the query string of `POST /api/auth/signup?inviteToken=…`
  * (the Vue client puts it there, not in the body). The morgan log pattern logs
  * `:url`, so without redaction a live single-use invite token lands in prod logs
  * (and any log shipper / aggregator downstream). Redact it to `REDACTED`.
+ *
+ * Sourced from `config.log.sensitiveQueryKeys` (extendable per-module without
+ * editing this shared helper); falls back to `DEFAULT_SENSITIVE_QUERY_KEYS`
+ * when config/the key is absent so redaction never silently degrades to nothing.
  */
-const SENSITIVE_QUERY_KEYS = ['inviteToken'];
+const SENSITIVE_QUERY_KEYS = config?.log?.sensitiveQueryKeys ?? DEFAULT_SENSITIVE_QUERY_KEYS;
 
 /**
  * Path segments that are immediately followed by a single-use secret carried as
@@ -15,8 +36,12 @@ const SENSITIVE_QUERY_KEYS = ['inviteToken'];
  * `GET /api/*(auth/)?invitations/verify/:token` embed a still-valid token
  * directly in the path, so the segment right after one of these markers must be
  * redacted before the URL reaches any log/analytics store.
+ *
+ * Sourced from `config.log.sensitivePathMarkers` (extendable per-module without
+ * editing this shared helper); falls back to `DEFAULT_SENSITIVE_PATH_MARKERS`
+ * when config/the key is absent so redaction never silently degrades to nothing.
  */
-const SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
+const SENSITIVE_PATH_MARKERS = config?.log?.sensitivePathMarkers ?? DEFAULT_SENSITIVE_PATH_MARKERS;
 
 /**
  * @desc Redact single-use secrets embedded as PATH parameters. Any segment that

--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -4,13 +4,14 @@
 import config from '../../config/index.js';
 
 /**
- * Built-in fallback values. `lib/` must stay module-agnostic — the real source
- * of truth is `config.log.sensitiveQueryKeys` / `config.log.sensitivePathMarkers`
- * (see below), which a module extends from its own config without editing this
- * shared helper. These literals are the ultimate fallback: if config is absent
- * or does not define the key (e.g. an edge context that builds a partial config
- * object), redaction still degrades safely to the current known-sensitive
- * routes instead of silently redacting nothing.
+ * Built-in, authoritative base lists. `lib/` must stay module-agnostic, so a
+ * module/downstream project never edits this shared helper to add its own
+ * token-bearing routes — it extends `config.log.sensitiveQueryKeys` /
+ * `config.log.sensitivePathMarkers` (see below) instead. These built-ins
+ * ALWAYS apply, unioned with whatever config contributes: config can only
+ * ADD markers/keys, never remove or replace these, so redaction can never be
+ * silently disabled (an absent key or an explicit empty array in config both
+ * degrade to exactly these defaults, never to nothing).
  */
 const DEFAULT_SENSITIVE_QUERY_KEYS = ['inviteToken'];
 const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
@@ -23,11 +24,13 @@ const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
  * `:url`, so without redaction a live single-use invite token lands in prod logs
  * (and any log shipper / aggregator downstream). Redact it to `REDACTED`.
  *
- * Sourced from `config.log.sensitiveQueryKeys` (extendable per-module without
- * editing this shared helper); falls back to `DEFAULT_SENSITIVE_QUERY_KEYS`
- * when config/the key is absent so redaction never silently degrades to nothing.
+ * Union of `DEFAULT_SENSITIVE_QUERY_KEYS` and `config.log.sensitiveQueryKeys`:
+ * a module/downstream project extends the set purely additively from its own
+ * config, without editing this shared helper. Deduplicated via `Set`. Missing
+ * config, a missing key, or an explicit empty array all resolve to exactly the
+ * built-in defaults — config can never shrink or clobber this list.
  */
-const SENSITIVE_QUERY_KEYS = config?.log?.sensitiveQueryKeys ?? DEFAULT_SENSITIVE_QUERY_KEYS;
+const SENSITIVE_QUERY_KEYS = [...new Set([...DEFAULT_SENSITIVE_QUERY_KEYS, ...(config?.log?.sensitiveQueryKeys ?? [])])];
 
 /**
  * Path segments that are immediately followed by a single-use secret carried as
@@ -37,11 +40,13 @@ const SENSITIVE_QUERY_KEYS = config?.log?.sensitiveQueryKeys ?? DEFAULT_SENSITIV
  * directly in the path, so the segment right after one of these markers must be
  * redacted before the URL reaches any log/analytics store.
  *
- * Sourced from `config.log.sensitivePathMarkers` (extendable per-module without
- * editing this shared helper); falls back to `DEFAULT_SENSITIVE_PATH_MARKERS`
- * when config/the key is absent so redaction never silently degrades to nothing.
+ * Union of `DEFAULT_SENSITIVE_PATH_MARKERS` and `config.log.sensitivePathMarkers`:
+ * a module/downstream project extends the set purely additively from its own
+ * config, without editing this shared helper. Deduplicated via `Set`. Missing
+ * config, a missing key, or an explicit empty array all resolve to exactly the
+ * built-in defaults — config can never shrink or clobber this list.
  */
-const SENSITIVE_PATH_MARKERS = config?.log?.sensitivePathMarkers ?? DEFAULT_SENSITIVE_PATH_MARKERS;
+const SENSITIVE_PATH_MARKERS = [...new Set([...DEFAULT_SENSITIVE_PATH_MARKERS, ...(config?.log?.sensitivePathMarkers ?? [])])];
 
 /**
  * @desc Redact single-use secrets embedded as PATH parameters. Any segment that

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -1,5 +1,6 @@
 import { jest, describe, test, expect } from '@jest/globals';
 import redactUrl, { SENSITIVE_QUERY_KEYS, SENSITIVE_PATH_MARKERS, redactPathSecrets } from '../redactUrl.js';
+import developmentConfig from '../../../config/defaults/development.config.js';
 
 describe('redactUrl', () => {
   test('redacts an inviteToken value, preserving the path', () => {
@@ -184,5 +185,54 @@ describe('redactUrl config sourcing (#3953)', () => {
     const mod = await loadWithConfig(undefined);
     expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
     expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+  });
+
+  /**
+   * A shape mismatch on the config value (e.g. a typo'd object instead of an
+   * array) must degrade the same way an absent/empty value does — never throw
+   * at module-eval time (`[...{}]` is not iterable, which would crash the
+   * whole app on boot) and never silently spread a string char-by-char
+   * (`[...'oops']` → `['o','o','p','s']`, which would over-redact app-wide).
+   */
+  test('an object value for sensitivePathMarkers is ignored — defaults still apply, no throw, warns', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await loadWithConfig({
+      log: { sensitivePathMarkers: { notAnArray: true } },
+    });
+    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
+    expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitivePathMarkers'));
+    warnSpy.mockRestore();
+  });
+
+  test('a string value for sensitiveQueryKeys is ignored (not spread char-by-char) — defaults still apply, no throw, warns', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await loadWithConfig({
+      log: { sensitiveQueryKeys: 'oops' },
+    });
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitiveQueryKeys'));
+    warnSpy.mockRestore();
+  });
+});
+
+/**
+ * Lockstep guard (#3953): `config/defaults/development.config.js` must never
+ * declare `log.sensitivePathMarkers` / `log.sensitiveQueryKeys` again, not
+ * even as `[]`. `deepMerge` (config/index.js) replaces arrays wholesale
+ * instead of merging them, so a Layer-2 (global defaults) value — including
+ * an explicit empty array — would silently clobber a Layer-1 (module config)
+ * extension of the same key. Omitting the key entirely is what lets a
+ * module's value pass through untouched to `lib/helpers/redactUrl.js`. This
+ * test pins that fix against regression.
+ */
+describe('development.config.js lockstep guard (#3953)', () => {
+  test('does not declare log.sensitivePathMarkers', () => {
+    expect(Object.prototype.hasOwnProperty.call(developmentConfig.log, 'sensitivePathMarkers')).toBe(false);
+  });
+
+  test('does not declare log.sensitiveQueryKeys', () => {
+    expect(Object.prototype.hasOwnProperty.call(developmentConfig.log, 'sensitiveQueryKeys')).toBe(false);
   });
 });

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+import { jest, describe, test, expect } from '@jest/globals';
 import redactUrl, { SENSITIVE_QUERY_KEYS, SENSITIVE_PATH_MARKERS, redactPathSecrets } from '../redactUrl.js';
 
 describe('redactUrl', () => {
@@ -111,5 +111,57 @@ describe('redactPathSecrets', () => {
 
   test('exports the sensitive path markers', () => {
     expect(SENSITIVE_PATH_MARKERS).toEqual(expect.arrayContaining(['reset', 'verify', 'verify-email']));
+  });
+});
+
+/**
+ * `SENSITIVE_QUERY_KEYS` / `SENSITIVE_PATH_MARKERS` are read from
+ * `config.log.*` once, at module-evaluation time (#3953). These tests mock
+ * `config/index.js` and re-import the module fresh (via `jest.resetModules()`
+ * + dynamic `import()` — see `posthog-context.middleware.unit.tests.js` for
+ * the same pattern) to exercise both the config-honoring path and the
+ * fail-safe fallback path, without disturbing the static-import tests above
+ * (which exercise the real config's current defaults, unchanged).
+ */
+describe('redactUrl config sourcing (#3953)', () => {
+  /**
+   * Load a fresh instance of the module under a given mocked config.
+   * @param {Object|undefined} mockConfig - the value `config/index.js` default-exports
+   * @returns {Promise<Object>} the freshly-loaded module exports
+   */
+  const loadWithConfig = async (mockConfig) => {
+    jest.resetModules();
+    jest.unstable_mockModule('../../../config/index.js', () => ({ default: mockConfig }));
+    return import('../redactUrl.js');
+  };
+
+  test('honors a module-extended path marker from config', async () => {
+    const mod = await loadWithConfig({
+      log: { sensitivePathMarkers: ['reset', 'verify', 'verify-email', 'unsubscribe'] },
+    });
+    expect(mod.SENSITIVE_PATH_MARKERS).toContain('unsubscribe');
+    expect(mod.redactPathSecrets('/api/newsletter/unsubscribe/SECRETTOKEN')).toBe('/api/newsletter/unsubscribe/REDACTED');
+  });
+
+  test('honors a module-extended query key from config', async () => {
+    const mod = await loadWithConfig({
+      log: { sensitiveQueryKeys: ['inviteToken', 'magicToken'] },
+    });
+    expect(mod.SENSITIVE_QUERY_KEYS).toContain('magicToken');
+    expect(mod.default('/x?magicToken=secret')).toBe('/x?magicToken=REDACTED');
+  });
+
+  test('falls back to the built-in defaults when config.log is missing', async () => {
+    const mod = await loadWithConfig({});
+    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+    expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
+  });
+
+  test('falls back to the built-in defaults when config itself is undefined', async () => {
+    const mod = await loadWithConfig(undefined);
+    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
   });
 });

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -196,24 +196,30 @@ describe('redactUrl config sourcing (#3953)', () => {
    */
   test('an object value for sensitivePathMarkers is ignored — defaults still apply, no throw, warns', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const mod = await loadWithConfig({
-      log: { sensitivePathMarkers: { notAnArray: true } },
-    });
-    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
-    expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitivePathMarkers'));
-    warnSpy.mockRestore();
+    try {
+      const mod = await loadWithConfig({
+        log: { sensitivePathMarkers: { notAnArray: true } },
+      });
+      expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
+      expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitivePathMarkers'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test('a string value for sensitiveQueryKeys is ignored (not spread char-by-char) — defaults still apply, no throw, warns', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const mod = await loadWithConfig({
-      log: { sensitiveQueryKeys: 'oops' },
-    });
-    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
-    expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitiveQueryKeys'));
-    warnSpy.mockRestore();
+    try {
+      const mod = await loadWithConfig({
+        log: { sensitiveQueryKeys: 'oops' },
+      });
+      expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+      expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitiveQueryKeys'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -116,12 +116,17 @@ describe('redactPathSecrets', () => {
 
 /**
  * `SENSITIVE_QUERY_KEYS` / `SENSITIVE_PATH_MARKERS` are read from
- * `config.log.*` once, at module-evaluation time (#3953). These tests mock
- * `config/index.js` and re-import the module fresh (via `jest.resetModules()`
- * + dynamic `import()` — see `posthog-context.middleware.unit.tests.js` for
- * the same pattern) to exercise both the config-honoring path and the
- * fail-safe fallback path, without disturbing the static-import tests above
- * (which exercise the real config's current defaults, unchanged).
+ * `config.log.*` once, at module-evaluation time (#3953), and UNIONED with
+ * the built-in `DEFAULT_SENSITIVE_*` lists — config is extension-only, it can
+ * never shrink or clobber the built-ins (deepMerge replaces arrays wholesale,
+ * so a naive fallback would let a module-level config array silently clobber
+ * the global default instead of extending it; union sidesteps that entirely).
+ * These tests mock `config/index.js` and re-import the module fresh (via
+ * `jest.resetModules()` + dynamic `import()` — see
+ * `posthog-context.middleware.unit.tests.js` for the same pattern) to
+ * exercise the union, the empty-array no-op, and the absent-config fallback,
+ * without disturbing the static-import tests above (which exercise the real
+ * config's current defaults, unchanged).
  */
 describe('redactUrl config sourcing (#3953)', () => {
   /**
@@ -135,20 +140,36 @@ describe('redactUrl config sourcing (#3953)', () => {
     return import('../redactUrl.js');
   };
 
-  test('honors a module-extended path marker from config', async () => {
+  test('unions a module-extended path marker from config with the built-in defaults', async () => {
     const mod = await loadWithConfig({
-      log: { sensitivePathMarkers: ['reset', 'verify', 'verify-email', 'unsubscribe'] },
+      log: { sensitivePathMarkers: ['unsubscribe'] },
     });
-    expect(mod.SENSITIVE_PATH_MARKERS).toContain('unsubscribe');
+    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(expect.arrayContaining(['reset', 'verify', 'verify-email', 'unsubscribe']));
+    // built-in marker still redacts — extension never clobbers it
+    expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+    // config-added marker redacts too
     expect(mod.redactPathSecrets('/api/newsletter/unsubscribe/SECRETTOKEN')).toBe('/api/newsletter/unsubscribe/REDACTED');
   });
 
-  test('honors a module-extended query key from config', async () => {
+  test('unions a module-extended query key from config with the built-in defaults', async () => {
     const mod = await loadWithConfig({
-      log: { sensitiveQueryKeys: ['inviteToken', 'magicToken'] },
+      log: { sensitiveQueryKeys: ['magicToken'] },
     });
-    expect(mod.SENSITIVE_QUERY_KEYS).toContain('magicToken');
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(expect.arrayContaining(['inviteToken', 'magicToken']));
+    // built-in key still redacts — extension never clobbers it
+    expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
+    // config-added key redacts too
     expect(mod.default('/x?magicToken=secret')).toBe('/x?magicToken=REDACTED');
+  });
+
+  test('an explicit empty array in config is a no-op — built-in defaults still apply', async () => {
+    const mod = await loadWithConfig({
+      log: { sensitivePathMarkers: [], sensitiveQueryKeys: [] },
+    });
+    expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
+    expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
   });
 
   test('falls back to the built-in defaults when config.log is missing', async () => {


### PR DESCRIPTION
## Summary

- What changed: `SENSITIVE_PATH_MARKERS` and `SENSITIVE_QUERY_KEYS` (module route vocabulary) were hardcoded inside `lib/helpers/redactUrl.js`. They now read optional `config.log.sensitivePathMarkers` / `config.log.sensitiveQueryKeys` keys and Set-union them with the authoritative built-in defaults, behind a shape guard (non-array / malformed config values are ignored, never thrown).
- Why: route vocabulary is module-specific, not shared-lib concern — modules need a way to extend the redaction surface without forking `lib/`. Config extension is additive-only by design: config can never shrink, disable, or crash redaction, since the built-ins always apply regardless of what config provides.
- Related issues: Closes #3953

## Scope

- Module(s) impacted: `lib/helpers/redactUrl.js` (shared lib), `config/defaults/development.config.js`
- Cross-module impact: `none` — pure additive extension point, existing callers unaffected (empty/absent config = built-in-only behavior, byte-identical to before)
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: redaction is additive-only by construction — a shape guard means malformed/missing config can never disable or narrow the built-in redaction set, so a misconfigured downstream project cannot accidentally leak sensitive path segments or query params into logs. `config/defaults/development.config.js` deliberately **omits** the two keys — a downstream/module-layer default that *did* set them would otherwise get clobbered by `deepMerge`'s array-replace semantics; a lockstep test pins this (defaults file has no markers/keys) so the omission can't regress silently.
- Mergeability considerations: `redactUrl.js` now imports `config` — verified no circular dependency; degrades gracefully (falls back to built-ins) if config resolution fails.
- Follow-up tasks (optional): the lockstep guard test currently pins only `development.config.js` (prod/test configs don't define these keys today); extending the pin to those configs if/when they start defining the keys is a cheap follow-up, not required for this change.

Tests: 2148 green, `redactUrl.js` at 100% coverage — new cases cover union semantics, empty config, malformed config (shape guard), and the defaults-omission lockstep.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration options for extending sensitive URL query keys and path markers used during log redaction.
  * Built-in redaction protections remain enforced, while custom entries are merged and deduplicated.

* **Bug Fixes**
  * Invalid redaction configuration values are safely ignored with a warning instead of causing failures.

* **Documentation**
  * Added guidance describing the available redaction configuration options and their handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->