### PR TITLE
fix(log): redact OAuth code and state query params in the access log

### DIFF
--- a/config/defaults/development.config.js
+++ b/config/defaults/development.config.js
@@ -88,8 +88,8 @@ const config = {
     // `lib/helpers/redactUrl.js` (`redactPathSecrets` for PATH segments e.g.
     // `/api/auth/reset/:token`; `redactUrl` for query params e.g.
     // `?inviteToken=…`). Values are UNIONED with the built-in defaults there
-    // (['reset', 'verify', 'verify-email'] / ['inviteToken']), never
-    // replacing them.
+    // (['reset', 'verify', 'verify-email'] / ['inviteToken', 'code', 'state']),
+    // never replacing them.
     //
     // These two keys are intentionally OMITTED from this file: `deepMerge`
     // (config/index.js) replaces arrays wholesale rather than merging them,

--- a/lib/helpers/redactUrl.js
+++ b/lib/helpers/redactUrl.js
@@ -13,7 +13,7 @@ import config from '../../config/index.js';
  * silently disabled (an absent key or an explicit empty array in config both
  * degrade to exactly these defaults, never to nothing).
  */
-const DEFAULT_SENSITIVE_QUERY_KEYS = ['inviteToken'];
+const DEFAULT_SENSITIVE_QUERY_KEYS = ['inviteToken', 'code', 'state'];
 const DEFAULT_SENSITIVE_PATH_MARKERS = ['reset', 'verify', 'verify-email'];
 
 /**
@@ -42,9 +42,12 @@ const sanitizeConfigList = (value, label) => {
  * Sensitive query-string parameters that must never reach the request log.
  *
  * `inviteToken` rides the query string of `POST /api/auth/signup?inviteToken=…`
- * (the Vue client puts it there, not in the body). The morgan log pattern logs
- * `:url`, so without redaction a live single-use invite token lands in prod logs
- * (and any log shipper / aggregator downstream). Redact it to `REDACTED`.
+ * (the Vue client puts it there, not in the body). `code` and `state` ride the
+ * query string of `GET /api/auth/:strategy/callback?code=…&state=…` (the OAuth
+ * provider redirects there with the one-time authorization code). The morgan
+ * log pattern logs `:url`, so without redaction a live single-use secret lands
+ * in prod logs (and any log shipper / aggregator downstream). Redact them to
+ * `REDACTED`.
  *
  * Union of `DEFAULT_SENSITIVE_QUERY_KEYS` and `config.log.sensitiveQueryKeys`:
  * a module/downstream project extends the set purely additively from its own

--- a/lib/helpers/tests/redactUrl.unit.tests.js
+++ b/lib/helpers/tests/redactUrl.unit.tests.js
@@ -71,6 +71,19 @@ describe('redactUrl', () => {
   test('exports inviteToken as a sensitive key', () => {
     expect(SENSITIVE_QUERY_KEYS).toContain('inviteToken');
   });
+
+  test('redacts an OAuth callback code and state, preserving the path', () => {
+    expect(redactUrl('/api/auth/google/callback?code=SECRET&state=xyz')).toBe('/api/auth/google/callback?code=REDACTED&state=REDACTED');
+  });
+
+  test('redacts an OAuth callback code among other query params, leaving the rest intact', () => {
+    expect(redactUrl('/api/auth/google/callback?state=xyz&scope=email&code=SECRET')).toBe('/api/auth/google/callback?state=REDACTED&scope=email&code=REDACTED');
+  });
+
+  test('exports code and state as sensitive keys', () => {
+    expect(SENSITIVE_QUERY_KEYS).toContain('code');
+    expect(SENSITIVE_QUERY_KEYS).toContain('state');
+  });
 });
 
 describe('redactPathSecrets', () => {
@@ -168,7 +181,7 @@ describe('redactUrl config sourcing (#3953)', () => {
       log: { sensitivePathMarkers: [], sensitiveQueryKeys: [] },
     });
     expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
-    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken', 'code', 'state']);
     expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
     expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
   });
@@ -176,7 +189,7 @@ describe('redactUrl config sourcing (#3953)', () => {
   test('falls back to the built-in defaults when config.log is missing', async () => {
     const mod = await loadWithConfig({});
     expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
-    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken', 'code', 'state']);
     expect(mod.redactPathSecrets('/api/auth/reset/SECRETTOKEN')).toBe('/api/auth/reset/REDACTED');
     expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
   });
@@ -184,7 +197,7 @@ describe('redactUrl config sourcing (#3953)', () => {
   test('falls back to the built-in defaults when config itself is undefined', async () => {
     const mod = await loadWithConfig(undefined);
     expect(mod.SENSITIVE_PATH_MARKERS).toEqual(['reset', 'verify', 'verify-email']);
-    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+    expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken', 'code', 'state']);
   });
 
   /**
@@ -214,7 +227,7 @@ describe('redactUrl config sourcing (#3953)', () => {
       const mod = await loadWithConfig({
         log: { sensitiveQueryKeys: 'oops' },
       });
-      expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken']);
+      expect(mod.SENSITIVE_QUERY_KEYS).toEqual(['inviteToken', 'code', 'state']);
       expect(mod.default('/x?inviteToken=secret')).toBe('/x?inviteToken=REDACTED');
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('log.sensitiveQueryKeys'));
     } finally {


### PR DESCRIPTION
## Summary

- What changed: added `code` and `state` to `DEFAULT_SENSITIVE_QUERY_KEYS` in `lib/helpers/redactUrl.js`, unioned with `config.log.sensitiveQueryKeys` extensions per #3961. Updated the `development.config.js` comment listing the built-in defaults to match.
- Why: OAuth callback requests (`GET /api/auth/:strategy/callback?code=...&state=...`) were logging the one-time authorization code and state cleartext in the morgan access log. Same single-use-secret-in-URL leak class already closed for `inviteToken`/reset/verify-email tokens (#3955/#3961) — access logs persist and reach log shippers far longer than the code's short TTL.
- Related issues: Closes #3967

## Scope

- Module(s) impacted: `lib/helpers/redactUrl.js` (shared log redaction helper), `config/defaults/development.config.js` (comment only)
- Cross-module impact: none — pure additive extension to the existing sensitive-query-key list, no schema/API change
- Risk level: low

## Validation

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual checks done (if applicable)

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects
- [x] Tests added or updated when behavior changed

## Notes for reviewers

- Security considerations: this closes a confirmed cleartext leak of OAuth `code`/`state` in the access log. Fix is additive-only (built-in defaults list), consistent with the config-sourcing contract landed in #3961 (union of defaults + config extensions, never a replace).
- Mergeability considerations: none — isolated to the redaction helper and its tests.
- Tests: added red-green callback-redaction unit tests (bare `code`/`state` params, mixed with other query params, and an explicit `SENSITIVE_QUERY_KEYS` assertion), plus updated the 4 existing config-sourcing tests that assert the exact default array. Full suite: 2187 tests green, 100% coverage on `lib/helpers/redactUrl.js`.

https://claude.ai/code/session_01WfNC8bt1TgL4AsiYgCEGup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive OAuth callback parameters (`code` and `state`) are now automatically redacted from logged URLs.
  * URL paths and other query parameters remain unchanged when sensitive values are removed.
* **Documentation**
  * Updated configuration notes to reflect the default redaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->