### PR TITLE
feat(invitations): config-gated lifetime cap on invitation creation

### DIFF
--- a/modules/invitations/config/invitations.development.config.js
+++ b/modules/invitations/config/invitations.development.config.js
@@ -39,6 +39,9 @@ const config = {
      * `rateLimit.invitationsCreate` (bounds burst rate, not lifetime volume).
      * Downstream consumers opt in with a number in their config layer, e.g.:
      *   invitations: { maxLifetime: 50 }
+     * NOTE: `0` is a valid (if unusual) opt-in, not an alias for "disabled" — it
+     * rejects every invitation immediately (count >= 0 is always true). Use
+     * `null`/omit the key to disable the cap.
      */
     maxLifetime: null,
   },

--- a/modules/invitations/config/invitations.development.config.js
+++ b/modules/invitations/config/invitations.development.config.js
@@ -29,6 +29,18 @@ const config = {
      * (`invitations.userFacing`) so the frontend can gate referral UI on it.
      */
     userFacing: false,
+    /**
+     * Lifetime cap per inviter (#3986) — stack default OFF (absent/null = disabled,
+     * no behavior change). DB-backed: InvitationsService.create() counts ALL
+     * invitations (any status) already sent by the same `invitedBy` and rejects
+     * (422) once the count reaches this value. Bounds cumulative volume — the
+     * exposure that matters when `billing.referral` rewards are enabled (credit
+     * farming via fake referrer/referee pairs) — as a complement to
+     * `rateLimit.invitationsCreate` (bounds burst rate, not lifetime volume).
+     * Downstream consumers opt in with a number in their config layer, e.g.:
+     *   invitations: { maxLifetime: 50 }
+     */
+    maxLifetime: null,
   },
   // #3945: POST /api/invitations already had no rate limiter under admin-only access
   // (a trusted caller); with `invitations.userFacing` able to widen `create` to any

--- a/modules/invitations/repositories/invitations.repository.js
+++ b/modules/invitations/repositories/invitations.repository.js
@@ -34,6 +34,17 @@ const findByEmail = (email) =>
     .exec();
 
 /**
+ * @desc #3986 — count ALL invitations ever created by a given inviter, across every
+ * status (pending, accepted, revoked, expired). Unlike findByEmail (pending-only,
+ * gate-opening), this is the cumulative-volume signal for the maxLifetime cap: a
+ * status filter here would let the cap reset by letting invites expire or revoking
+ * them, defeating the guard.
+ * @param {String} invitedBy - the inviter's user id
+ * @returns {Promise<Number>}
+ */
+const countByInvitedBy = (invitedBy) => Invitation.countDocuments({ invitedBy }).exec();
+
+/**
  * @desc E2 — atomically CLAIM a pending, unclaimed invite by token. Stamps
  * `consumingAt` so a concurrent claim (or the email-resolved path) sees it as
  * in-flight/invalid. Returns the claimed doc, or null when nothing matched
@@ -165,4 +176,4 @@ const revoke = (id) =>
     { returnDocument: 'after' },
   ).exec();
 
-export default { create, findByToken, findByEmail, claim, finalize, release, releaseStaleClaims, list, findAccepted, findByAcceptedUserId, get, revoke };
+export default { create, findByToken, findByEmail, countByInvitedBy, claim, finalize, release, releaseStaleClaims, list, findAccepted, findByAcceptedUserId, get, revoke };

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -41,7 +41,7 @@ const inviteMailPayload = (invitation) => ({
  * @param {String} email - invitee email (any case)
  * @param {Object} invitedBy - the admin user creating the invite
  * @returns {Promise<Object>} created invitation
- * @throws {AppError} 409 when a pending invitation already exists for the email; 422 when the invitee email is the inviter's own, or a user already exists for this email
+ * @throws {AppError} 409 when a pending invitation already exists for the email; 422 when the invitee email is the inviter's own, a user already exists for this email, or the inviter has reached `config.invitations.maxLifetime` (if set)
  */
 const create = async (email, invitedBy) => {
   const normalizedEmail = String(email).toLowerCase().trim();
@@ -60,6 +60,25 @@ const create = async (email, invitedBy) => {
       code: 'VALIDATION_ERROR',
       details: { message: 'You cannot invite yourself.' },
     });
+  }
+  // #3986: config-gated lifetime cap per inviter. Absent/null = disabled (stack default,
+  // mirrors billing.referral) — no behavior change until a downstream consumer opts in
+  // with a number. DB-backed, not a rate window: counts ALL invitations ever created by
+  // this inviter (any status), so the cap cannot be reset by letting invites expire or
+  // revoking them. Bounds cumulative volume — the exposure that matters when
+  // billing.referral rewards are enabled (credit farming via fake referrer/referee
+  // pairs) — as a complement to rateLimit.invitationsCreate (bounds burst rate only).
+  const inviterId = invitedBy?.id || invitedBy?._id || null;
+  const maxLifetime = config.invitations?.maxLifetime;
+  if (typeof maxLifetime === 'number' && inviterId) {
+    const lifetimeCount = await InvitationRepository.countByInvitedBy(inviterId);
+    if (lifetimeCount >= maxLifetime) {
+      throw new AppError('You have reached the maximum number of invitations you can send', {
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        details: { message: 'You have reached the maximum number of invitations you can send.' },
+      });
+    }
   }
   // E9: an already-registered email must not be invited — they are already a user.
   const existing = await UserService.findByEmail(normalizedEmail);
@@ -91,7 +110,7 @@ const create = async (email, invitedBy) => {
     email: normalizedEmail,
     token,
     expiresAt,
-    invitedBy: invitedBy?.id || invitedBy?._id || null,
+    invitedBy: inviterId,
   });
   if (mails.isConfigured()) {
     mails

--- a/modules/invitations/services/invitations.service.js
+++ b/modules/invitations/services/invitations.service.js
@@ -68,6 +68,12 @@ const create = async (email, invitedBy) => {
   // revoking them. Bounds cumulative volume — the exposure that matters when
   // billing.referral rewards are enabled (credit farming via fake referrer/referee
   // pairs) — as a complement to rateLimit.invitationsCreate (bounds burst rate only).
+  // Best-effort, same accepted shape as the outstanding-pending-invite guard below (no
+  // atomic counter): two racing creates at count === maxLifetime-1 can both pass the
+  // check and both land, admitting the cap by a document or two. Acceptable for an
+  // admin/owner surface already bounded by rateLimit.invitationsCreate — turning this
+  // into a hard ceiling needs an atomically-incremented counter (a schema change), out
+  // of this fix's scope.
   const inviterId = invitedBy?.id || invitedBy?._id || null;
   const maxLifetime = config.invitations?.maxLifetime;
   if (typeof maxLifetime === 'number' && inviterId) {

--- a/modules/invitations/tests/invitations.integration.tests.js
+++ b/modules/invitations/tests/invitations.integration.tests.js
@@ -697,6 +697,34 @@ describe('Signup invitations:', () => {
     });
   });
 
+  describe('#3986 lifetime cap per inviter', () => {
+    let originalMaxLifetime;
+    beforeEach(() => { originalMaxLifetime = config.invitations.maxLifetime; });
+    afterEach(() => { config.invitations.maxLifetime = originalMaxLifetime; });
+
+    test('rejects (422) once the REAL DB count reaches config.invitations.maxLifetime, via the real HTTP path', async () => {
+      config.invitations.maxLifetime = 2;
+      // createAdminAndSignin() always (re)creates a fresh admin, so this admin's
+      // invitedBy count starts at 0 — no cross-test bleed.
+      const adminAgent = await createAdminAndSignin();
+      const first = await adminAgent.post('/api/invitations').send({ email: 'cap1-3986@example.com' });
+      expect(first.status).toBe(200);
+      const second = await adminAgent.post('/api/invitations').send({ email: 'cap2-3986@example.com' });
+      expect(second.status).toBe(200); // boundary: count was 1 (cap - 1), passes
+      const third = await adminAgent.post('/api/invitations').send({ email: 'cap3-3986@example.com' });
+      expect(third.status).toBe(422); // count is now 2 (== cap), rejected
+    });
+
+    test('default-off (maxLifetime null): unaffected regardless of how many invitations already exist', async () => {
+      config.invitations.maxLifetime = null;
+      const adminAgent = await createAdminAndSignin();
+      const first = await adminAgent.post('/api/invitations').send({ email: 'cap4-3986@example.com' });
+      expect(first.status).toBe(200);
+      const second = await adminAgent.post('/api/invitations').send({ email: 'cap5-3986@example.com' });
+      expect(second.status).toBe(200);
+    });
+  });
+
   describe('P8a referral substrate (referredBy + invitation.accepted)', () => {
     let invitationEvents;
     let originalUp; let originalCap;

--- a/modules/invitations/tests/invitations.repository.unit.tests.js
+++ b/modules/invitations/tests/invitations.repository.unit.tests.js
@@ -23,6 +23,7 @@ InvitationModel.find = jest.fn(() => chain);
 InvitationModel.findById = jest.fn(() => chain);
 InvitationModel.deleteOne = jest.fn(() => chain);
 InvitationModel.updateMany = jest.fn(() => chain);
+InvitationModel.countDocuments = jest.fn(() => chain);
 
 const isValid = jest.fn(() => true);
 
@@ -134,6 +135,14 @@ describe('InvitationRepository', () => {
     expect(chain.select).toHaveBeenCalledWith('-token');
     expect(chain.populate).toHaveBeenCalledWith('invitedBy', 'email firstName lastName');
     expect(chain.sort).toHaveBeenCalledWith('-createdAt');
+  });
+
+  test('countByInvitedBy counts across ALL statuses for a given inviter (#3986)', async () => {
+    exec.mockResolvedValue(5);
+    const result = await InvitationRepository.countByInvitedBy('u1');
+    // No status filter — the lifetime cap must not reset on expire/revoke.
+    expect(InvitationModel.countDocuments).toHaveBeenCalledWith({ invitedBy: 'u1' });
+    expect(result).toBe(5);
   });
 
   test('findAccepted scans status:accepted lean with the minimal referral projection (#3842)', async () => {

--- a/modules/invitations/tests/invitations.service.unit.tests.js
+++ b/modules/invitations/tests/invitations.service.unit.tests.js
@@ -5,6 +5,7 @@ jest.unstable_mockModule('../repositories/invitations.repository.js', () => ({
     create: jest.fn(),
     findByToken: jest.fn(),
     findByEmail: jest.fn(),
+    countByInvitedBy: jest.fn(),
     claim: jest.fn(),
     finalize: jest.fn(),
     release: jest.fn(),
@@ -28,6 +29,8 @@ jest.unstable_mockModule('../../../config/index.js', () => ({
   default: {
     sign: { inviteExpiresInDays: 14 },
     app: { title: 'Test App', contact: 'contact@test.com' },
+    // #3986: stack default OFF (mirrors production config/index.js absent/null shape).
+    invitations: { maxLifetime: null },
   },
 }));
 
@@ -48,6 +51,9 @@ const InvitationRepository = (await import('../repositories/invitations.reposito
 const InvitationService = (await import('../services/invitations.service.js')).default;
 // Real events singleton — the service emits on it; we spy to assert the payload.
 const invitationEvents = (await import('../lib/events.js')).default;
+// Mocked config singleton — mutated per-test for the #3986 lifetime-cap describe block
+// (mirrors how integration tests flip config.sign.up/cap, kept + restored per test).
+const config = (await import('../../../config/index.js')).default;
 
 beforeEach(() => {
   // Default: no stale claims to sweep, no pre-existing user (E9), no outstanding
@@ -55,8 +61,10 @@ beforeEach(() => {
   // mockResolvedValue, so a prior test's findByEmail value would otherwise leak in.
   InvitationRepository.releaseStaleClaims.mockResolvedValue({ modifiedCount: 0 });
   InvitationRepository.findByEmail.mockResolvedValue(undefined);
+  InvitationRepository.countByInvitedBy.mockResolvedValue(0);
   mockUserService.findByEmail.mockResolvedValue(null);
   mockUserService.updateById.mockResolvedValue({});
+  config.invitations.maxLifetime = null; // stack default OFF, reset between tests
 });
 
 describe('InvitationService.findValid', () => {
@@ -398,6 +406,57 @@ describe('InvitationService.create — #3833 self-invite guard', () => {
     InvitationRepository.create.mockImplementation((doc) => Promise.resolve({ ...doc, id: '2' }));
     const inv = await InvitationService.create('someone@example.com', { id: 'u1' });
     expect(inv.email).toBe('someone@example.com');
+  });
+});
+
+describe('InvitationService.create — #3986 lifetime cap per inviter', () => {
+  test('default-off (config absent/null): create succeeds regardless of count, countByInvitedBy never consulted', async () => {
+    InvitationRepository.countByInvitedBy.mockResolvedValue(999); // would be way over any real cap
+    InvitationRepository.create.mockImplementation((doc) => Promise.resolve({ ...doc, id: '1' }));
+    const inv = await InvitationService.create('friend@example.com', { id: 'admin1' });
+    expect(inv.email).toBe('friend@example.com');
+    expect(InvitationRepository.countByInvitedBy).not.toHaveBeenCalled();
+    expect(InvitationRepository.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('boundary: count at cap−1 passes (create proceeds)', async () => {
+    config.invitations.maxLifetime = 5;
+    InvitationRepository.countByInvitedBy.mockResolvedValue(4); // cap - 1
+    InvitationRepository.create.mockImplementation((doc) => Promise.resolve({ ...doc, id: '1' }));
+    const inv = await InvitationService.create('friend@example.com', { id: 'admin1' });
+    expect(inv.email).toBe('friend@example.com');
+    expect(InvitationRepository.countByInvitedBy).toHaveBeenCalledWith('admin1');
+    expect(InvitationRepository.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('capped path: count at threshold rejects (422), same AppError shape as the self-invite guard', async () => {
+    config.invitations.maxLifetime = 5;
+    InvitationRepository.countByInvitedBy.mockResolvedValue(5); // == cap
+    await expect(InvitationService.create('friend@example.com', { id: 'admin1' })).rejects.toMatchObject({
+      status: 422,
+      code: 'VALIDATION_ERROR',
+    });
+    expect(InvitationRepository.create).not.toHaveBeenCalled();
+    // Fires BEFORE E9 / the outstanding-invite lookup, same fail-fast ordering as self-invite.
+    expect(mockUserService.findByEmail).not.toHaveBeenCalled();
+  });
+
+  test('capped path: count past threshold also rejects (422)', async () => {
+    config.invitations.maxLifetime = 5;
+    InvitationRepository.countByInvitedBy.mockResolvedValue(6); // > cap
+    await expect(InvitationService.create('friend@example.com', { id: 'admin1' })).rejects.toMatchObject({
+      status: 422,
+      code: 'VALIDATION_ERROR',
+    });
+    expect(InvitationRepository.create).not.toHaveBeenCalled();
+  });
+
+  test('an inviter with no resolvable id (defensive) skips the cap entirely, even when configured', async () => {
+    config.invitations.maxLifetime = 1;
+    InvitationRepository.create.mockImplementation((doc) => Promise.resolve({ ...doc, id: '1' }));
+    const inv = await InvitationService.create('friend@example.com', {});
+    expect(inv.email).toBe('friend@example.com');
+    expect(InvitationRepository.countByInvitedBy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- What changed: Adds a DB-backed lifetime cap per inviter in `InvitationsService.create()`. It counts ALL invitations ever created by the same `invitedBy` (any status) and rejects with a 422 `AppError` (same shape as the existing self-invite guard) once the count reaches `config.invitations.maxLifetime`.
- Why: `rateLimit.invitationsCreate` bounds request rate but not cumulative volume. When `billing.referral` rewards are enabled, total invitations per account — not rate — is the exposure that matters (credit farming via fake referrer/referee pairs). This closes that gap without touching the burst limiter, which stays out of scope (already wired, per-route profile).
- Related issues: Closes #3986

## Scope

- Module(s) impacted: `invitations` (config, repository, service, tests only)
- Cross-module impact: `none`
- Risk level: `low`

## Validation

- [x] `npm run lint`
- [x] `npm test` (full suite: 213 test suites / 2768 tests passing, incl. new unit + integration coverage)
- [x] Manual checks done (if applicable) — verified boundary (cap−1 passes) and threshold (cap reached → 422) via both mocked unit tests and a real-DB/real-HTTP integration test

## Guardrails check

- [x] No secrets or credentials introduced (`.env*`, `secrets/**`, keys, tokens)
- [x] No risky rename/move of core stack paths
- [x] Changes remain merge-friendly for downstream projects — config default is `null` (absent = disabled), no behavior change until a downstream consumer opts in with a number in their own config layer
- [x] Tests added or updated when behavior changed — unit (repository + service: capped/boundary/default-off) + integration (real DB count + real HTTP 422 path)

## Notes for reviewers

- Security considerations: the count-then-create check is best-effort, not atomic under concurrent requests at the exact threshold — this mirrors the existing outstanding-pending-invite guard's identical (and already-accepted) race in the same `create()` function; a hard atomic ceiling would need a separate incrementing counter (schema change), judged out of scope for this fix.
- Mergeability considerations: none — isolated to the `invitations` module, no shared/core files touched.
- Follow-up tasks (optional): none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional lifetime cap for invitations created by each inviter.
  * When enabled, additional invitations are rejected with a validation error after the configured limit is reached.
  * The cap considers all invitations, regardless of status, and remains disabled by default.

* **Tests**
  * Added coverage for enabled, disabled, and edge-case lifetime-cap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->