### PR TITLE
docs(skills): add the minimal-code decision ladder to /feature Phase 0

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -117,11 +117,28 @@ For each user-facing flow this feature creates or modifies, identify:
 - Works WITHOUT organizations enabled?
 - No hard dependency on external services for core flow?
 
+### 4b. Minimal-code ladder (run before presenting)
+
+Challenge every **mechanism** this change would introduce — a schema field, a flag, a collection, an abstraction, a scheduled job. Stop at the first rung that holds:
+
+0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user.
+1. **Already in this codebase?** — reuse the helper, service or pattern.
+2. **In the standard library?** — use it.
+3. **A native platform feature?** (DB constraint/index, framework built-in) — use it.
+4. **An already-installed dependency?** — use it.
+5. **One line, a constant, or config?** — make it that.
+6. Only then: build it, minimal.
+
+**Persisted state is the expensive rung.** A schema field, collection or flag encoding a *policy* (a known-bad marker, a cap, a memo of a past failure) is not a code choice — code is deleted, data is migrated. Rung 0 is mandatory for it, and it needs **explicit user confirmation in §5** before it is built.
+
+**Never traded away** (lazy ≠ negligent): understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, and anything the user explicitly asked for.
+
 ### 5. Present plan & ask questions
 
 **STOP and present to the user:**
 - Flows identified (happy + error + edge cases)
 - Users impacted + notification plan
+- **Ladder outcome (§4b)** — one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`), plus any persisted state awaiting confirmation. A change that adds a mechanism and rejects nothing means nobody looked.
 - Open questions or scope decisions
 
 **Wait for user validation before coding.** (Non-interactive runs: Phase 0.0

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -121,7 +121,7 @@ For each user-facing flow this feature creates or modifies, identify:
 
 Challenge every **mechanism** this change would introduce — a schema field, a flag, a collection, an abstraction, a scheduled job. Stop at the first rung that holds:
 
-0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user.
+0. **Does a product decision remove it?** — accept the cost, accept the failure, do nothing, or surface it to the user. This rung holds **only if the mechanism then disappears**; if the product still needs it, keep going down the ladder.
 1. **Already in this codebase?** — reuse the helper, service or pattern.
 2. **In the standard library?** — use it.
 3. **A native platform feature?** (DB constraint/index, framework built-in) — use it.
@@ -129,7 +129,7 @@ Challenge every **mechanism** this change would introduce — a schema field, a 
 5. **One line, a constant, or config?** — make it that.
 6. Only then: build it, minimal.
 
-**Persisted state is the expensive rung.** A schema field, collection or flag encoding a *policy* (a known-bad marker, a cap, a memo of a past failure) is not a code choice — code is deleted, data is migrated. Rung 0 is mandatory for it, and it needs **explicit user confirmation in §5** before it is built.
+**Persisted state is the expensive rung.** A schema field, collection or flag encoding a *policy* (a known-bad marker, a cap, a memo of a past failure) is not a code choice — code is deleted, data is migrated. Rung 0 is mandatory for it, and it needs an **explicit, blocking user confirmation in §5** before it is built — a yes on that specific state, never implied by the general plan validation.
 
 **Never traded away** (lazy ≠ negligent): understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, and anything the user explicitly asked for.
 
@@ -138,7 +138,8 @@ Challenge every **mechanism** this change would introduce — a schema field, a 
 **STOP and present to the user:**
 - Flows identified (happy + error + edge cases)
 - Users impacted + notification plan
-- **Ladder outcome (§4b)** — one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`), plus any persisted state awaiting confirmation. A change that adds a mechanism and rejects nothing means nobody looked.
+- **Ladder outcome (§4b)** — the **selected rung** first (`<rung> — <what it resolves to>`, e.g. `1 reuse — existing users service`), then one line per rejected mechanism (`<mechanism> — simpler option <X> rejected because <reason>`). A change that adds a mechanism and rejects nothing means nobody looked.
+- **Persisted state, if any** — name it and **wait for an explicit yes on it**; a general "plan validated" does not cover it, and it is not built without that yes.
 - Open questions or scope decisions
 
 **Wait for user validation before coding.** (Non-interactive runs: Phase 0.0


### PR DESCRIPTION
Closes #3944
Part of #3943

Adds the minimal-code decision ladder to the `/feature` skill, run before an implementation is proposed.

## Placement — deliberate change vs the issue text

The issue asked for the ladder in **Phase 1** ("before writing new code"). It landed at the **end of Phase 0** instead, as `§4b`, immediately before `§5 Present plan & ask questions`.

Reason: the first rung is a *product* question ("does a decision remove this mechanism?"), and §5 is the one place the skill already stops and talks to the user. Running the ladder in Phase 1 would mean discovering the answer after the plan was already validated. The ladder outcome is now carried into §5 as an explicit bullet, so a rejected mechanism is visible at the moment the user validates.

## Rungs

Product decision → reuse → stdlib → native platform → installed dependency → one-liner → minimal code. Stop at the first rung that holds.

Two additions beyond the original 7-rung list:

- **Rung 0 — the product decision.** The other rungs all ask "what is the cheapest way to build this?". Rung 0 asks whether the requirement can be dropped: accept the cost, accept the failure, do nothing, or surface it to the user. It is the only rung that removes code rather than shrinking it.
- **Persisted state is the expensive rung.** A schema field, collection or flag encoding a *policy* is not a code choice — code is deleted, data is migrated. Rung 0 is mandatory for it, and it needs explicit user confirmation in §5 before it is built.

## Guardrails unchanged

Understanding the problem before picking a rung, validation at trust boundaries, error handling that prevents data loss, security, and anything the user explicitly asked for are never traded away. The ladder prunes gratuitous mechanisms, never guardrails.

Docs-only: one file, no runtime code, no dependency change.

https://claude.ai/code/session_019Cow7oT71FcBKpD5brmwBs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to evaluate simpler alternatives before introducing new mechanisms.
  * Added requirements to document product decisions and explicit confirmation for persisted policy state.
  * Updated the Phase 0 planning checklist to capture these evaluations and decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->